### PR TITLE
Add Gemini TTS support across clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,4 +357,5 @@ vite.config.ts.timestamp-*
 
 # Conversation monitor cache
 cache/
-generated_image_*
+generated_image*
+generated_audio*

--- a/llmsdk_docs/gemini3/docs/text-to-speech-generation.md
+++ b/llmsdk_docs/gemini3/docs/text-to-speech-generation.md
@@ -1,0 +1,863 @@
+# Text-to-speech generation (TTS)
+
+<br />
+
+The Gemini API can transform text input into single speaker or multi-speaker
+audio using Gemini text-to-speech (TTS) generation capabilities.
+Text-to-speech (TTS) generation is *[controllable](https://ai.google.dev/gemini-api/docs/speech-generation#controllable)* ,
+meaning you can use natural language to structure interactions and guide the
+*style* , *accent* , *pace* , and *tone* of the audio.
+[Try in Google AI Studio](https://aistudio.google.com/apps/bundled/voice-library?showPreview=truew)
+
+The TTS capability differs from speech generation provided through the
+[Live API](https://ai.google.dev/gemini-api/docs/live), which is designed for interactive,
+unstructured audio, and multimodal inputs and outputs. While the Live API excels
+in dynamic conversational contexts, TTS through the Gemini API
+is tailored for scenarios that require exact text recitation with fine-grained
+control over style and sound, such as podcast or audiobook generation.
+
+This guide shows you how to generate single-speaker and multi-speaker audio from
+text.
+
+> [!WARNING]
+> **Preview:** Gemini text-to-speech (TTS) is in [Preview](https://ai.google.dev/gemini-api/docs/models#preview).
+
+## Before you begin
+
+Ensure you use a Gemini model variant with Gemini text-to-speech (TTS)
+capabilities, as listed in the [Supported models](https://ai.google.dev/gemini-api/docs/speech-generation#supported-models) section. For optimal
+results, consider which model best fits your specific use case.
+
+You may find it useful to [test the Gemini TTS models in AI Studio](https://aistudio.google.com/generate-speech) before you start building.
+
+> [!NOTE]
+> **Note:** TTS models accept text-only inputs and produce audio-only outputs. For a complete list of restrictions specific to TTS models, review the [Limitations](https://ai.google.dev/gemini-api/docs/speech-generation#limitations) section.
+
+## Single-speaker TTS
+
+To convert text to single-speaker audio, set the response modality to "audio",
+and pass a `SpeechConfig` object with `VoiceConfig` set.
+You'll need to choose a voice name from the prebuilt [output voices](https://ai.google.dev/gemini-api/docs/speech-generation#voices).
+
+This example saves the output audio from the model in a wave file:
+
+### Python
+
+    from google import genai
+    from google.genai import types
+    import wave
+
+    # Set up the wave file to save the output:
+    def wave_file(filename, pcm, channels=1, rate=24000, sample_width=2):
+       with wave.open(filename, "wb") as wf:
+          wf.setnchannels(channels)
+          wf.setsampwidth(sample_width)
+          wf.setframerate(rate)
+          wf.writeframes(pcm)
+
+    client = genai.Client()
+
+    response = client.models.generate_content(
+       model="gemini-3.1-flash-tts-preview",
+       contents="Say cheerfully: Have a wonderful day!",
+       config=types.GenerateContentConfig(
+          response_modalities=["AUDIO"],
+          speech_config=types.SpeechConfig(
+             voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                   voice_name='Kore',
+                )
+             )
+          ),
+       )
+    )
+
+    data = response.candidates[0].content.parts[0].inline_data.data
+
+    file_name='out.wav'
+    wave_file(file_name, data) # Saves the file to current directory
+
+> [!NOTE]
+> For more code samples, refer to the
+> "TTS - Get Started" file in the cookbooks repository:
+>
+>
+> [View
+> on GitHub](https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Get_started_TTS.ipynb)
+
+### JavaScript
+
+    import {GoogleGenAI} from '@google/genai';
+    import wav from 'wav';
+
+    async function saveWaveFile(
+       filename,
+       pcmData,
+       channels = 1,
+       rate = 24000,
+       sampleWidth = 2,
+    ) {
+       return new Promise((resolve, reject) => {
+          const writer = new wav.FileWriter(filename, {
+                channels,
+                sampleRate: rate,
+                bitDepth: sampleWidth * 8,
+          });
+
+          writer.on('finish', resolve);
+          writer.on('error', reject);
+
+          writer.write(pcmData);
+          writer.end();
+       });
+    }
+
+    async function main() {
+       const ai = new GoogleGenAI({});
+
+       const response = await ai.models.generateContent({
+          model: "gemini-3.1-flash-tts-preview",
+          contents: [{ parts: [{ text: 'Say cheerfully: Have a wonderful day!' }] }],
+          config: {
+                responseModalities: ['AUDIO'],
+                speechConfig: {
+                   voiceConfig: {
+                      prebuiltVoiceConfig: { voiceName: 'Kore' },
+                   },
+                },
+          },
+       });
+
+       const data = response.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+       const audioBuffer = Buffer.from(data, 'base64');
+
+       const fileName = 'out.wav';
+       await saveWaveFile(fileName, audioBuffer);
+    }
+    await main();
+
+### REST
+
+    curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent" \
+      -H "x-goog-api-key: $GEMINI_API_KEY" \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d '{
+            "contents": [{
+              "parts":[{
+                "text": "Say cheerfully: Have a wonderful day!"
+              }]
+            }],
+            "generationConfig": {
+              "responseModalities": ["AUDIO"],
+              "speechConfig": {
+                "voiceConfig": {
+                  "prebuiltVoiceConfig": {
+                    "voiceName": "Kore"
+                  }
+                }
+              }
+            },
+            "model": "gemini-3.1-flash-tts-preview",
+        }' | jq -r '.candidates[0].content.parts[0].inlineData.data' | \
+              base64 --decode >out.pcm
+    # You may need to install ffmpeg.
+    ffmpeg -f s16le -ar 24000 -ac 1 -i out.pcm out.wav
+
+## Multi-speaker TTS
+
+For multi-speaker audio, you'll need a `MultiSpeakerVoiceConfig` object with
+each speaker (up to 2) configured as a `SpeakerVoiceConfig`.
+You'll need to define each `speaker` with the same names used in the
+[prompt](https://ai.google.dev/gemini-api/docs/speech-generation#controllable):
+
+### Python
+
+    from google import genai
+    from google.genai import types
+    import wave
+
+    # Set up the wave file to save the output:
+    def wave_file(filename, pcm, channels=1, rate=24000, sample_width=2):
+       with wave.open(filename, "wb") as wf:
+          wf.setnchannels(channels)
+          wf.setsampwidth(sample_width)
+          wf.setframerate(rate)
+          wf.writeframes(pcm)
+
+    client = genai.Client()
+
+    prompt = """TTS the following conversation between Joe and Jane:
+             Joe: How's it going today Jane?
+             Jane: Not too bad, how about you?"""
+
+    response = client.models.generate_content(
+       model="gemini-3.1-flash-tts-preview",
+       contents=prompt,
+       config=types.GenerateContentConfig(
+          response_modalities=["AUDIO"],
+          speech_config=types.SpeechConfig(
+             multi_speaker_voice_config=types.MultiSpeakerVoiceConfig(
+                speaker_voice_configs=[
+                   types.SpeakerVoiceConfig(
+                      speaker='Joe',
+                      voice_config=types.VoiceConfig(
+                         prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name='Kore',
+                         )
+                      )
+                   ),
+                   types.SpeakerVoiceConfig(
+                      speaker='Jane',
+                      voice_config=types.VoiceConfig(
+                         prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name='Puck',
+                         )
+                      )
+                   ),
+                ]
+             )
+          )
+       )
+    )
+
+    data = response.candidates[0].content.parts[0].inline_data.data
+
+    file_name='out.wav'
+    wave_file(file_name, data) # Saves the file to current directory
+
+### JavaScript
+
+    import {GoogleGenAI} from '@google/genai';
+    import wav from 'wav';
+
+    async function saveWaveFile(
+       filename,
+       pcmData,
+       channels = 1,
+       rate = 24000,
+       sampleWidth = 2,
+    ) {
+       return new Promise((resolve, reject) => {
+          const writer = new wav.FileWriter(filename, {
+                channels,
+                sampleRate: rate,
+                bitDepth: sampleWidth * 8,
+          });
+
+          writer.on('finish', resolve);
+          writer.on('error', reject);
+
+          writer.write(pcmData);
+          writer.end();
+       });
+    }
+
+    async function main() {
+       const ai = new GoogleGenAI({});
+
+       const prompt = `TTS the following conversation between Joe and Jane:
+             Joe: How's it going today Jane?
+             Jane: Not too bad, how about you?`;
+
+       const response = await ai.models.generateContent({
+          model: "gemini-3.1-flash-tts-preview",
+          contents: [{ parts: [{ text: prompt }] }],
+          config: {
+                responseModalities: ['AUDIO'],
+                speechConfig: {
+                   multiSpeakerVoiceConfig: {
+                      speakerVoiceConfigs: [
+                            {
+                               speaker: 'Joe',
+                               voiceConfig: {
+                                  prebuiltVoiceConfig: { voiceName: 'Kore' }
+                               }
+                            },
+                            {
+                               speaker: 'Jane',
+                               voiceConfig: {
+                                  prebuiltVoiceConfig: { voiceName: 'Puck' }
+                               }
+                            }
+                      ]
+                   }
+                }
+          }
+       });
+
+       const data = response.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+       const audioBuffer = Buffer.from(data, 'base64');
+
+       const fileName = 'out.wav';
+       await saveWaveFile(fileName, audioBuffer);
+    }
+
+    await main();
+
+### REST
+
+    curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent" \
+      -H "x-goog-api-key: $GEMINI_API_KEY" \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -d '{
+      "contents": [{
+        "parts":[{
+          "text": "TTS the following conversation between Joe and Jane:
+                    Joe: Hows it going today Jane?
+                    Jane: Not too bad, how about you?"
+        }]
+      }],
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "multiSpeakerVoiceConfig": {
+            "speakerVoiceConfigs": [{
+                "speaker": "Joe",
+                "voiceConfig": {
+                  "prebuiltVoiceConfig": {
+                    "voiceName": "Kore"
+                  }
+                }
+              }, {
+                "speaker": "Jane",
+                "voiceConfig": {
+                  "prebuiltVoiceConfig": {
+                    "voiceName": "Puck"
+                  }
+                }
+              }]
+          }
+        }
+      },
+      "model": "gemini-3.1-flash-tts-preview",
+    }' | jq -r '.candidates[0].content.parts[0].inlineData.data' | \
+        base64 --decode > out.pcm
+    # You may need to install ffmpeg.
+    ffmpeg -f s16le -ar 24000 -ac 1 -i out.pcm out.wav
+
+## Controlling speech style with prompts
+
+You can control style, tone, accent, and pace using natural language prompts
+or [audio tags](https://ai.google.dev/gemini-api/docs/speech-generation#transcript-tags) for both single- and multi-speaker TTS.
+For example, in a single-speaker prompt, you can say:
+
+    Say in an spooky voice:
+    "By the pricking of my thumbs... [short pause]
+    [whisper] Something wicked this way comes"
+
+In a multi-speaker prompt, provide the model with each speaker's name and
+corresponding transcript. You can also provide guidance for each speaker
+individually:
+
+    Make Speaker1 sound tired and bored, and Speaker2 sound excited and happy:
+
+    Speaker1: So... [yawn] what's on the agenda today?
+    Speaker2: You're never going to guess!
+
+Try using a [voice option](https://ai.google.dev/gemini-api/docs/speech-generation#voices) that corresponds to the style or emotion you
+want to convey, to emphasize it even more. In the previous prompt, for example,
+*Enceladus* 's breathiness might emphasize "tired" and "bored", while
+*Puck*'s upbeat tone could complement "excited" and "happy".
+
+> [!TIP]
+> **Tip:** The [Voice Library](https://aistudio.google.com/apps/bundled/voice-library?showPreview=true) applet in Google AI Studio is a great way to try out speech styles and voices with Gemini TTS.
+
+## Generating a prompt to convert to audio
+
+The TTS models only output audio, but you can use
+[other models](https://ai.google.dev/gemini-api/docs/models) to generate a transcript first,
+then pass that transcript to the TTS model to read aloud.
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+
+    transcript = client.models.generate_content(
+       model="gemini-3-flash-preview",
+       contents="""Generate a short transcript around 100 words that reads
+                like it was clipped from a podcast by excited herpetologists.
+                The hosts names are Dr. Anya and Liam.""").text
+
+    response = client.models.generate_content(
+       model="gemini-3.1-flash-tts-preview",
+       contents=transcript,
+       config=types.GenerateContentConfig(
+          response_modalities=["AUDIO"],
+          speech_config=types.SpeechConfig(
+             multi_speaker_voice_config=types.MultiSpeakerVoiceConfig(
+                speaker_voice_configs=[
+                   types.SpeakerVoiceConfig(
+                      speaker='Dr. Anya',
+                      voice_config=types.VoiceConfig(
+                         prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name='Kore',
+                         )
+                      )
+                   ),
+                   types.SpeakerVoiceConfig(
+                      speaker='Liam',
+                      voice_config=types.VoiceConfig(
+                         prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                            voice_name='Puck',
+                         )
+                      )
+                   ),
+                ]
+             )
+          )
+       )
+    )
+
+    # ...Code to handle audio output
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+
+    const ai = new GoogleGenAI({});
+
+    async function main() {
+
+    const transcript = await ai.models.generateContent({
+       model: "gemini-3-flash-preview",
+       contents: "Generate a short transcript around 100 words that reads like it was clipped from a podcast by excited herpetologists. The hosts names are Dr. Anya and Liam.",
+       })
+
+    const response = await ai.models.generateContent({
+       model: "gemini-3.1-flash-tts-preview",
+       contents: transcript,
+       config: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+             multiSpeakerVoiceConfig: {
+                speakerVoiceConfigs: [
+                       {
+                         speaker: "Dr. Anya",
+                         voiceConfig: {
+                            prebuiltVoiceConfig: {voiceName: "Kore"},
+                         }
+                      },
+                      {
+                         speaker: "Liam",
+                         voiceConfig: {
+                            prebuiltVoiceConfig: {voiceName: "Puck"},
+                        }
+                      }
+                    ]
+                  }
+                }
+          }
+      });
+    }
+    // ..JavaScript code for exporting .wav file for output audio
+
+    await main();
+
+## Voice options
+
+TTS models support the following 30 voice options in the `voice_name` field:
+
+|---|---|---|
+| **Zephyr** -- *Bright* | **Puck** -- *Upbeat* | **Charon** -- *Informative* |
+| **Kore** -- *Firm* | **Fenrir** -- *Excitable* | **Leda** -- *Youthful* |
+| **Orus** -- *Firm* | **Aoede** -- *Breezy* | **Callirrhoe** -- *Easy-going* |
+| **Autonoe** -- *Bright* | **Enceladus** -- *Breathy* | **Iapetus** -- *Clear* |
+| **Umbriel** -- *Easy-going* | **Algieba** -- *Smooth* | **Despina** -- *Smooth* |
+| **Erinome** -- *Clear* | **Algenib** -- *Gravelly* | **Rasalgethi** -- *Informative* |
+| **Laomedeia** -- *Upbeat* | **Achernar** -- *Soft* | **Alnilam** -- *Firm* |
+| **Schedar** -- *Even* | **Gacrux** -- *Mature* | **Pulcherrima** -- *Forward* |
+| **Achird** -- *Friendly* | **Zubenelgenubi** -- *Casual* | **Vindemiatrix** -- *Gentle* |
+| **Sadachbia** -- *Lively* | **Sadaltager** -- *Knowledgeable* | **Sulafat** -- *Warm* |
+
+You can hear all the voice options in
+[AI Studio](https://aistudio.google.com/generate-speech).
+
+## Supported languages
+
+The TTS models detect the input language automatically. The following languages
+are supported:
+
+| Language | BCP-47 Code | Language | BCP-47 Code |
+|---|---|---|---|
+| Arabic | ar | Filipino | fil |
+| Bangla | bn | Finnish | fi |
+| Dutch | nl | Galician | gl |
+| English | en | Georgian | ka |
+| French | fr | Greek | el |
+| German | de | Gujarati | gu |
+| Hindi | hi | Haitian Creole | ht |
+| Indonesian | id | Hebrew | he |
+| Italian | it | Hungarian | hu |
+| Japanese | ja | Icelandic | is |
+| Korean | ko | Javanese | jv |
+| Marathi | mr | Kannada | kn |
+| Polish | pl | Konkani | kok |
+| Portuguese | pt | Lao | lo |
+| Romanian | ro | Latin | la |
+| Russian | ru | Latvian | lv |
+| Spanish | es | Lithuanian | lt |
+| Tamil | ta | Luxembourgish | lb |
+| Telugu | te | Macedonian | mk |
+| Thai | th | Maithili | mai |
+| Turkish | tr | Malagasy | mg |
+| Ukrainian | uk | Malay | ms |
+| Vietnamese | vi | Malayalam | ml |
+| Afrikaans | af | Mongolian | mn |
+| Albanian | sq | Nepali | ne |
+| Amharic | am | Norwegian, Bokmål | nb |
+| Armenian | hy | Norwegian, Nynorsk | nn |
+| Azerbaijani | az | Odia | or |
+| Basque | eu | Pashto | ps |
+| Belarusian | be | Persian | fa |
+| Bulgarian | bg | Punjabi | pa |
+| Burmese | my | Serbian | sr |
+| Catalan | ca | Sindhi | sd |
+| Cebuano | ceb | Sinhala | si |
+| Chinese, Mandarin | cmn | Slovak | sk |
+| Croatian | hr | Slovenian | sl |
+| Czech | cs | Swahili | sw |
+| Danish | da | Swedish | sv |
+| Estonian | et | Urdu | ur |
+
+## Supported models
+
+| Model | Single speaker | Multispeaker |
+|---|---|---|
+| [Gemini 3.1 Flash TTS Preview](https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-tts-preview) | ✔️ | ✔️ |
+| [Gemini 2.5 Flash Preview TTS](https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-preview-tts) | ✔️ | ✔️ |
+| [Gemini 2.5 Pro Preview TTS](https://ai.google.dev/gemini-api/docs/models/gemini-2.5-pro-preview-tts) | ✔️ | ✔️ |
+
+## Prompting guide
+
+The **Gemini Native Audio Generation Text-to-Speech (TTS)** model differentiates
+itself from traditional TTS models by using a large language model that
+knows ***not only what to say, but also how to say it***.
+
+Out of the box, the model will natively interpret a transcript and determine how
+your words should be delivered. Simple transcripts without any additional
+prompting sound natural. But Gemini TTS also comes with tools you can use to
+steer it.
+
+The purpose of this guide is to offer fundamental direction and spark ideas when
+developing audio experiences. We'll start with **Tags** for quick inline
+control, and then explore advanced **Prompting structures** for full performance
+direction.
+
+### Audio tags
+
+Tags are inline modifiers like `[whispers]` or `[laughs]` that give you granular
+control over the delivery. You can use them to change the tone, pace, and
+emotional vibe of a line or section of the transcript. You can also use them to
+add interjections and a few other non-verbal sounds to the performance, like
+`[cough]`, `[sighs]` or `[gasp]`.
+
+There is no exhaustive list on what tags do and don't work, we recommend
+experimenting with different emotions and expressions to see how the output
+changes.
+
+If your transcript is not in English, for best results we recommend that you
+still use English audio tags.
+
+**Be creative with audio tags**
+
+To show the kind of variability you can get with audio tags, here are a set of
+examples that each say the same thing, but the delivery changes based on the
+tags used.
+
+You can change the emphasis of the delivery by adding tags at the start of a
+line to make the speaker excited, bored, or reluctant:
+
+- `[excitedly]` Hey there, I'm a new text to speech model, and I can say things in many different ways. How can I help you today?
+- `[bored]` Hey there, I'm a new text to speech model...
+- `[reluctantly]` Hey there, I'm a new text to speech model...
+
+Tags can also be used to change the pace of the delivery, or to combine pace
+with emphasis:
+
+- `[very fast]` Hey there, I'm a new text to speech model...
+- `[very slow]` Hey there, I'm a new text to speech model...
+- `[sarcastically, one painfully slow word at a time]` Hey there, I'm a new text to speech model...
+
+You also have precise control over specific sections, meaning you can whisper
+one part and shout another.
+
+- `[whispers]` Hey there, I'm a new text to speech model, `[shouting]` and I can say things in many different ways. `[whispers]` How can I help you today
+
+You can also experiment with any creative idea you want:
+
+- `[like a cartoon dog]` Hey there, I'm a new text to speech model...
+- `[like dracula]` Hey there, I'm a new text to speech model...
+
+Commonly used tags include:
+
+|---|---|---|---|
+| `[amazed]` | `[crying]` | `[curious]` | `[excited]` |
+| `[sighs]` | `[gasp]` | `[giggles]` | `[laughs]` |
+| `[mischievously]` | `[panicked]` | `[sarcastic]` | `[serious]` |
+| `[shouting]` | `[tired]` | `[trembling]` | `[whispers]` |
+
+Tags give quick and easy control over the delivery of your transcript. For even
+more control, you can combine them with a context prompt to set the overall tone
+and vibe of the performance.
+
+### Advanced prompting
+
+You can think of an advanced prompt as a system instruction for the model to
+follow. It's a way to give the model more context and control over the
+performance.
+
+A robust prompt ideally includes the following elements that come together to
+craft a great performance:
+
+- **Audio Profile** - Establishes a persona for the voice, defining a character identity, archetype and any other characteristics like age, background etc.
+- **Scene** - Sets the stage. Describes both the physical environment and the "vibe".
+- **Director's Notes** - Performance guidance where you can break down which instructions are important for your virtual talent to take note of. Examples are style, breathing, pacing, articulation and accent.
+- **Sample context** - Gives the model a contextual starting point, so your virtual actor enters the scene you set up naturally.
+- **Transcript** - The text that the model will speak out. For best performance, remember that the transcript topic and writing style should correlate to the directions you are giving.
+- **Audio tags** - Modifiers you can put into a transcript to change how that part of the text is delivered, such as `[whispers]` or `[shouting]`.
+
+> [!NOTE]
+> **Note:** Have Gemini help you build your prompt, just give it a blank outline of the format below and ask it to sketch out a character for you.
+
+Example full prompt:
+
+    # AUDIO PROFILE: Jaz R.
+    ## "The Morning Hype"
+
+    ## THE SCENE: The London Studio
+    It is 10:00 PM in a glass-walled studio overlooking the moonlit London skyline,
+    but inside, it is blindingly bright. The red "ON AIR" tally light is blazing.
+    Jaz is standing up, not sitting, bouncing on the balls of their heels to the
+    rhythm of a thumping backing track. Their hands fly across the faders on a
+    massive mixing desk. It is a chaotic, caffeine-fueled cockpit designed to wake
+    up an entire nation.
+
+    ### DIRECTOR'S NOTES
+    Style:
+    * The "Vocal Smile": You must hear the grin in the audio. The soft palate is
+    always raised to keep the tone bright, sunny, and explicitly inviting.
+    * Dynamics: High projection without shouting. Punchy consonants and elongated
+    vowels on excitement words (e.g., "Beauuutiful morning").
+
+    Pace: Speaks at an energetic pace, keeping up with the fast music.  Speaks
+    with A "bouncing" cadence. High-speed delivery with fluid transitions --- no dead
+    air, no gaps.
+
+    Accent: Jaz is from Brixton, London
+
+    ### SAMPLE CONTEXT
+    Jaz is the industry standard for Top 40 radio, high-octane event promos, or any
+    script that requires a charismatic Estuary accent and 11/10 infectious energy.
+
+    #### TRANSCRIPT
+    [excitedly] Yes, massive vibes in the studio! You are locked in and it is
+    absolutely popping off in London right now. If you're stuck on the tube, or
+    just sat there pretending to work... stop it. Seriously, I see you.
+    [shouting] Turn this up! We've got the project roadmap landing in three,
+    two... let's go!
+
+### Detailed prompting strategies
+
+Let's break down each element of the prompt.
+
+#### Audio Profile
+
+Briefly describe the persona of the character.
+
+- **Name.** Giving your character a name helps ground the model and tight performance together, Refer to the character by name when setting the scene and context
+- **Role.** Core identity and archetype of the character that's playing out in the scene. e.g., Radio DJ, Podcaster, News reporter etc.
+
+Examples:
+
+    # AUDIO PROFILE: Jaz R.
+    ## "The Morning Hype"
+
+<br />
+
+    # AUDIO PROFILE: Monica A.
+    ## "The Beauty Influencer"
+
+#### Scene
+
+Set the context for the scene, including location, mood, and environmental
+details that establish the tone and vibe. Describe what is happening around the
+character and how it affects them. The scene provides the environmental context
+for the entire interaction and guides the acting performance in a subtle
+organic way.
+
+Examples:
+
+    ## THE SCENE: The London Studio
+    It is 10:00 PM in a glass-walled studio overlooking the moonlit London skyline,
+    but inside, it is blindingly bright. The red "ON AIR" tally light is blazing.
+    Jaz is standing up, not sitting, bouncing on the balls of their heels to the
+    rhythm of a thumping backing track. Their hands fly across the faders on a
+    massive mixing desk. It is a chaotic, caffeine-fueled cockpit designed to
+    wake up an entire nation.
+
+<br />
+
+    ## THE SCENE: Homegrown Studio
+    A meticulously sound-treated bedroom in a suburban home. The space is
+    deadened by plush velvet curtains and a heavy rug, but there is a
+    distinct "proximity effect."
+
+#### Directors notes
+
+This critical section includes specific performance guidance. You can skip all
+the other elements, but we recommend you include this element.
+
+Define only what's important to the performance, being careful to not
+overspecify. Too many strict rules will limit the models' creativity and may
+result in a worse performance. Balance the role and scene description with the
+specific performance rules.
+
+The most common directions are **Style, Pacing and Accent**, but the model is
+not limited to these, nor requires them. Feel free to include custom
+instructions to cover any additional details important to your performance, and
+go into as much or as little detail as necessary.
+
+For example:
+
+    ### DIRECTOR'S NOTES
+
+    Style: Enthusiastic and Sassy GenZ beauty YouTuber
+
+    Pacing: Speaks at an energetic pace, keeping up with the extremely fast, rapid
+    delivery influencers use in short form videos.
+
+    Accent: Southern california valley girl from Laguna Beach |
+
+**Style:**
+
+Sets the tone and Style of the generated speech. Include things like upbeat,
+energetic, relaxed, bored etc. to guide the performance. Be descriptive and
+provide as much detail as necessary: *"Infectious enthusiasm. The listener
+should feel like they are part of a massive, exciting community event."* works
+better than simply saying *"energetic and enthusiastic".*
+
+You can even try terms that are popular in the voiceover industry, like "vocal
+smile". You can layer as many style characteristics as you want.
+
+Examples:
+
+Simple Emotion
+
+    DIRECTORS NOTES
+    ...
+    Style: Frustrated and angry developer who can't get the build to run.
+    ...
+
+More depth
+
+    DIRECTORS NOTES
+    ...
+    Style: Sassy GenZ beauty YouTuber, who mostly creates content for YouTube Shorts.
+    ...
+
+Complex
+
+    DIRECTORS NOTES
+    Style:
+    * The "Vocal Smile": You must hear the grin in the audio. The soft palate is
+    always raised to keep the tone bright, sunny, and explicitly inviting.
+    *Dynamics: High projection without shouting. Punchy consonants and
+    elongated vowels on excitement words (e.g., "Beauuutiful morning").
+
+**Accent:**
+
+Describe the desired accent. The more specific you are, the better the
+results are. For example use "*British English accent as heard in Croydon,
+England* " vs "*British Accent*".
+
+Examples:
+
+    ### DIRECTORS NOTES
+    ...
+    Accent: Southern california valley girl from Laguna Beach
+    ...
+
+<br />
+
+    ### DIRECTORS NOTES
+    ...
+    Accent: Jaz is a DJ from Brixton, London
+    ...
+
+**Pacing:**
+
+Overall pacing and pace variation throughout the piece.
+
+Examples:
+
+Simple
+
+    ### DIRECTORS NOTES
+    ...
+    Pacing: Speak as fast as possible
+    ...
+
+More Depth
+
+    ### DIRECTORS NOTES
+    ...
+    Pacing: Speaks at a faster, energetic pace, keeping up with fast paced music.
+    ...
+
+Complex
+
+    ### DIRECTORS NOTES
+    ...
+    Pacing: The "Drift": The tempo is incredibly slow and liquid. Words bleed into each other. There is zero urgency.
+    ...
+
+#### Transcript and audio tags
+
+The transcript is the exact words the model will speak. An audio tag is a word
+in square brackets that indicates either how something should be said, a change
+of tone, or an interjection.
+
+    ### TRANSCRIPT
+
+    I know right, [sarcastically] I couldn't believe it. [whispers] She should have totally left
+    at that point.
+
+    [cough] Well, [sighs] I guess it doesn't matter now.
+
+**Give it a try**
+
+Try some of these examples yourself on
+[AI Studio](https://aistudio.google.com/generate-speech), play with our
+[TTS App](http://aistudio.google.com/app/apps/bundled/synergy_intro) and let
+Gemini put you in the directors chair. Keep these tips in mind to make great
+vocal performances:
+
+- Remember to keep the entire prompt coherent -- the script and direction go hand in hand in creating a great performance.
+- Don't feel you have to describe everything, sometimes giving the model space to fill in the gaps helps naturalness. (Just like a talented actor)
+- If you ever are feeling stuck, have Gemini lend you a hand to help you craft your script or performance.
+
+## Limitations
+
+- TTS models can only receive text inputs and generate audio outputs.
+- A TTS session has a [context window](https://ai.google.dev/gemini-api/docs/long-context) limit of 32k tokens.
+- Review [Languages](https://ai.google.dev/gemini-api/docs/speech-generation#languages) section for language support.
+- TTS does not support streaming.
+
+The following constraints apply specifically when using the Gemini 3.1 Flash
+TTS Preview model for speech generation:
+
+- **Voice inconsistency with prompt instructions:** The model's output may not always strictly match the selected speaker, causing the audio to sound different than expected. To avoid mismatched tones (such as a deep male voice attempting to speak like a young girl), ensure your prompt's written tone and context align naturally with the selected speaker's profile.
+- **Quality of longer outputs:** Speech quality and consistency may begin to drift with generated outputs that are longer than a few minutes. We recommend splitting your transcripts into smaller chunks.
+- **Occasional text token returns:** The model occasionally returns text tokens instead of audio tokens, causing the server to fail the request with a `500` error. Because this occurs randomly in a very small percentage of requests, you should implement automated retry logic in your application to handle these.
+- **Prompt classifier false rejections:** Vague prompts may fail to trigger the speech synthesis classifier, resulting in a rejected request (`PROHIBITED_CONTENT`) or causing the model to read your style instructions and director's notes aloud. Validate your prompts by adding a clear preamble instructing the model to synthesize speech, and explicitly label where the actual spoken transcript begins.
+
+## What's next
+
+- Try the [audio generation cookbook](https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Get_started_TTS.ipynb).
+- Gemini's [Live API](https://ai.google.dev/gemini-api/docs/live) offers interactive audio generation options you can interleave with other modalities.
+- For working with audio *inputs* , visit the [Audio understanding](https://ai.google.dev/gemini-api/docs/audio) guide.

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -133,6 +133,37 @@ class Gemini3Client(LLMClient):
         if config.get("image_config") is not None:
             config_params["image_config"] = types.ImageConfig(**config["image_config"])
 
+        if (tts_config := config.get("tts_config")) is not None:
+            speaker_voices = tts_config.get("speaker_voices", [])
+            if len(speaker_voices) not in (1, 2):
+                raise ValueError("tts_config.speaker_voices must contain 1 or 2 entries.")
+            config_params["response_modalities"] = ["AUDIO"]
+            if len(speaker_voices) == 1:
+                config_params["speech_config"] = types.SpeechConfig(
+                    voice_config=types.VoiceConfig(
+                        prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=speaker_voices[0]["voice"])
+                    )
+                )
+            else:
+                speaker_voice_configs = []
+                for speaker_config in speaker_voices:
+                    speaker = speaker_config.get("speaker")
+                    if not speaker:
+                        raise ValueError("speaker is required when tts_config.speaker_voices has 2 entries.")
+                    speaker_voice_configs.append(
+                        types.SpeakerVoiceConfig(
+                            speaker=speaker,
+                            voice_config=types.VoiceConfig(
+                                prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=speaker_config["voice"])
+                            ),
+                        )
+                    )
+                config_params["speech_config"] = types.SpeechConfig(
+                    multi_speaker_voice_config=types.MultiSpeakerVoiceConfig(
+                        speaker_voice_configs=speaker_voice_configs
+                    )
+                )
+
         thinking_summary = config.get("thinking_summary")
         thinking_level = config.get("thinking_level")
         if thinking_summary is not None or thinking_level is not None:
@@ -307,6 +338,16 @@ class Gemini3Client(LLMClient):
         """Stream generate using Gemini SDK with unified conversion methods."""
         # Use unified config conversion
         gemini_config = self.transform_uni_config_to_model_config(config)
+
+        if config.get("tts_config") is not None:
+            invalid_item = next(
+                (item for message in messages for item in message["content_items"] if item["type"] != "text"),
+                None,
+            )
+            if invalid_item is not None:
+                raise ValueError(
+                    f"Gemini TTS only supports text input, got content item type={invalid_item['type']!r}."
+                )
 
         # Use unified message conversion
         contents = await self.transform_uni_message_to_model_input(messages)

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -133,26 +133,25 @@ class Gemini3Client(LLMClient):
         if config.get("image_config") is not None:
             config_params["image_config"] = types.ImageConfig(**config["image_config"])
 
-        tts_config = config.get("tts_config")
-        if tts_config is not None or "tts" in self._model.lower():
+        if "tts" in self._model.lower():
+            tts_config = config.get("tts_config")
             if tts_config is None:
-                tts_config = {"speaker_voices": [{"voice": "Kore"}]}
-            speaker_voices = tts_config.get("speaker_voices", [])
-            if len(speaker_voices) not in (1, 2):
-                raise ValueError("tts_config.speaker_voices must contain 1 or 2 entries.")
+                tts_config = [{"voice": "Kore"}]
+            if len(tts_config) not in (1, 2):
+                raise ValueError("tts_config must contain 1 or 2 entries.")
             config_params["response_modalities"] = ["AUDIO"]
-            if len(speaker_voices) == 1:
+            if len(tts_config) == 1:
                 config_params["speech_config"] = types.SpeechConfig(
                     voice_config=types.VoiceConfig(
-                        prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=speaker_voices[0]["voice"])
+                        prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=tts_config[0]["voice"])
                     )
                 )
             else:
                 speaker_voice_configs = []
-                for speaker_config in speaker_voices:
+                for speaker_config in tts_config:
                     speaker = speaker_config.get("speaker")
                     if not speaker:
-                        raise ValueError("speaker is required when tts_config.speaker_voices has 2 entries.")
+                        raise ValueError("speaker is required when tts_config has 2 entries.")
                     speaker_voice_configs.append(
                         types.SpeakerVoiceConfig(
                             speaker=speaker,
@@ -342,7 +341,7 @@ class Gemini3Client(LLMClient):
         # Use unified config conversion
         gemini_config = self.transform_uni_config_to_model_config(config)
 
-        if "tts" in self._model.lower() or config.get("tts_config") is not None:
+        if "tts" in self._model.lower():
             invalid_item = next(
                 (item for message in messages for item in message["content_items"] if item["type"] != "text"),
                 None,

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -133,7 +133,10 @@ class Gemini3Client(LLMClient):
         if config.get("image_config") is not None:
             config_params["image_config"] = types.ImageConfig(**config["image_config"])
 
-        if (tts_config := config.get("tts_config")) is not None:
+        tts_config = config.get("tts_config")
+        if tts_config is not None or "tts" in self._model.lower():
+            if tts_config is None:
+                tts_config = {"speaker_voices": [{"voice": "Kore"}]}
             speaker_voices = tts_config.get("speaker_voices", [])
             if len(speaker_voices) not in (1, 2):
                 raise ValueError("tts_config.speaker_voices must contain 1 or 2 entries.")
@@ -339,7 +342,7 @@ class Gemini3Client(LLMClient):
         # Use unified config conversion
         gemini_config = self.transform_uni_config_to_model_config(config)
 
-        if config.get("tts_config") is not None:
+        if "tts" in self._model.lower() or config.get("tts_config") is not None:
             invalid_item = next(
                 (item for message in messages for item in message["content_items"] if item["type"] != "text"),
                 None,

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -113,6 +113,7 @@ def create_chat_app() -> Flask:
                         <option value="gpt-5.4">GPT 5.4</option>
                         <option value="gemini-3-flash-preview">Gemini 3 Flash</option>
                         <option value="gemini-3.1-flash-image-preview">Gemini 3.1 Flash Image</option>
+                        <option value="gemini-3.1-flash-tts-preview">Gemini 3.1 Flash TTS</option>
                         <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
                         <option value="kimi-k2.5">Kimi K2.5</option>
                         <option value="glm-5">GLM 5</option>
@@ -168,6 +169,20 @@ def create_chat_app() -> Flask:
                     <input type="text" id="traceIdInput" placeholder="e.g., session_001" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                 </div>
             </div>
+            <div id="ttsConfigSection" class="hidden mt-4">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div class="flex flex-col">
+                        <label class="text-sm font-semibold text-gray-900 mb-1" for="ttsVoiceInput">Voice</label>
+                        <input
+                            type="text"
+                            id="ttsVoiceInput"
+                            value="Kore"
+                            placeholder="e.g., Kore"
+                            class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                        >
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="flex-1 overflow-y-auto px-6 py-6" id="messagesContainer">
@@ -205,6 +220,69 @@ def create_chat_app() -> Flask:
                 const d = new Date(ms);
                 const pad = n => n.toString().padStart(2, '0');
                 return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+            }
+
+            function pcmBase64ToWavDataUrl(pcmBase64, sampleRate = 24000, channels = 1, bitsPerSample = 16) {
+                const binary = atob(pcmBase64);
+                const pcmBytes = new Uint8Array(binary.length);
+                for (let i = 0; i < binary.length; i++) {
+                    pcmBytes[i] = binary.charCodeAt(i);
+                }
+
+                const header = new ArrayBuffer(44);
+                const view = new DataView(header);
+                const byteRate = sampleRate * channels * bitsPerSample / 8;
+                const blockAlign = channels * bitsPerSample / 8;
+
+                const writeString = (offset, value) => {
+                    for (let i = 0; i < value.length; i++) {
+                        view.setUint8(offset + i, value.charCodeAt(i));
+                    }
+                };
+
+                writeString(0, 'RIFF');
+                view.setUint32(4, 36 + pcmBytes.length, true);
+                writeString(8, 'WAVE');
+                writeString(12, 'fmt ');
+                view.setUint32(16, 16, true);
+                view.setUint16(20, 1, true);
+                view.setUint16(22, channels, true);
+                view.setUint32(24, sampleRate, true);
+                view.setUint32(28, byteRate, true);
+                view.setUint16(32, blockAlign, true);
+                view.setUint16(34, bitsPerSample, true);
+                writeString(36, 'data');
+                view.setUint32(40, pcmBytes.length, true);
+
+                const wavBytes = new Uint8Array(44 + pcmBytes.length);
+                wavBytes.set(new Uint8Array(header), 0);
+                wavBytes.set(pcmBytes, 44);
+
+                let wavBinary = '';
+                const chunkSize = 0x8000;
+                for (let i = 0; i < wavBytes.length; i += chunkSize) {
+                    wavBinary += String.fromCharCode(...wavBytes.subarray(i, i + chunkSize));
+                }
+                return `data:audio/wav;base64,${btoa(wavBinary)}`;
+            }
+
+            function renderInlineData(item) {
+                const mimeType = (item.mime_type || '').toLowerCase();
+                if (mimeType.startsWith('image/')) {
+                    return `<div class="mb-3"><img src="data:${mimeType || 'image/png'};base64,${item.data}" class="max-w-xs rounded border border-gray-300"></div>`;
+                }
+
+                const audioMimeTypes = ['audio/wav', 'audio/x-wav', 'audio/mpeg', 'audio/mp3', 'audio/ogg', 'audio/webm', 'audio/flac', 'audio/aac', 'audio/mp4'];
+                const isAudio = !mimeType || mimeType === 'application/octet-stream' || mimeType.startsWith('audio/');
+                if (!isAudio) {
+                    return `<div class="mb-3 rounded border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-600">Inline data: ${escapeHtml(item.mime_type || 'application/octet-stream')}</div>`;
+                }
+
+                const playableMimeType = audioMimeTypes.includes(mimeType);
+                const audioSrc = playableMimeType
+                    ? `data:${mimeType || 'application/octet-stream'};base64,${item.data}`
+                    : pcmBase64ToWavDataUrl(item.data);
+                return `<div class="mb-3"><audio controls preload="metadata" class="max-w-xs"><source src="${audioSrc}" type="${playableMimeType ? mimeType : 'audio/wav'}"></audio></div>`;
             }
 
             function handleImageSelect(event) {
@@ -266,7 +344,13 @@ def create_chat_app() -> Flask:
                 panel.classList.toggle('hidden');
             }
 
+            function updateConditionalConfigVisibility() {
+                const model = document.getElementById('modelSelect').value.trim().toLowerCase();
+                document.getElementById('ttsConfigSection').classList.toggle('hidden', !model.includes('tts'));
+            }
+
             function getConfig() {
+                const selectedModel = document.getElementById('modelSelect').value.trim().toLowerCase();
                 const config = {
                     model: document.getElementById('modelSelect').value,
                     temperature: parseFloat(document.getElementById('temperatureInput').value),
@@ -306,6 +390,13 @@ def create_chat_app() -> Flask:
                 const traceId = document.getElementById('traceIdInput').value.trim();
                 if (traceId) {
                     config.trace_id = traceId;
+                }
+
+                const voice = document.getElementById('ttsVoiceInput').value.trim();
+                if (selectedModel.includes('tts') && voice) {
+                    config.tts_config = {
+                        speaker_voices: [{ voice: voice }]
+                    };
                 }
 
                 return config;
@@ -479,10 +570,11 @@ def create_chat_app() -> Flask:
                                             toolResultDiv.innerHTML = `<strong class="text-sm">✅ Tool Result:</strong><br><div class="mt-1 text-xs whitespace-pre-wrap">${escapeHtml(item.text)}</div>`;
                                             contentDiv.appendChild(toolResultDiv);
                                         } else if (item.type === 'inline_data') {
-                                            const imageDiv = document.createElement('div');
-                                            imageDiv.className = 'mb-3';
-                                            imageDiv.innerHTML = `<img src="data:${item.mime_type || 'image/png'};base64,${item.data}" class="max-w-xs rounded border border-gray-300">`;
-                                            contentDiv.appendChild(imageDiv);
+                                            const inlineDataDiv = document.createElement('div');
+                                            inlineDataDiv.innerHTML = renderInlineData(item);
+                                            if (inlineDataDiv.firstChild) {
+                                                contentDiv.appendChild(inlineDataDiv.firstChild);
+                                            }
                                         }
                                     }
 
@@ -593,6 +685,10 @@ def create_chat_app() -> Flask:
                 this.style.height = 'auto';
                 this.style.height = Math.min(this.scrollHeight, 200) + 'px';
             });
+
+            document.getElementById('modelSelect').addEventListener('input', updateConditionalConfigVisibility);
+            document.getElementById('modelSelect').addEventListener('change', updateConditionalConfigVisibility);
+            updateConditionalConfigVisibility();
         </script>
     </body>
     </html>

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -169,20 +169,6 @@ def create_chat_app() -> Flask:
                     <input type="text" id="traceIdInput" placeholder="e.g., session_001" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                 </div>
             </div>
-            <div id="ttsConfigSection" class="hidden mt-4">
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div class="flex flex-col">
-                        <label class="text-sm font-semibold text-gray-900 mb-1" for="ttsVoiceInput">Voice</label>
-                        <input
-                            type="text"
-                            id="ttsVoiceInput"
-                            value="Kore"
-                            placeholder="e.g., Kore"
-                            class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                        >
-                    </div>
-                </div>
-            </div>
         </div>
 
         <div class="flex-1 overflow-y-auto px-6 py-6" id="messagesContainer">
@@ -344,13 +330,7 @@ def create_chat_app() -> Flask:
                 panel.classList.toggle('hidden');
             }
 
-            function updateConditionalConfigVisibility() {
-                const model = document.getElementById('modelSelect').value.trim().toLowerCase();
-                document.getElementById('ttsConfigSection').classList.toggle('hidden', !model.includes('tts'));
-            }
-
             function getConfig() {
-                const selectedModel = document.getElementById('modelSelect').value.trim().toLowerCase();
                 const config = {
                     model: document.getElementById('modelSelect').value,
                     temperature: parseFloat(document.getElementById('temperatureInput').value),
@@ -390,13 +370,6 @@ def create_chat_app() -> Flask:
                 const traceId = document.getElementById('traceIdInput').value.trim();
                 if (traceId) {
                     config.trace_id = traceId;
-                }
-
-                const voice = document.getElementById('ttsVoiceInput').value.trim();
-                if (selectedModel.includes('tts') && voice) {
-                    config.tts_config = {
-                        speaker_voices: [{ voice: voice }]
-                    };
                 }
 
                 return config;
@@ -686,9 +659,6 @@ def create_chat_app() -> Flask:
                 this.style.height = Math.min(this.scrollHeight, 200) + 'px';
             });
 
-            document.getElementById('modelSelect').addEventListener('input', updateConditionalConfigVisibility);
-            document.getElementById('modelSelect').addEventListener('change', updateConditionalConfigVisibility);
-            updateConditionalConfigVisibility();
         </script>
     </body>
     </html>

--- a/src_py/agenthub/integration/tracer.py
+++ b/src_py/agenthub/integration/tracer.py
@@ -20,8 +20,10 @@ and serve them via a web interface for real-time monitoring.
 """
 
 import base64
+import io
 import json
 import os
+import wave
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -70,6 +72,59 @@ class Tracer:
             return [self._serialize_for_json(item) for item in obj]
         return obj
 
+    @staticmethod
+    def _is_browser_playable_audio_mime_type(mime_type: str | None) -> bool:
+        """Return whether browsers can usually play this MIME type directly."""
+        return (mime_type or "").lower() in {
+            "audio/wav",
+            "audio/x-wav",
+            "audio/mpeg",
+            "audio/mp3",
+            "audio/ogg",
+            "audio/webm",
+            "audio/flac",
+            "audio/aac",
+            "audio/mp4",
+        }
+
+    @staticmethod
+    def _decode_inline_data(item: dict[str, Any]) -> bytes:
+        """Decode inline_data payloads from bytes or base64 text."""
+        data = item.get("data") or b""
+        if isinstance(data, str):
+            return base64.b64decode(data.encode("utf-8"))
+        return data
+
+    def _build_wave_bytes_from_pcm(self, item: dict[str, Any]) -> bytes:
+        """Wrap raw PCM bytes in a WAV header using Gemini TTS defaults."""
+        pcm_bytes = self._decode_inline_data(item)
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(pcm_bytes)
+        return buffer.getvalue()
+
+    def _build_inline_data_url(self, item: dict[str, Any]) -> str:
+        """Build a browser-friendly data URL for inline_data content."""
+        mime_type = item.get("mime_type") or "application/octet-stream"
+        raw_bytes = self._decode_inline_data(item)
+
+        if mime_type.startswith("image/"):
+            encoded = base64.b64encode(raw_bytes).decode("utf-8")
+            return f"data:{mime_type};base64,{encoded}"
+
+        if mime_type.startswith("audio/"):
+            if not self._is_browser_playable_audio_mime_type(mime_type):
+                mime_type = "audio/wav"
+                raw_bytes = self._build_wave_bytes_from_pcm(item)
+            encoded = base64.b64encode(raw_bytes).decode("utf-8")
+            return f"data:{mime_type};base64,{encoded}"
+
+        encoded = base64.b64encode(raw_bytes).decode("utf-8")
+        return f"data:{mime_type};base64,{encoded}"
+
     def _format_inline_data_summary(self, item: dict[str, Any], *, is_thinking: bool = False) -> str:
         """
         Format inline_data metadata without emitting raw payloads.
@@ -93,7 +148,12 @@ class Tracer:
         mb_count = byte_count / (1024 * 1024)
 
         label = "Thinking " if is_thinking else ""
-        label += "Inline Image" if mime_type.startswith("image/") else "Inline Data"
+        if mime_type.startswith("image/"):
+            label += "Inline Image"
+        elif mime_type.startswith("audio/"):
+            label += "Inline Audio"
+        else:
+            label += "Inline Data"
 
         if kb_count < 1000:
             return f"{label}: {mime_type} ({kb_count:.2f} KB)"
@@ -239,13 +299,7 @@ class Tracer:
         @app.template_filter("inline_data_url")
         def inline_data_url(item: dict[str, Any]) -> str:
             """Build a data URL for inline_data content."""
-            mime_type = item.get("mime_type") or "application/octet-stream"
-            data = item.get("data") or ""
-            if isinstance(data, bytes):
-                encoded = base64.b64encode(data).decode("utf-8")
-            else:
-                encoded = data
-            return f"data:{mime_type};base64,{encoded}"
+            return self._build_inline_data_url(item)
 
         @app.template_filter("inline_data_summary")
         def inline_data_summary(item: dict[str, Any]) -> str:
@@ -410,6 +464,10 @@ class Tracer:
                                             <div class="text-xs text-purple-700 mb-2">{{ item|inline_data_summary }}</div>
                                             {% if item.mime_type and item.mime_type.startswith('image/') %}
                                                 <img src="{{ item|inline_data_url|e }}" class="max-w-xs max-h-48 rounded-md" alt="Inline Image">
+                                            {% elif item.mime_type and item.mime_type.startswith('audio/') %}
+                                                <audio controls preload="metadata" class="max-w-xs">
+                                                    <source src="{{ item|inline_data_url|e }}">
+                                                </audio>
                                             {% else %}
                                                 <div class="font-mono text-sm whitespace-pre-wrap text-gray-800">
                                                     {{ item|inline_data_summary }}

--- a/src_py/agenthub/types.py
+++ b/src_py/agenthub/types.py
@@ -155,17 +155,11 @@ class ImageConfig(TypedDict):
     image_size: NotRequired[ImageSize]
 
 
-class TTSSpeakerConfig(TypedDict):
+class SpeakerConfig(TypedDict):
     """Speaker and voice assignment for TTS."""
 
     voice: str
     speaker: NotRequired[str]
-
-
-class TTSConfig(TypedDict):
-    """Unified TTS configuration."""
-
-    speaker_voices: list[TTSSpeakerConfig]
 
 
 class UniConfig(TypedDict):
@@ -180,5 +174,5 @@ class UniConfig(TypedDict):
     system_prompt: NotRequired[str]
     prompt_caching: NotRequired[PromptCaching]
     image_config: NotRequired[ImageConfig]
-    tts_config: NotRequired[TTSConfig]
+    tts_config: NotRequired[list[SpeakerConfig]]
     trace_id: NotRequired[str]

--- a/src_py/agenthub/types.py
+++ b/src_py/agenthub/types.py
@@ -155,6 +155,19 @@ class ImageConfig(TypedDict):
     image_size: NotRequired[ImageSize]
 
 
+class TTSSpeakerConfig(TypedDict):
+    """Speaker and voice assignment for TTS."""
+
+    voice: str
+    speaker: NotRequired[str]
+
+
+class TTSConfig(TypedDict):
+    """Unified TTS configuration."""
+
+    speaker_voices: list[TTSSpeakerConfig]
+
+
 class UniConfig(TypedDict):
     """Universal configuration format for LLM requests."""
 
@@ -167,4 +180,5 @@ class UniConfig(TypedDict):
     system_prompt: NotRequired[str]
     prompt_caching: NotRequired[PromptCaching]
     image_config: NotRequired[ImageConfig]
+    tts_config: NotRequired[TTSConfig]
     trace_id: NotRequired[str]

--- a/src_py/examples/tts_example.py
+++ b/src_py/examples/tts_example.py
@@ -1,0 +1,88 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example demonstrating Gemini single-speaker TTS generation.
+
+This example sends a text-only prompt with transcript tags such as [excitedly],
+collects the returned audio chunks, and saves the final output as a WAV file.
+"""
+
+import asyncio
+import os
+import wave
+from pathlib import Path
+
+from agenthub import AutoLLMClient
+
+
+def save_wav_file(
+    filename: Path, pcm_data: bytes, channels: int = 1, rate: int = 24000, sample_width: int = 2
+) -> None:
+    """Save raw PCM bytes as a WAV file using Gemini TTS defaults."""
+
+    with wave.open(str(filename), "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(sample_width)
+        wav_file.setframerate(rate)
+        wav_file.writeframes(pcm_data)
+
+
+async def main():
+    """Example of single-speaker Gemini TTS generation."""
+    print("=" * 60)
+    print("Gemini TTS Example")
+    print("=" * 60)
+
+    # Get model from environment variable, default to gemini-3.1-flash-tts-preview
+    model = os.getenv("MODEL", "gemini-3.1-flash-tts-preview")
+    print(f"Using model: {model}")
+
+    client = AutoLLMClient(model=model)
+    prompt = """Synthesize speech for the transcript below using a single speaker.
+
+### TRANSCRIPT
+[excitedly] Welcome to AgentHub! We just added Gemini text-to-speech support.
+[warmly] This demo saves the generated audio as a WAV file so you can play it back right away.
+[whispers] And yes, prompt tags like this can shape the performance.
+"""
+    output_path = Path.cwd() / "generated_audio.wav"
+
+    print("User:")
+    print(prompt)
+    print("Assistant:")
+    print(f"Saving output to: {output_path}")
+
+    audio_chunks: list[bytes] = []
+    async for event in client.streaming_response(
+        messages=[{"role": "user", "content_items": [{"type": "text", "text": prompt}]}],
+        config={"tts_config": {"speaker_voices": [{"voice": "Kore"}]}},
+    ):
+        for item in event["content_items"]:
+            if item["type"] == "inline_data":
+                audio_chunks.append(item["data"])
+
+    if not audio_chunks:
+        raise RuntimeError("No audio data was returned by the model.")
+
+    save_wav_file(output_path, b"".join(audio_chunks))
+    print(f"Saved WAV file to: {output_path}")
+
+    print("\n" + "=" * 60)
+    print("Gemini TTS complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src_py/examples/tts_example.py
+++ b/src_py/examples/tts_example.py
@@ -67,7 +67,7 @@ async def main():
     audio_chunks: list[bytes] = []
     async for event in client.streaming_response(
         messages=[{"role": "user", "content_items": [{"type": "text", "text": prompt}]}],
-        config={"tts_config": {"speaker_voices": [{"voice": "Kore"}]}},
+        config={"tts_config": [{"voice": "Kore"}]},
     ):
         for item in event["content_items"]:
             if item["type"] == "inline_data":

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -36,6 +36,7 @@ class Model:
     support_temperature: bool = True
     support_image_understanding: bool = True
     support_image_generation: bool = False
+    support_tts: bool = False
     provider: Literal["official", "siliconflow", "openrouter", "bedrock", "vertex"] = "official"
 
     def __repr__(self) -> str:
@@ -54,6 +55,7 @@ if os.getenv("GEMINI_API_KEY"):
             support_image_generation=True,
         )
     )
+    AVAILABLE_MODELS.append(Model(name="gemini-3.1-flash-tts-preview", support_tts=True))
 
 if os.getenv("ANTHROPIC_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="claude-sonnet-4-6"))
@@ -95,6 +97,7 @@ if os.getenv("VERTEX_API_KEY"):
             support_image_generation=True,
         )
     )
+    AVAILABLE_MODELS.append(Model(name="gemini-3.1-flash-tts-preview", provider="vertex", support_tts=True))
 
 
 async def _create_client(model: Model) -> AutoLLMClient:
@@ -585,6 +588,38 @@ async def test_image_generation(model: Model):
     assert inline_items, f"No inline data returned for generated image by {model.name}"
     assert any("image/" in item["mime_type"] for item in inline_items)
     assert all(isinstance(item["data"], bytes) and item["data"] for item in inline_items)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=[str(model) for model in AVAILABLE_MODELS])
+async def test_tts_generation_single_speaker(model: Model):
+    """Test single-speaker TTS output."""
+    if not model.support_tts:
+        pytest.skip(f"TTS is not supported by {model.name}.")
+
+    client = await _create_client(model)
+    events = []
+    async for event in client.streaming_response(
+        messages=[
+            {
+                "role": "user",
+                "content_items": [
+                    {
+                        "type": "text",
+                        "text": "Say cheerfully: Have a wonderful day!",
+                    }
+                ],
+            }
+        ],
+        config={"tts_config": {"speaker_voices": [{"voice": "Kore"}]}},
+    ):
+        await _check_event_integrity(event)
+        events.append(event)
+
+    inline_items = [item for event in events for item in event["content_items"] if item["type"] == "inline_data"]
+    assert inline_items, f"No inline data returned for TTS output by {model.name}"
+    assert all(isinstance(item["data"], bytes) and item["data"] for item in inline_items)
+    assert events[-1]["finish_reason"] is not None
 
 
 if __name__ == "__main__":

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -611,7 +611,7 @@ async def test_tts_generation_single_speaker(model: Model):
                 ],
             }
         ],
-        config={"tts_config": {"speaker_voices": [{"voice": "Kore"}]}},
+        config={"tts_config": [{"voice": "Kore"}]},
     ):
         await _check_event_integrity(event)
         events.append(event)

--- a/src_py/tests/test_tracer.py
+++ b/src_py/tests/test_tracer.py
@@ -142,6 +142,10 @@ def test_format_history_with_different_content_types(temp_cache_dir):
             ],
         },
         {
+            "role": "assistant",
+            "content_items": [{"type": "inline_data", "data": b"\x00\x01\x02\x03", "mime_type": "audio/pcm"}],
+        },
+        {
             "role": "user",
             "content_items": [{"type": "tool_result", "text": "Temperature is 20C", "tool_call_id": "call_123"}],
         },
@@ -159,6 +163,7 @@ def test_format_history_with_different_content_types(temp_cache_dir):
     assert "Let me analyze..." in content
     assert "Thinking Inline Image: image/png" in content
     assert "This is a flower." in content
+    assert "Inline Audio: audio/pcm" in content
     assert "Tool Result" in content
     assert "Temperature is 20C" in content
 

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -204,8 +204,12 @@ export class Gemini3Client extends LLMClient {
       } as GeminiImageConfig;
     }
 
-    if (config.tts_config !== undefined) {
-      const speakerVoices = config.tts_config.speaker_voices || [];
+    const isTtsModel = this._model.toLowerCase().includes("tts");
+    if (isTtsModel || config.tts_config !== undefined) {
+      const ttsConfig = config.tts_config ?? {
+        speaker_voices: [{ voice: "Kore" }],
+      };
+      const speakerVoices = ttsConfig.speaker_voices || [];
       if (![1, 2].includes(speakerVoices.length)) {
         throw new Error(
           "tts_config.speaker_voices must contain 1 or 2 entries.",
@@ -483,7 +487,10 @@ export class Gemini3Client extends LLMClient {
     messages: UniMessage[];
     config: UniConfig;
   }): AsyncGenerator<UniEvent> {
-    if (options.config.tts_config !== undefined) {
+    if (
+      this._model.toLowerCase().includes("tts") ||
+      options.config.tts_config !== undefined
+    ) {
       const invalidItem = options.messages
         .flatMap((message) => message.content_items)
         .find((item) => item.type !== "text");

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -17,11 +17,15 @@ import {
   Content,
   GenerateContentConfig,
   ImageConfig as GeminiImageConfig,
+  MultiSpeakerVoiceConfig,
   Part,
+  PrebuiltVoiceConfig,
   FunctionCall,
   ThinkingConfig,
   ThinkingLevel as GeminiThinkingLevel,
   FunctionCallingConfig,
+  SpeakerVoiceConfig,
+  SpeechConfig,
   Tool,
   ToolConfig,
   GenerateContentResponse,
@@ -29,6 +33,7 @@ import {
   FunctionResponsePart,
   FunctionResponseBlob,
   FunctionResponse,
+  VoiceConfig,
 } from "@google/genai";
 import * as path from "path";
 import { LLMClient } from "../baseClient";
@@ -197,6 +202,49 @@ export class Gemini3Client extends LLMClient {
         aspectRatio: config.image_config.aspect_ratio,
         imageSize: config.image_config.image_size,
       } as GeminiImageConfig;
+    }
+
+    if (config.tts_config !== undefined) {
+      const speakerVoices = config.tts_config.speaker_voices || [];
+      if (![1, 2].includes(speakerVoices.length)) {
+        throw new Error(
+          "tts_config.speaker_voices must contain 1 or 2 entries.",
+        );
+      }
+
+      configParams.responseModalities = ["AUDIO"];
+      if (speakerVoices.length === 1) {
+        configParams.speechConfig = {
+          voiceConfig: {
+            prebuiltVoiceConfig: {
+              voiceName: speakerVoices[0].voice,
+            } as PrebuiltVoiceConfig,
+          } as VoiceConfig,
+        } as SpeechConfig;
+      } else {
+        const speakerVoiceConfigs = speakerVoices.map((speakerConfig) => {
+          if (!speakerConfig.speaker) {
+            throw new Error(
+              "speaker is required when tts_config.speaker_voices has 2 entries.",
+            );
+          }
+
+          return {
+            speaker: speakerConfig.speaker,
+            voiceConfig: {
+              prebuiltVoiceConfig: {
+                voiceName: speakerConfig.voice,
+              } as PrebuiltVoiceConfig,
+            } as VoiceConfig,
+          } as SpeakerVoiceConfig;
+        });
+
+        configParams.speechConfig = {
+          multiSpeakerVoiceConfig: {
+            speakerVoiceConfigs,
+          } as MultiSpeakerVoiceConfig,
+        } as SpeechConfig;
+      }
     }
 
     const thinkingSummary = config.thinking_summary;
@@ -435,6 +483,17 @@ export class Gemini3Client extends LLMClient {
     messages: UniMessage[];
     config: UniConfig;
   }): AsyncGenerator<UniEvent> {
+    if (options.config.tts_config !== undefined) {
+      const invalidItem = options.messages
+        .flatMap((message) => message.content_items)
+        .find((item) => item.type !== "text");
+      if (invalidItem) {
+        throw new Error(
+          `Gemini TTS only supports text input, got content item type=${JSON.stringify(invalidItem.type)}.`,
+        );
+      }
+    }
+
     const geminiConfig = this.transformUniConfigToModelConfig(options.config);
     const contents = await this.transformUniMessageToModelInput(
       options.messages,

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -205,32 +205,25 @@ export class Gemini3Client extends LLMClient {
     }
 
     const isTtsModel = this._model.toLowerCase().includes("tts");
-    if (isTtsModel || config.tts_config !== undefined) {
-      const ttsConfig = config.tts_config ?? {
-        speaker_voices: [{ voice: "Kore" }],
-      };
-      const speakerVoices = ttsConfig.speaker_voices || [];
-      if (![1, 2].includes(speakerVoices.length)) {
-        throw new Error(
-          "tts_config.speaker_voices must contain 1 or 2 entries.",
-        );
+    if (isTtsModel) {
+      const ttsConfig = config.tts_config ?? [{ voice: "Kore" }];
+      if (![1, 2].includes(ttsConfig.length)) {
+        throw new Error("tts_config must contain 1 or 2 entries.");
       }
 
       configParams.responseModalities = ["AUDIO"];
-      if (speakerVoices.length === 1) {
+      if (ttsConfig.length === 1) {
         configParams.speechConfig = {
           voiceConfig: {
             prebuiltVoiceConfig: {
-              voiceName: speakerVoices[0].voice,
+              voiceName: ttsConfig[0].voice,
             } as PrebuiltVoiceConfig,
           } as VoiceConfig,
         } as SpeechConfig;
       } else {
-        const speakerVoiceConfigs = speakerVoices.map((speakerConfig) => {
+        const speakerVoiceConfigs = ttsConfig.map((speakerConfig) => {
           if (!speakerConfig.speaker) {
-            throw new Error(
-              "speaker is required when tts_config.speaker_voices has 2 entries.",
-            );
+            throw new Error("speaker is required when tts_config has 2 entries.");
           }
 
           return {
@@ -487,10 +480,7 @@ export class Gemini3Client extends LLMClient {
     messages: UniMessage[];
     config: UniConfig;
   }): AsyncGenerator<UniEvent> {
-    if (
-      this._model.toLowerCase().includes("tts") ||
-      options.config.tts_config !== undefined
-    ) {
+    if (this._model.toLowerCase().includes("tts")) {
       const invalidItem = options.messages
         .flatMap((message) => message.content_items)
         .find((item) => item.type !== "text");

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -94,6 +94,7 @@ export function createChatApp(): Express {
                       <option value="gpt-5.4">GPT 5.4</option>
                       <option value="gemini-3-flash-preview">Gemini 3 Flash</option>
                       <option value="gemini-3.1-flash-image-preview">Gemini 3.1 Flash Image</option>
+                      <option value="gemini-3.1-flash-tts-preview">Gemini 3.1 Flash TTS</option>
                       <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
                       <option value="kimi-k2.5">Kimi K2.5</option>
                       <option value="glm-5">GLM 5</option>
@@ -149,6 +150,20 @@ export function createChatApp(): Express {
                   <input type="text" id="traceIdInput" placeholder="e.g., session_001" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
               </div>
           </div>
+          <div id="ttsConfigSection" class="hidden mt-4">
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div class="flex flex-col">
+                      <label class="text-sm font-semibold text-gray-900 mb-1" for="ttsVoiceInput">Voice</label>
+                      <input
+                          type="text"
+                          id="ttsVoiceInput"
+                          value="Kore"
+                          placeholder="e.g., Kore"
+                          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      >
+                  </div>
+              </div>
+          </div>
       </div>
 
       <div class="flex-1 overflow-y-auto px-6 py-6" id="messagesContainer">
@@ -186,6 +201,69 @@ export function createChatApp(): Express {
               const d = new Date(ms);
               const pad = n => n.toString().padStart(2, '0');
               return \`\${d.getFullYear()}-\${pad(d.getMonth()+1)}-\${pad(d.getDate())} \${pad(d.getHours())}:\${pad(d.getMinutes())}:\${pad(d.getSeconds())}\`;
+          }
+
+          function pcmBase64ToWavDataUrl(pcmBase64, sampleRate = 24000, channels = 1, bitsPerSample = 16) {
+              const binary = atob(pcmBase64);
+              const pcmBytes = new Uint8Array(binary.length);
+              for (let i = 0; i < binary.length; i++) {
+                  pcmBytes[i] = binary.charCodeAt(i);
+              }
+
+              const header = new ArrayBuffer(44);
+              const view = new DataView(header);
+              const byteRate = sampleRate * channels * bitsPerSample / 8;
+              const blockAlign = channels * bitsPerSample / 8;
+
+              const writeString = (offset, value) => {
+                  for (let i = 0; i < value.length; i++) {
+                      view.setUint8(offset + i, value.charCodeAt(i));
+                  }
+              };
+
+              writeString(0, 'RIFF');
+              view.setUint32(4, 36 + pcmBytes.length, true);
+              writeString(8, 'WAVE');
+              writeString(12, 'fmt ');
+              view.setUint32(16, 16, true);
+              view.setUint16(20, 1, true);
+              view.setUint16(22, channels, true);
+              view.setUint32(24, sampleRate, true);
+              view.setUint32(28, byteRate, true);
+              view.setUint16(32, blockAlign, true);
+              view.setUint16(34, bitsPerSample, true);
+              writeString(36, 'data');
+              view.setUint32(40, pcmBytes.length, true);
+
+              const wavBytes = new Uint8Array(44 + pcmBytes.length);
+              wavBytes.set(new Uint8Array(header), 0);
+              wavBytes.set(pcmBytes, 44);
+
+              let wavBinary = '';
+              const chunkSize = 0x8000;
+              for (let i = 0; i < wavBytes.length; i += chunkSize) {
+                  wavBinary += String.fromCharCode(...wavBytes.subarray(i, i + chunkSize));
+              }
+              return \`data:audio/wav;base64,\${btoa(wavBinary)}\`;
+          }
+
+          function renderInlineData(item) {
+              const mimeType = (item.mime_type || '').toLowerCase();
+              if (mimeType.startsWith('image/')) {
+                  return \`<div class="mb-3"><img src="data:\${mimeType || 'image/png'};base64,\${item.data}" class="max-w-xs rounded border border-gray-300"></div>\`;
+              }
+
+              const audioMimeTypes = ['audio/wav', 'audio/x-wav', 'audio/mpeg', 'audio/mp3', 'audio/ogg', 'audio/webm', 'audio/flac', 'audio/aac', 'audio/mp4'];
+              const isAudio = !mimeType || mimeType === 'application/octet-stream' || mimeType.startsWith('audio/');
+              if (!isAudio) {
+                  return \`<div class="mb-3 rounded border border-gray-300 bg-gray-50 px-3 py-2 text-xs text-gray-600">Inline data: \${escapeHtml(item.mime_type || 'application/octet-stream')}</div>\`;
+              }
+
+              const playableMimeType = audioMimeTypes.includes(mimeType);
+              const audioSrc = playableMimeType
+                  ? \`data:\${mimeType || 'application/octet-stream'};base64,\${item.data}\`
+                  : pcmBase64ToWavDataUrl(item.data);
+              return \`<div class="mb-3"><audio controls preload="metadata" class="max-w-xs"><source src="\${audioSrc}" type="\${playableMimeType ? mimeType : 'audio/wav'}"></audio></div>\`;
           }
 
           function handleImageSelect(event) {
@@ -247,7 +325,13 @@ export function createChatApp(): Express {
               panel.classList.toggle('hidden');
           }
 
+          function updateConditionalConfigVisibility() {
+              const model = document.getElementById('modelSelect').value.trim().toLowerCase();
+              document.getElementById('ttsConfigSection').classList.toggle('hidden', !model.includes('tts'));
+          }
+
           function getConfig() {
+              const selectedModel = document.getElementById('modelSelect').value.trim().toLowerCase();
               const config = {
                   model: document.getElementById('modelSelect').value,
                   temperature: parseFloat(document.getElementById('temperatureInput').value),
@@ -287,6 +371,13 @@ export function createChatApp(): Express {
               const traceId = document.getElementById('traceIdInput').value.trim();
               if (traceId) {
                   config.trace_id = traceId;
+              }
+
+              const voice = document.getElementById('ttsVoiceInput').value.trim();
+              if (selectedModel.includes('tts') && voice) {
+                  config.tts_config = {
+                      speaker_voices: [{ voice: voice }]
+                  };
               }
 
               return config;
@@ -460,10 +551,11 @@ export function createChatApp(): Express {
                                           toolResultDiv.innerHTML = \`<strong class="text-sm">✅ Tool Result:</strong><br><div class="mt-1 text-xs whitespace-pre-wrap">\${escapeHtml(item.text)}</div>\`;
                                           contentDiv.appendChild(toolResultDiv);
                                       } else if (item.type === 'inline_data') {
-                                          const imageDiv = document.createElement('div');
-                                          imageDiv.className = 'mb-3';
-                                          imageDiv.innerHTML = \`<img src="data:\${item.mime_type || 'image/png'};base64,\${item.data}" class="max-w-xs rounded border border-gray-300">\`;
-                                          contentDiv.appendChild(imageDiv);
+                                          const inlineDataDiv = document.createElement('div');
+                                          inlineDataDiv.innerHTML = renderInlineData(item);
+                                          if (inlineDataDiv.firstChild) {
+                                              contentDiv.appendChild(inlineDataDiv.firstChild);
+                                          }
                                       }
                                   }
 
@@ -574,6 +666,10 @@ export function createChatApp(): Express {
               this.style.height = 'auto';
               this.style.height = Math.min(this.scrollHeight, 200) + 'px';
           });
+
+          document.getElementById('modelSelect').addEventListener('input', updateConditionalConfigVisibility);
+          document.getElementById('modelSelect').addEventListener('change', updateConditionalConfigVisibility);
+          updateConditionalConfigVisibility();
       </script>
   </body>
   </html>

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -150,20 +150,6 @@ export function createChatApp(): Express {
                   <input type="text" id="traceIdInput" placeholder="e.g., session_001" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
               </div>
           </div>
-          <div id="ttsConfigSection" class="hidden mt-4">
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  <div class="flex flex-col">
-                      <label class="text-sm font-semibold text-gray-900 mb-1" for="ttsVoiceInput">Voice</label>
-                      <input
-                          type="text"
-                          id="ttsVoiceInput"
-                          value="Kore"
-                          placeholder="e.g., Kore"
-                          class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                      >
-                  </div>
-              </div>
-          </div>
       </div>
 
       <div class="flex-1 overflow-y-auto px-6 py-6" id="messagesContainer">
@@ -325,13 +311,7 @@ export function createChatApp(): Express {
               panel.classList.toggle('hidden');
           }
 
-          function updateConditionalConfigVisibility() {
-              const model = document.getElementById('modelSelect').value.trim().toLowerCase();
-              document.getElementById('ttsConfigSection').classList.toggle('hidden', !model.includes('tts'));
-          }
-
           function getConfig() {
-              const selectedModel = document.getElementById('modelSelect').value.trim().toLowerCase();
               const config = {
                   model: document.getElementById('modelSelect').value,
                   temperature: parseFloat(document.getElementById('temperatureInput').value),
@@ -371,13 +351,6 @@ export function createChatApp(): Express {
               const traceId = document.getElementById('traceIdInput').value.trim();
               if (traceId) {
                   config.trace_id = traceId;
-              }
-
-              const voice = document.getElementById('ttsVoiceInput').value.trim();
-              if (selectedModel.includes('tts') && voice) {
-                  config.tts_config = {
-                      speaker_voices: [{ voice: voice }]
-                  };
               }
 
               return config;
@@ -667,9 +640,6 @@ export function createChatApp(): Express {
               this.style.height = Math.min(this.scrollHeight, 200) + 'px';
           });
 
-          document.getElementById('modelSelect').addEventListener('input', updateConditionalConfigVisibility);
-          document.getElementById('modelSelect').addEventListener('change', updateConditionalConfigVisibility);
-          updateConditionalConfigVisibility();
       </script>
   </body>
   </html>

--- a/src_ts/src/integration/tracer.ts
+++ b/src_ts/src/integration/tracer.ts
@@ -80,6 +80,71 @@ export class Tracer {
   }
 
   /**
+   * Return whether browsers can usually play this MIME type directly.
+   *
+   * @param mimeType - MIME type to inspect
+   * @returns Whether the browser can typically play the audio type
+   */
+  private _isBrowserPlayableAudioMimeType(mimeType?: string): boolean {
+    return new Set([
+      "audio/wav",
+      "audio/x-wav",
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/ogg",
+      "audio/webm",
+      "audio/flac",
+      "audio/aac",
+      "audio/mp4",
+    ]).has((mimeType || "").toLowerCase());
+  }
+
+  /**
+   * Decode an inline_data payload to raw bytes.
+   *
+   * @param item - inline_data content item
+   * @returns Raw payload bytes
+   */
+  private _decodeInlineData(item: { data?: Buffer | string }): Buffer {
+    if (typeof item.data === "string") {
+      return Buffer.from(item.data, "base64");
+    }
+    return item.data || Buffer.alloc(0);
+  }
+
+  /**
+   * Wrap raw PCM bytes in a WAV header using Gemini TTS defaults.
+   *
+   * @param item - inline_data content item
+   * @returns WAV bytes
+   */
+  private _buildWaveBytesFromPcm(item: { data?: Buffer | string }): Buffer {
+    const pcmBytes = this._decodeInlineData(item);
+    const channels = 1;
+    const sampleRate = 24000;
+    const bitsPerSample = 16;
+    const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+    const blockAlign = (channels * bitsPerSample) / 8;
+    const header = Buffer.alloc(44);
+
+    header.write("RIFF", 0, "ascii");
+    header.writeUInt32LE(36 + pcmBytes.length, 4);
+    header.write("WAVE", 8, "ascii");
+    header.write("fmt ", 12, "ascii");
+    header.writeUInt32LE(16, 16);
+    header.writeUInt16LE(1, 20);
+    header.writeUInt16LE(channels, 22);
+    header.writeUInt32LE(sampleRate, 24);
+    header.writeUInt32LE(byteRate, 28);
+    header.writeUInt16LE(blockAlign, 32);
+    header.writeUInt16LE(bitsPerSample, 34);
+    header.write("data", 36, "ascii");
+    header.writeUInt32LE(pcmBytes.length, 40);
+
+    return Buffer.concat([header, pcmBytes]);
+  }
+
+  /**
    * Format inline_data metadata without emitting raw payloads.
    *
    * @param item - inline_data content item
@@ -106,7 +171,13 @@ export class Tracer {
     const mbCount = byteCount / (1024 * 1024);
 
     let label = isThinking ? "Thinking " : "";
-    label += mimeType.startsWith("image/") ? "Inline Image" : "Inline Data";
+    if (mimeType.startsWith("image/")) {
+      label += "Inline Image";
+    } else if (mimeType.startsWith("audio/")) {
+      label += "Inline Audio";
+    } else {
+      label += "Inline Data";
+    }
 
     if (kbCount < 1000) {
       return `${label}: ${mimeType} (${kbCount.toFixed(2)} KB)`;
@@ -125,10 +196,42 @@ export class Tracer {
     data?: Buffer | string;
   }): string {
     const mimeType = item.mime_type || "application/octet-stream";
-    const data = Buffer.isBuffer(item.data)
-      ? item.data.toString("base64")
-      : item.data || "";
-    return `data:${mimeType};base64,${data}`;
+    let rawBytes = this._decodeInlineData(item);
+    let normalizedMimeType = mimeType;
+
+    if (mimeType.startsWith("audio/")) {
+      if (!this._isBrowserPlayableAudioMimeType(mimeType)) {
+        normalizedMimeType = "audio/wav";
+        rawBytes = this._buildWaveBytesFromPcm(item);
+      }
+      return `data:${normalizedMimeType};base64,${rawBytes.toString("base64")}`;
+    }
+
+    return `data:${normalizedMimeType};base64,${rawBytes.toString("base64")}`;
+  }
+
+  /**
+   * Return whether inline_data should be rendered as audio.
+   *
+   * @param item - inline_data content item
+   * @returns Whether the payload is audio
+   */
+  private _inlineDataIsAudio(item: { mime_type?: string }): boolean {
+    return (item.mime_type || "").toLowerCase().startsWith("audio/");
+  }
+
+  /**
+   * Return the browser-facing audio MIME type after any WAV fallback.
+   *
+   * @param item - inline_data content item
+   * @returns Playable audio MIME type
+   */
+  private _inlineDataAudioType(item: { mime_type?: string }): string {
+    const mimeType = item.mime_type || "application/octet-stream";
+    if (this._isBrowserPlayableAudioMimeType(mimeType)) {
+      return mimeType;
+    }
+    return "audio/wav";
   }
 
   /**
@@ -516,6 +619,8 @@ export class Tracer {
                       itemHtml += `<div class="bg-purple-50 border-purple-500 p-4 rounded-md border-l-4"><div class="text-xs text-purple-700 mb-2">${this._escapeHtml(summary)}</div>`;
                       if (item.mime_type?.startsWith("image/")) {
                         itemHtml += `<img src="${this._escapeHtml(this._inlineDataUrl(item))}" class="max-w-xs max-h-48 rounded-md" alt="Inline Image">`;
+                      } else if (this._inlineDataIsAudio(item)) {
+                        itemHtml += `<audio controls preload="metadata" class="max-w-xs"><source src="${this._escapeHtml(this._inlineDataUrl(item))}" type="${this._escapeHtml(this._inlineDataAudioType(item))}"></audio>`;
                       } else {
                         itemHtml += `<div class="font-mono text-sm whitespace-pre-wrap text-gray-800">${this._escapeHtml(summary)}</div>`;
                       }

--- a/src_ts/src/types.ts
+++ b/src_ts/src/types.ts
@@ -168,16 +168,9 @@ export interface ImageConfig {
 /**
  * Speaker and voice assignment for TTS.
  */
-export interface TTSSpeakerConfig {
+export interface SpeakerConfig {
   voice: string;
   speaker?: string;
-}
-
-/**
- * Unified TTS configuration.
- */
-export interface TTSConfig {
-  speaker_voices: TTSSpeakerConfig[];
 }
 
 /**
@@ -193,6 +186,6 @@ export interface UniConfig {
   system_prompt?: string;
   prompt_caching?: PromptCaching;
   image_config?: ImageConfig;
-  tts_config?: TTSConfig;
+  tts_config?: SpeakerConfig[];
   trace_id?: string;
 }

--- a/src_ts/src/types.ts
+++ b/src_ts/src/types.ts
@@ -166,6 +166,21 @@ export interface ImageConfig {
 }
 
 /**
+ * Speaker and voice assignment for TTS.
+ */
+export interface TTSSpeakerConfig {
+  voice: string;
+  speaker?: string;
+}
+
+/**
+ * Unified TTS configuration.
+ */
+export interface TTSConfig {
+  speaker_voices: TTSSpeakerConfig[];
+}
+
+/**
  * Universal configuration format for LLM requests.
  */
 export interface UniConfig {
@@ -178,5 +193,6 @@ export interface UniConfig {
   system_prompt?: string;
   prompt_caching?: PromptCaching;
   image_config?: ImageConfig;
+  tts_config?: TTSConfig;
   trace_id?: string;
 }

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -844,9 +844,7 @@ if (AVAILABLE_MODELS.length > 0) {
 
       const client = createClient(model);
       const config: UniConfig = {
-        tts_config: {
-          speaker_voices: [{ voice: "Kore" }],
-        },
+        tts_config: [{ voice: "Kore" }],
       };
       const messages: UniMessage[] = [
         {

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -25,6 +25,7 @@ interface Model {
   supportTemperature: boolean;
   supportImageUnderstanding: boolean;
   supportImageGeneration: boolean;
+  supportAudioGeneration: boolean;
   provider: "official" | "siliconflow" | "openrouter" | "bedrock" | "vertex";
 }
 
@@ -37,6 +38,7 @@ if (process.env.GEMINI_API_KEY) {
     supportTemperature: true,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "official",
   });
 
@@ -46,6 +48,17 @@ if (process.env.GEMINI_API_KEY) {
     supportTemperature: false,
     supportImageUnderstanding: false,
     supportImageGeneration: true,
+    supportAudioGeneration: false,
+    provider: "official",
+  });
+
+  AVAILABLE_MODELS.push({
+    name: "gemini-3.1-flash-tts-preview",
+    supportTextGeneration: false,
+    supportTemperature: true,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: true,
     provider: "official",
   });
 }
@@ -57,6 +70,7 @@ if (process.env.ANTHROPIC_API_KEY) {
     supportTemperature: true,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "official",
   });
 }
@@ -68,6 +82,7 @@ if (process.env.OPENAI_API_KEY) {
     supportTemperature: false,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "official",
   });
 }
@@ -79,6 +94,7 @@ if (process.env.ZAI_API_KEY) {
     supportTemperature: true,
     supportImageUnderstanding: false,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "official",
   });
 }
@@ -90,6 +106,7 @@ if (process.env.MOONSHOT_API_KEY) {
     supportTemperature: false,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "official",
   });
 }
@@ -103,6 +120,7 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: true,
     supportImageUnderstanding: false,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -111,6 +129,7 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: true,
     supportImageUnderstanding: false,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -119,6 +138,7 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: false,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "openrouter",
   });
 }
@@ -130,6 +150,7 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: true,
     supportImageUnderstanding: false,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "siliconflow",
   });
   AVAILABLE_MODELS.push({
@@ -138,6 +159,7 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: true,
     supportImageUnderstanding: false,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "siliconflow",
   });
   AVAILABLE_MODELS.push({
@@ -146,6 +168,7 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportTemperature: false,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "siliconflow",
   });
 }
@@ -157,6 +180,7 @@ if (process.env.BEDROCK_API_KEY) {
     supportTemperature: true,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "bedrock",
   });
 }
@@ -168,6 +192,7 @@ if (process.env.VERTEX_API_KEY) {
     supportTemperature: true,
     supportImageUnderstanding: true,
     supportImageGeneration: false,
+    supportAudioGeneration: false,
     provider: "vertex",
   });
 
@@ -177,6 +202,17 @@ if (process.env.VERTEX_API_KEY) {
     supportTemperature: false,
     supportImageUnderstanding: false,
     supportImageGeneration: true,
+    supportAudioGeneration: false,
+    provider: "vertex",
+  });
+
+  AVAILABLE_MODELS.push({
+    name: "gemini-3.1-flash-tts-preview",
+    supportTextGeneration: false,
+    supportTemperature: true,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: true,
     provider: "vertex",
   });
 }
@@ -426,6 +462,10 @@ if (AVAILABLE_MODELS.length > 0) {
     });
 
     test("should concatenate events to message", async () => {
+      if (!model.supportTextGeneration) {
+        return;
+      }
+
       const client = createClient(model);
       const messages: UniMessage[] = [
         {
@@ -793,6 +833,53 @@ if (AVAILABLE_MODELS.length > 0) {
       expect(inlineItems.length).toBeGreaterThan(0);
       expect(
         inlineItems.some((item) => item.mime_type.startsWith("image/")),
+      ).toBe(true);
+      expect(inlineItems.every((item) => item.data.length > 0)).toBe(true);
+    }, 180000);
+
+    test("should handle tts generation", async () => {
+      if (!model.supportAudioGeneration) {
+        return;
+      }
+
+      const client = createClient(model);
+      const config: UniConfig = {
+        tts_config: {
+          speaker_voices: [{ voice: "Kore" }],
+        },
+      };
+      const messages: UniMessage[] = [
+        {
+          role: "user",
+          content_items: [
+            {
+              type: "text",
+              text: "Say cheerfully: Have a wonderful day!",
+            },
+          ],
+        },
+      ];
+
+      const inlineItems: { data: Buffer; mime_type: string }[] = [];
+      for await (const event of client.streamingResponse({
+        messages,
+        config,
+      })) {
+        checkEventIntegrity(event);
+        for (const item of event.content_items) {
+          if (item.type === "inline_data") {
+            inlineItems.push(item);
+          }
+        }
+      }
+
+      expect(inlineItems.length).toBeGreaterThan(0);
+      expect(
+        inlineItems.some(
+          (item) =>
+            item.mime_type.startsWith("audio/") ||
+            item.mime_type === "application/octet-stream",
+        ),
       ).toBe(true);
       expect(inlineItems.every((item) => item.data.length > 0)).toBe(true);
     }, 180000);

--- a/src_ts/tests/tracer.test.ts
+++ b/src_ts/tests/tracer.test.ts
@@ -233,4 +233,36 @@ describe("Tracer", () => {
     expect(txtContent).toContain("get_weather");
     expect(txtContent).toContain("parameters");
   });
+
+  test("should format audio inline data in history export", () => {
+    const tracer = new Tracer(tempCacheDir);
+
+    const model = "fake-model";
+    const history: UniMessage[] = [
+      {
+        role: "user",
+        content_items: [{ type: "text", text: "Hello" }],
+      },
+      {
+        role: "assistant",
+        content_items: [
+          {
+            type: "inline_data",
+            data: Buffer.from([0x00, 0x01, 0x02, 0x03]),
+            mime_type: "audio/pcm",
+          },
+        ],
+      },
+    ];
+
+    const fileId = "test/audio_inline_data";
+    const config = {};
+
+    tracer.saveHistory(model, history, fileId, config);
+
+    const txtPath = path.join(tempCacheDir, fileId + ".txt");
+    const txtContent = fs.readFileSync(txtPath, "utf-8");
+
+    expect(txtContent).toContain("Inline Audio: audio/pcm");
+  });
 });


### PR DESCRIPTION
﻿## Summary

Add Gemini TTS support across the Python and TypeScript clients, including playground/tracer integration, a Python example, and targeted tests.

## Changes

- add shared `tts_config` support
- map Gemini TTS requests to audio output
- support single-speaker and two-speaker voices
- render returned audio in playground and tracer
- add example and targeted test coverage

## Validation

Not run as part of this PR preparation step.
