### PR TITLE
Add DeepSeek V4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ https://github.com/user-attachments/assets/c49a21a1-5bf9-4768-a76d-f73c9a03ca87
 | Kimi-K2.5      | Official/OpenRouter/SiliconFlow     | :white_check_mark: | :white_check_mark: | :white_check_mark:  | :x:                | :x:                |
 | GLM-5          | Official/OpenRouter/SiliconFlow     | :white_check_mark: | :white_check_mark: | :x:                 | :x:                | :x:                |
 | Qwen3          | OpenRouter/SiliconFlow/vLLM         | :white_check_mark: | :white_check_mark: | :x:                 | :x:                | :x:                |
+| DeepSeek V4 Pro/Flash | Official                     | :white_check_mark: | :white_check_mark: | :x:                 | :x:                | :x:                |
 
 ## Installation
 

--- a/llmsdk_docs/README.md
+++ b/llmsdk_docs/README.md
@@ -7,12 +7,12 @@ This directory contains documentation and examples for all supported AI model SD
 To use a specific model, please refer to its dedicated README:
 
 - **[Claude 4.6](./claude4_6/README.md)** - Anthropic's Claude 4.6 API documentation and examples
+- **[DeepSeek](./deepseek/README.md)** - DeepSeek API documentation and OpenAI-compatible usage guides
 - **[Gemini 3](./gemini3/README.md)** - Google's Gemini 3 API documentation and examples
 - **[GLM-5](./glm5/README.md)** - Z.AI's GLM-5 API documentation and examples
 - **[GPT-5.5](./gpt5_5/README.md)** - OpenAI's GPT-5.5 API documentation and examples
 
 Each model directory contains:
 - `docs/` - Detailed documentation for the model's features and capabilities
-- `examples/` - Code examples demonstrating usage (Python and TypeScript)
-- `quickstart.python.md` - Python-specific usage guide
-- `quickstart.typescript.md` - TypeScript-specific usage guide
+- `examples/` - Code examples demonstrating usage, when available
+- `quickstart*.md` - Quickstart usage guide

--- a/llmsdk_docs/deepseek/README.md
+++ b/llmsdk_docs/deepseek/README.md
@@ -14,6 +14,7 @@ The `docs/` folder contains focused guides for DeepSeek API features:
 - [multi-round-chat.md](./docs/multi-round-chat.md) - Stateless multi-turn conversation history
 - [json-mode.md](./docs/json-mode.md) - Structured JSON output
 - [tool-calls.md](./docs/tool-calls.md) - Tool calling, thinking-mode tool calls, and strict mode
+- [kv-cache.md](./docs/kv-cache.md) - Default context caching, hit rules, and usage counters
 
 ## Notes
 

--- a/llmsdk_docs/deepseek/README.md
+++ b/llmsdk_docs/deepseek/README.md
@@ -6,6 +6,10 @@ This directory contains documentation for using the DeepSeek API with OpenAI-com
 
 - [quickstart.md](./quickstart.md) - First API call with curl, Python, and Node.js
 
+## API Reference
+
+- [create-chat-completion.md](./docs/create-chat-completion.md) - Chat Completion request body fields and streaming response chunks
+
 ## Documentation
 
 The `docs/` folder contains focused guides for DeepSeek API features:
@@ -15,6 +19,7 @@ The `docs/` folder contains focused guides for DeepSeek API features:
 - [json-mode.md](./docs/json-mode.md) - Structured JSON output
 - [tool-calls.md](./docs/tool-calls.md) - Tool calling, thinking-mode tool calls, and strict mode
 - [kv-cache.md](./docs/kv-cache.md) - Default context caching, hit rules, and usage counters
+- [chat_completion_api.md](./docs/deepseek-chat_completion_api.md) - DeepSeek Chat Completion API reference
 
 ## Notes
 

--- a/llmsdk_docs/deepseek/README.md
+++ b/llmsdk_docs/deepseek/README.md
@@ -1,0 +1,20 @@
+# DeepSeek SDK Documentation
+
+This directory contains documentation for using the DeepSeek API with OpenAI-compatible SDK patterns.
+
+## Quick Start
+
+- [quickstart.md](./quickstart.md) - First API call with curl, Python, and Node.js
+
+## Documentation
+
+The `docs/` folder contains focused guides for DeepSeek API features:
+
+- [thinking-mode.md](./docs/thinking-mode.md) - Thinking mode, reasoning content, effort control, and tool-call context rules
+- [multi-round-chat.md](./docs/multi-round-chat.md) - Stateless multi-turn conversation history
+- [json-mode.md](./docs/json-mode.md) - Structured JSON output
+- [tool-calls.md](./docs/tool-calls.md) - Tool calling, thinking-mode tool calls, and strict mode
+
+## Notes
+
+DeepSeek supports OpenAI-compatible and Anthropic-compatible API formats. The examples in this folder focus on the OpenAI-compatible path because it matches the existing SDK documentation style in this repository.

--- a/llmsdk_docs/deepseek/docs/chat_completion_api.md
+++ b/llmsdk_docs/deepseek/docs/chat_completion_api.md
@@ -1,0 +1,267 @@
+# Create Chat Completion
+
+```
+POST https://api.deepseek.com/chat/completions
+```
+
+Creates a model response for the given chat conversation.
+
+---
+
+## Request
+
+- **Content-Type**: `application/json`
+
+### Body
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `messages` | `object[]` | **Yes** | No | A list of messages comprising the conversation so far. Minimum 1 item. |
+| `model` | `string` | **Yes** | No | ID of the model to use. Possible values: `deepseek-v4-flash`, `deepseek-v4-pro`. |
+| `thinking` | `object` | No | Yes | Controls the switch between thinking and non-thinking mode. |
+| `thinking.type` | `string` | No | No | Possible values: `enabled`, `disabled`. Default: `enabled`. If set to `enabled`, then use thinking mode. If set to `disabled`, then use non-thinking mode. |
+| `thinking.reasoning_effort` | `string` | No | No | Possible values: `high`, `max`. Controls the reasoning effort of the model. The default effort is `high` for regular requests; for some complex agent requests (such as Claude Code, OpenCode), effort is automatically set to `max`. For compatibility, `low` and `medium` are mapped to `high`, and `xhigh` is mapped to `max`. |
+| `max_tokens` | `integer` | No | Yes | The maximum number of tokens that can be generated in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. |
+| `response_format` | `object` | No | Yes | An object specifying the format that the model must output. Setting to `{ "type": "json_object" }` enables JSON Output, which guarantees the message the model generates is valid JSON. **Important:** When using JSON Output, you must also instruct the model to produce JSON yourself via a system or user message. Without this, the model may generate an unending stream of whitespace until the generation reaches the token limit, resulting in a long-running and seemingly "stuck" request. Also note that the message content may be partially cut off if `finish_reason="length"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length. |
+| `response_format.type` | `string` | No | No | Possible values: `text`, `json_object`. Default: `text`. |
+| `stop` | `string` or `string[]` | No | Yes | Up to 16 sequences where the API will stop generating further tokens. |
+| `stream` | `boolean` | No | Yes | If set, partial message deltas will be sent. Tokens will be sent as data-only server-sent events (SSE) as they become available, with the stream terminated by a `data: [DONE]` message. |
+| `stream_options` | `object` | No | Yes | Options for streaming response. Only set this when you set `stream: true`. |
+| `stream_options.include_usage` | `boolean` | No | No | If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value. |
+| `temperature` | `number` | No | Yes | What sampling temperature to use, between 0 and 2. Default: `1`. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or `top_p` but not both. |
+| `top_p` | `number` | No | Yes | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. Default: `1`. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or `temperature` but not both. |
+| `tools` | `object[]` | No | Yes | A list of tools the model may call. Currently, only functions are supported as a tool. A max of 128 functions are supported. |
+| `tools[].type` | `string` | **Yes** | No | The type of the tool. Currently, only `function` is supported. |
+| `tools[].function` | `object` | **Yes** | No | The function definition. |
+| `tools[].function.description` | `string` | No | No | A description of what the function does, used by the model to choose when and how to call the function. |
+| `tools[].function.name` | `string` | **Yes** | No | The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64. |
+| `tools[].function.parameters` | `object` | No | No | The parameters the functions accepts, described as a JSON Schema object. Omitting `parameters` defines a function with an empty parameter list. |
+| `tools[].function.strict` | `boolean` | No | No | Default: `false`. If set to true, the API will use strict-mode for the tool calls to ensure the output always complies with the function's JSON schema. This is a Beta feature. |
+| `tool_choice` | `string` or `object` | No | Yes | Controls which (if any) tool is called by the model. `none` means the model will not call any tool and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools. `required` means the model must call one or more tools. Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool. `none` is the default when no tools are present. `auto` is the default if tools are present. |
+| `tool_choice.type` | `string` | **Yes** | No | Possible values: `function`. The type of the tool. |
+| `tool_choice.function` | `object` | **Yes** | No | The function specification. |
+| `tool_choice.function.name` | `string` | **Yes** | No | The name of the function to call. |
+| `logprobs` | `boolean` | No | Yes | Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the `content` of `message`. |
+| `top_logprobs` | `integer` | No | Yes | An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used. |
+| `user_id` | `string` | No | Yes | A custom user_id. Allowed character set is [a-zA-Z0-9\-_], with a maximum length of 512. Do not include user privacy information in the user_id. user_id can be used to distinguish user identities on your side to help us with content safety review. user_id can be used for KVCache isolation for privacy management. |
+| `frequency_penalty` | - | No | No | **Deprecated.** This parameter is no longer supported. It will not take effect if you pass it to the API. |
+| `presence_penalty` | - | No | No | **Deprecated.** This parameter is no longer supported. It will not take effect if you pass it to the API. |
+
+### `messages` Item Types
+
+Each item in the `messages` array is one of the following message types:
+
+#### System Message
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `content` | `string` | **Yes** | No | The contents of the system message. |
+| `role` | `string` | **Yes** | No | The role of the messages author, in this case `system`. |
+| `name` | `string` | No | No | An optional name for the participant. Provides the model information to differentiate between participants of the same role. |
+
+#### User Message
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `content` | `string` | **Yes** | No | The contents of the user message. |
+| `role` | `string` | **Yes** | No | The role of the messages author, in this case `user`. |
+| `name` | `string` | No | No | An optional name for the participant. Provides the model information to differentiate between participants of the same role. |
+
+#### Assistant Message
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `content` | `string` or `null` | **Yes** | Yes | The contents of the assistant message. |
+| `role` | `string` | **Yes** | No | The role of the messages author, in this case `assistant`. |
+| `name` | `string` | No | No | An optional name for the participant. Provides the model information to differentiate between participants of the same role. |
+| `prefix` | `boolean` | No | No | (Beta) Set this to `true` to force the model to start its answer by the content of the supplied prefix in this `assistant` message. You must set `base_url="https://api.deepseek.com/beta"` to use this feature. |
+| `reasoning_content` | `string` or `null` | No | Yes | (Beta) Used for the thinking mode in the Chat Prefix Completion feature as the input for the CoT in the last assistant message. When using this feature, the `prefix` parameter must be set to `true`. |
+
+#### Tool Message
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `content` | `string` | **Yes** | No | The contents of the tool message. |
+| `role` | `string` | **Yes** | No | The role of the messages author, in this case `tool`. |
+| `tool_call_id` | `string` | **Yes** | No | Tool call that this message is responding to. |
+
+### Example Request Body
+
+```json
+{
+  "messages": [
+    {
+      "content": "You are a helpful assistant",
+      "role": "system"
+    },
+    {
+      "content": "Hi",
+      "role": "user"
+    }
+  ],
+  "model": "deepseek-v4-pro",
+  "thinking": {
+    "type": "enabled"
+  },
+  "reasoning_effort": "high",
+  "max_tokens": 4096,
+  "response_format": {
+    "type": "text"
+  },
+  "stop": null,
+  "stream": false,
+  "stream_options": null,
+  "temperature": 1,
+  "top_p": 1,
+  "tools": null,
+  "tool_choice": "none",
+  "logprobs": false,
+  "top_logprobs": null
+}
+```
+
+---
+
+## Responses
+
+### 200 — No Streaming
+
+OK, returns a `chat completion object`.
+
+- **Content-Type**: `application/json`
+
+#### Schema
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `id` | `string` | **Yes** | No | A unique identifier for the chat completion. |
+| `choices` | `object[]` | **Yes** | No | A list of chat completion choices. |
+| `choices[].finish_reason` | `string` | **Yes** | No | The reason the model stopped generating tokens. Possible values: `stop`, `length`, `content_filter`, `tool_calls`, `insufficient_system_resource`. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, `tool_calls` if the model called a tool, or `insufficient_system_resource` if the request is interrupted due to insufficient resource of the inference system. |
+| `choices[].index` | `integer` | **Yes** | No | The index of the choice in the list of choices. |
+| `choices[].message` | `object` | **Yes** | No | A chat completion message generated by the model. |
+| `choices[].message.content` | `string` or `null` | **Yes** | Yes | The contents of the message. |
+| `choices[].message.reasoning_content` | `string` or `null` | No | Yes | For thinking mode only. The reasoning contents of the assistant message, before the final answer. |
+| `choices[].message.tool_calls` | `object[]` | No | No | The tool calls generated by the model. |
+| `choices[].message.tool_calls[].id` | `string` | **Yes** | No | The ID of the tool call. |
+| `choices[].message.tool_calls[].type` | `string` | **Yes** | No | The type of the tool. Currently, only `function` is supported. |
+| `choices[].message.tool_calls[].function` | `object` | **Yes** | No | The function that the model called. |
+| `choices[].message.tool_calls[].function.name` | `string` | **Yes** | No | The name of the function to call. |
+| `choices[].message.tool_calls[].function.arguments` | `string` | **Yes** | No | The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function. |
+| `choices[].message.role` | `string` | **Yes** | No | The role of the author of this message. Value: `assistant`. |
+| `choices[].logprobs` | `object` or `null` | **Yes** | Yes | Log probability information for the choice. |
+| `choices[].logprobs.content` | `object[]` or `null` | **Yes** | Yes | A list of message content tokens with log probability information. |
+| `choices[].logprobs.content[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.content[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.content[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.content[].top_logprobs` | `object[]` | **Yes** | No | List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned. |
+| `choices[].logprobs.content[].top_logprobs[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.content[].top_logprobs[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.content[].top_logprobs[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.reasoning_content` | `object[]` or `null` | No | Yes | A list of reasoning content tokens with log probability information. |
+| `choices[].logprobs.reasoning_content[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.reasoning_content[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.reasoning_content[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.reasoning_content[].top_logprobs` | `object[]` | **Yes** | No | List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `created` | `integer` | **Yes** | No | The Unix timestamp (in seconds) of when the chat completion was created. |
+| `model` | `string` | **Yes** | No | The model used for the chat completion. |
+| `system_fingerprint` | `string` | **Yes** | No | This fingerprint represents the backend configuration that the model runs with. |
+| `object` | `string` | **Yes** | No | The object type, which is always `chat.completion`. |
+| `usage` | `object` | No | No | Usage statistics for the completion request. |
+| `usage.completion_tokens` | `integer` | **Yes** | No | Number of tokens in the generated completion. |
+| `usage.prompt_tokens` | `integer` | **Yes** | No | Number of tokens in the prompt. It equals `prompt_cache_hit_tokens` + `prompt_cache_miss_tokens`. |
+| `usage.prompt_cache_hit_tokens` | `integer` | **Yes** | No | Number of tokens in the prompt that hits the context cache. |
+| `usage.prompt_cache_miss_tokens` | `integer` | **Yes** | No | Number of tokens in the prompt that misses the context cache. |
+| `usage.total_tokens` | `integer` | **Yes** | No | Total number of tokens used in the request (prompt + completion). |
+| `usage.completion_tokens_details` | `object` | No | No | Breakdown of tokens used in a completion. |
+| `usage.completion_tokens_details.reasoning_tokens` | `integer` | No | No | Tokens generated by the model for reasoning. |
+
+#### Example Response
+
+```json
+{
+  "id": "930c60df-bf64-41c9-a88e-3ec75f81e00e",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "Hello! How can I help you today?",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1705651092,
+  "model": "deepseek-v4-pro",
+  "object": "chat.completion",
+  "usage": {
+    "completion_tokens": 10,
+    "prompt_tokens": 16,
+    "total_tokens": 26
+  }
+}
+```
+
+---
+
+### 200 — Streaming
+
+OK, returns a streamed sequence of `chat completion chunk` objects.
+
+- **Content-Type**: `text/event-stream`
+
+#### Schema
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| `id` | `string` | **Yes** | No | A unique identifier for the chat completion. Each chunk has the same ID. |
+| `choices` | `object[]` | **Yes** | No | A list of chat completion choices. |
+| `choices[].delta` | `object` | **Yes** | No | A chat completion delta generated by streamed model responses. |
+| `choices[].delta.content` | `string` or `null` | No | Yes | The contents of the chunk message. |
+| `choices[].delta.reasoning_content` | `string` or `null` | No | Yes | For thinking mode only. The reasoning contents of the assistant message, before the final answer. |
+| `choices[].delta.role` | `string` | No | No | The role of the author of this message. Value: `assistant`. |
+| `choices[].logprobs` | `object` or `null` | No | Yes | Log probability information for the choice. |
+| `choices[].logprobs.content` | `object[]` or `null` | **Yes** | Yes | A list of message content tokens with log probability information. |
+| `choices[].logprobs.content[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.content[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.content[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.content[].top_logprobs` | `object[]` | **Yes** | No | List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned. |
+| `choices[].logprobs.content[].top_logprobs[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.content[].top_logprobs[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.content[].top_logprobs[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.reasoning_content` | `object[]` or `null` | No | Yes | A list of reasoning content tokens with log probability information. |
+| `choices[].logprobs.reasoning_content[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.reasoning_content[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.reasoning_content[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].logprobs.reasoning_content[].top_logprobs` | `object[]` | **Yes** | No | List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].token` | `string` | **Yes** | No | The token. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].logprob` | `number` | **Yes** | No | The log probability of this token, if it is within the top 20 most likely tokens. Otherwise, the value `-9999.0` is used to signify that the token is very unlikely. |
+| `choices[].logprobs.reasoning_content[].top_logprobs[].bytes` | `integer[]` or `null` | **Yes** | Yes | A list of integers representing the UTF-8 bytes representation of the token. Useful in instances where characters are represented by multiple tokens and their byte representations must be combined to generate the correct text representation. Can be `null` if there is no bytes representation for the token. |
+| `choices[].finish_reason` | `string` or `null` | **Yes** | Yes | The reason the model stopped generating tokens. Possible values: `stop`, `length`, `content_filter`, `tool_calls`, `insufficient_system_resource`. |
+| `choices[].index` | `integer` | **Yes** | No | The index of the choice in the list of choices. |
+| `created` | `integer` | **Yes** | No | The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp. |
+| `model` | `string` | **Yes** | No | The model to generate the completion. |
+| `system_fingerprint` | `string` | **Yes** | No | This fingerprint represents the backend configuration that the model runs with. |
+| `object` | `string` | **Yes** | No | The object type, which is always `chat.completion.chunk`. |
+
+#### Example Response
+
+```
+data: {"id": "1f633d8bfc032625086f14113c411638", "choices": [{"index": 0, "delta": {"content": "", "role": "assistant"}, "finish_reason": null, "logprobs": null}], "created": 1718345013, "model": "deepseek-v4-pro", "system_fingerprint": "fp_a49d71b8a1", "object": "chat.completion.chunk", "usage": null}
+
+data: {"choices": [{"delta": {"content": "Hello", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: {"choices": [{"delta": {"content": "!", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: {"choices": [{"delta": {"content": " How", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: {"choices": [{"delta": {"content": " can", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: {"choices": [{"delta": {"content": " I", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: {"choices": [{"delta": {"content": " assist", "role": "assistant"}, "finish_reason": null, "index": 0, "logprobs": null}], "created": 1718345013, "id": "1f633d8bfc032625086f14113c411638", "model": "deepseek-v4-pro", "object": "chat.completion.chunk", "system_fingerprint": "fp_a49d71b8a1"}
+
+data: [DONE]
+```

--- a/llmsdk_docs/deepseek/docs/json-mode.md
+++ b/llmsdk_docs/deepseek/docs/json-mode.md
@@ -1,19 +1,21 @@
-# JSON Mode
+# JSON Output
 
-JSON mode asks DeepSeek to return valid JSON strings for structured output use cases.
+In many scenarios, users need the model to output in strict JSON format to achieve structured output, facilitating subsequent parsing.
 
-## Requirements
+DeepSeek provides JSON Output to ensure the model outputs valid JSON strings.
 
-To enable JSON output:
+## Notice
 
-1. Set `response_format` to `{"type": "json_object"}`.
-2. Include the word `json` in the system or user prompt.
-3. Provide an example of the desired JSON shape in the prompt.
-4. Set `max_tokens` high enough to avoid truncating the JSON response.
+To enable JSON Output, users should:
 
-The API may occasionally return empty content in JSON mode. If that happens, adjust the prompt and retry.
+1. Set the `response_format` parameter to `{'type': 'json_object'}`.
+2. Include the word "json" in the system or user prompt, and provide an example of the desired JSON format to guide the model in outputting valid JSON.
+3. Set the `max_tokens` parameter reasonably to prevent the JSON string from being truncated midway.
+4. When using the JSON Output feature, the API may occasionally return empty content. We are actively working on optimizing this issue. You can try modifying the prompt to mitigate such problems.
 
 ## Sample Code
+
+Here is the complete Python code demonstrating the use of JSON Output:
 
 ```python
 import json
@@ -38,25 +40,24 @@ EXAMPLE JSON OUTPUT:
 
 user_prompt = "Which is the longest river in the world? The Nile River."
 
-messages = [
-    {"role": "system", "content": system_prompt},
-    {"role": "user", "content": user_prompt},
-]
-
+messages = [{"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}]
 response = client.chat.completions.create(
     model="deepseek-v4-pro",
     messages=messages,
-    response_format={"type": "json_object"},
+    response_format={
+        'type': 'json_object'
+    }
 )
 
 print(json.loads(response.choices[0].message.content))
 ```
 
-Expected output:
+The model will output:
 
 ```json
 {
-  "question": "Which is the longest river in the world?",
-  "answer": "The Nile River"
+    "question": "Which is the longest river in the world?",
+    "answer": "The Nile River"
 }
 ```

--- a/llmsdk_docs/deepseek/docs/json-mode.md
+++ b/llmsdk_docs/deepseek/docs/json-mode.md
@@ -1,0 +1,62 @@
+# JSON Mode
+
+JSON mode asks DeepSeek to return valid JSON strings for structured output use cases.
+
+## Requirements
+
+To enable JSON output:
+
+1. Set `response_format` to `{"type": "json_object"}`.
+2. Include the word `json` in the system or user prompt.
+3. Provide an example of the desired JSON shape in the prompt.
+4. Set `max_tokens` high enough to avoid truncating the JSON response.
+
+The API may occasionally return empty content in JSON mode. If that happens, adjust the prompt and retry.
+
+## Sample Code
+
+```python
+import json
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="<your api key>",
+    base_url="https://api.deepseek.com",
+)
+
+system_prompt = """
+The user will provide some exam text. Please parse the "question" and "answer" and output them in JSON format.
+
+EXAMPLE INPUT:
+Which is the highest mountain in the world? Mount Everest.
+EXAMPLE JSON OUTPUT:
+{
+    "question": "Which is the highest mountain in the world?",
+    "answer": "Mount Everest"
+}
+"""
+
+user_prompt = "Which is the longest river in the world? The Nile River."
+
+messages = [
+    {"role": "system", "content": system_prompt},
+    {"role": "user", "content": user_prompt},
+]
+
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    response_format={"type": "json_object"},
+)
+
+print(json.loads(response.choices[0].message.content))
+```
+
+Expected output:
+
+```json
+{
+  "question": "Which is the longest river in the world?",
+  "answer": "The Nile River"
+}
+```

--- a/llmsdk_docs/deepseek/docs/kv-cache.md
+++ b/llmsdk_docs/deepseek/docs/kv-cache.md
@@ -1,132 +1,94 @@
 # Context Caching
 
-DeepSeek enables disk-based context caching by default for all users. No code changes are required to benefit from it.
+The DeepSeek API Context Caching on Disk Technology is enabled by default for all users, allowing them to benefit without needing to modify their code.
 
-Each request can build cache prefix units on disk. Later requests with matching prefixes can reuse the cached prefix, which is counted as a cache hit.
+Each user request will trigger the construction of a hard disk cache. If subsequent requests have overlapping prefixes with previous requests, the overlapping part will only be fetched from the cache, which counts as a "cache hit."
 
 ## Cache Persistence and Hit Rules
 
-A request can hit the cache only when its prefix fully matches a persisted cache prefix unit. With Sliding Window Attention, each cached prefix is an independent complete unit; partial matches against an existing unit do not count as hits.
+A cache hit requires that the corresponding prefix has already been "persisted" (written to the disk cache). Due to the Sliding Window Attention mechanism, the storage and matching of cached prefixes differs from before. Each cached prefix is an independent, complete unit. A subsequent request can only hit the cache if it fully matches a cache prefix unit.
 
-DeepSeek persists cache prefix units in three ways:
+### When cache prefixes are persisted:
 
-1. Request-boundary persistence: each request can persist prefix units at the end of the user input and at the end of the model output.
-2. Common-prefix detection: when multiple requests share a common prefix, DeepSeek can persist that common prefix as its own cache prefix unit.
-3. Fixed token intervals: for long inputs or outputs, DeepSeek can create cache prefix units at fixed token intervals so long prefixes can still become cacheable.
+1. Persistence at request boundaries: Each request will produce two cache prefix units at the end position of the user input and the end position of the model output. A subsequent request can hit the cache if it fully matches them.
+2. Common prefix detection persistence: When the system detects a common prefix across multiple requests, it will persist that common prefix as an independent cache prefix unit. A subsequent request can hit the cache if it fully reuses that cache prefix unit.
+3. Persistence at fixed token intervals: For long inputs or long outputs, the system will carve out cache prefix units at fixed token intervals, to avoid long prefixes from being completely uncacheable due to never reaching an end position.
 
-## Example: Multi-round Conversation
+Example 1: A user's first-round request is `A + B`, and the second-round request is `A + B + C`. The second request can fully match the cache prefix unit `A + B`, hitting the cache for `A + B`. See Example 1 below.
 
-First request:
+Example 2: A user's first-round request is `A + B`, and the second-round request is `A + C`. The second request cannot hit the cache, because `A + C` does not fully match the first round's cache prefix unit (`A + B`). However, at this point the system will detect that the two requests share a common prefix `A`, and persist `A` as a cache prefix unit. When a third-round request `A + D` arrives, it can fully match the cache prefix unit `A`, hitting the cache for `A`. See Example 2 below.
 
-```json
-[
-  {
-    "role": "system",
-    "content": "You are a helpful assistant"
-  },
-  {
-    "role": "user",
-    "content": "What is the capital of China?"
-  }
+---
+
+### Example 1: Multi-round Conversation
+
+First Request
+
+```text
+messages: [
+    {"role": "system", "content": "You are a helpful assistant"},
+    {"role": "user", "content": "What is the capital of China?"}
 ]
 ```
 
-Second request:
+Second Request
 
-```json
-[
-  {
-    "role": "system",
-    "content": "You are a helpful assistant"
-  },
-  {
-    "role": "user",
-    "content": "What is the capital of China?"
-  },
-  {
-    "role": "assistant",
-    "content": "The capital of China is Beijing."
-  },
-  {
-    "role": "user",
-    "content": "What is the capital of the United States?"
-  }
+```text
+messages: [
+    {"role": "system", "content": "You are a helpful assistant"},
+    {"role": "user", "content": "What is the capital of China?"},
+    {"role": "assistant", "content": "The capital of China is Beijing."},
+    {"role": "user", "content": "What is the capital of the United States?"}
 ]
 ```
 
-The second request fully reuses the first request as a prefix, so that prefix can count as a cache hit.
+In this example, the second request can fully reuse the cache prefix unit from the first request, which will count as a "cache hit."
 
-## Example: Long Text Q&A
+### Example 2: Long Text Q&A
 
-First request:
+First Request
 
-```json
-[
-  {
-    "role": "system",
-    "content": "You are an experienced financial report analyst..."
-  },
-  {
-    "role": "user",
-    "content": "<financial report content>\n\nPlease summarize the key information of this financial report."
-  }
+```text
+messages: [
+    {"role": "system", "content": "You are an experienced financial report analyst..."}
+    {"role": "user", "content": "<financial report content>\n\nPlease summarize the key information of this financial report."}
 ]
 ```
 
-Second request:
+Second Request
 
-```json
-[
-  {
-    "role": "system",
-    "content": "You are an experienced financial report analyst..."
-  },
-  {
-    "role": "user",
-    "content": "<financial report content>\n\nPlease analyze the profitability of this financial report."
-  }
+```text
+messages: [
+    {"role": "system", "content": "You are an experienced financial report analyst..."}
+    {"role": "user", "content": "<financial report content>\n\nPlease analyze the profitability of this financial report."}
 ]
 ```
 
-Third request:
+Third Request
 
-```json
-[
-  {
-    "role": "system",
-    "content": "You are an experienced financial report analyst..."
-  },
-  {
-    "role": "user",
-    "content": "<financial report content>\n\nPlease analyze the ratio of the company's revenue to expenses."
-  }
+```text
+messages: [
+    {"role": "system", "content": "You are an experienced financial report analyst..."}
+    {"role": "user", "content": "<financial report content>\n\nPlease analyze the ratio of the company's revenue to expenses."}
 ]
 ```
 
-The first two requests do not hit the cache because their full prefixes differ. After both requests complete, DeepSeek can detect and persist the shared `system` message plus the financial report content as a cache prefix unit. The third request can then hit that persisted prefix.
+In the above example, the first two requests will not hit the cache. After the first two requests are completed, the system will identify the `system` message + <financial report content> in the `user` message as a cache prefix unit and persist it. In the third request, since it fully matches the previously persisted cache prefix unit, it can hit the cache.
+
+---
 
 ## Checking Cache Hit Status
 
-DeepSeek includes cache status fields in the response `usage` object:
+In the response from the DeepSeek API, we have added two fields in the `usage` section to reflect the cache hit status of the request:
 
-```json
-{
-  "usage": {
-    "prompt_cache_hit_tokens": 1280,
-    "prompt_cache_miss_tokens": 320
-  }
-}
-```
+1. `prompt_cache_hit_tokens`: The number of tokens in the input of this request that resulted in a cache hit.
+2. `prompt_cache_miss_tokens`: The number of tokens in the input of this request that did not result in a cache hit.
 
-- `prompt_cache_hit_tokens`: input tokens served from cache.
-- `prompt_cache_miss_tokens`: input tokens not served from cache.
+## Hard Disk Cache and Output Randomness
 
-## Output Randomness
+The hard disk cache only matches the prefix part of the user's input. The output is still generated through computation and inference, and it is influenced by parameters such as temperature, introducing randomness.
 
-The disk cache matches only the prefix part of the user input. The model output is still generated through normal inference, so generation parameters such as `temperature` can still affect the output.
+## Additional Notes
 
-## Notes
-
-- Context caching is best effort and does not guarantee a 100% hit rate.
-- Cache construction can take seconds.
-- Unused cache entries are cleared automatically, usually within a few hours to a few days.
+1. The cache system works on a "best-effort" basis and does not guarantee a 100% cache hit rate.
+2. Cache construction takes seconds. Once the cache is no longer in use, it will be automatically cleared, usually within a few hours to a few days.

--- a/llmsdk_docs/deepseek/docs/kv-cache.md
+++ b/llmsdk_docs/deepseek/docs/kv-cache.md
@@ -1,0 +1,132 @@
+# Context Caching
+
+DeepSeek enables disk-based context caching by default for all users. No code changes are required to benefit from it.
+
+Each request can build cache prefix units on disk. Later requests with matching prefixes can reuse the cached prefix, which is counted as a cache hit.
+
+## Cache Persistence and Hit Rules
+
+A request can hit the cache only when its prefix fully matches a persisted cache prefix unit. With Sliding Window Attention, each cached prefix is an independent complete unit; partial matches against an existing unit do not count as hits.
+
+DeepSeek persists cache prefix units in three ways:
+
+1. Request-boundary persistence: each request can persist prefix units at the end of the user input and at the end of the model output.
+2. Common-prefix detection: when multiple requests share a common prefix, DeepSeek can persist that common prefix as its own cache prefix unit.
+3. Fixed token intervals: for long inputs or outputs, DeepSeek can create cache prefix units at fixed token intervals so long prefixes can still become cacheable.
+
+## Example: Multi-round Conversation
+
+First request:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are a helpful assistant"
+  },
+  {
+    "role": "user",
+    "content": "What is the capital of China?"
+  }
+]
+```
+
+Second request:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are a helpful assistant"
+  },
+  {
+    "role": "user",
+    "content": "What is the capital of China?"
+  },
+  {
+    "role": "assistant",
+    "content": "The capital of China is Beijing."
+  },
+  {
+    "role": "user",
+    "content": "What is the capital of the United States?"
+  }
+]
+```
+
+The second request fully reuses the first request as a prefix, so that prefix can count as a cache hit.
+
+## Example: Long Text Q&A
+
+First request:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are an experienced financial report analyst..."
+  },
+  {
+    "role": "user",
+    "content": "<financial report content>\n\nPlease summarize the key information of this financial report."
+  }
+]
+```
+
+Second request:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are an experienced financial report analyst..."
+  },
+  {
+    "role": "user",
+    "content": "<financial report content>\n\nPlease analyze the profitability of this financial report."
+  }
+]
+```
+
+Third request:
+
+```json
+[
+  {
+    "role": "system",
+    "content": "You are an experienced financial report analyst..."
+  },
+  {
+    "role": "user",
+    "content": "<financial report content>\n\nPlease analyze the ratio of the company's revenue to expenses."
+  }
+]
+```
+
+The first two requests do not hit the cache because their full prefixes differ. After both requests complete, DeepSeek can detect and persist the shared `system` message plus the financial report content as a cache prefix unit. The third request can then hit that persisted prefix.
+
+## Checking Cache Hit Status
+
+DeepSeek includes cache status fields in the response `usage` object:
+
+```json
+{
+  "usage": {
+    "prompt_cache_hit_tokens": 1280,
+    "prompt_cache_miss_tokens": 320
+  }
+}
+```
+
+- `prompt_cache_hit_tokens`: input tokens served from cache.
+- `prompt_cache_miss_tokens`: input tokens not served from cache.
+
+## Output Randomness
+
+The disk cache matches only the prefix part of the user input. The model output is still generated through normal inference, so generation parameters such as `temperature` can still affect the output.
+
+## Notes
+
+- Context caching is best effort and does not guarantee a 100% hit rate.
+- Cache construction can take seconds.
+- Unused cache entries are cleared automatically, usually within a few hours to a few days.

--- a/llmsdk_docs/deepseek/docs/multi-round-chat.md
+++ b/llmsdk_docs/deepseek/docs/multi-round-chat.md
@@ -1,0 +1,70 @@
+# Multi-round Chat
+
+DeepSeek's `/chat/completions` API is stateless. The server does not store conversation history, so callers must send the needed prior messages on every request.
+
+## Conversation Pattern
+
+1. Send the first user message.
+2. Append the assistant response to the local `messages` list.
+3. Append the next user message.
+4. Send the full `messages` list again.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
+
+# Round 1
+messages = [{"role": "user", "content": "What's the highest mountain in the world?"}]
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+)
+
+messages.append(response.choices[0].message)
+print(f"Messages Round 1: {messages}")
+
+# Round 2
+messages.append({"role": "user", "content": "What is the second?"})
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+)
+
+messages.append(response.choices[0].message)
+print(f"Messages Round 2: {messages}")
+```
+
+## Request Shape
+
+The first request only needs the first user message:
+
+```json
+[
+  {
+    "role": "user",
+    "content": "What's the highest mountain in the world?"
+  }
+]
+```
+
+The next request includes the original user message, the assistant answer, and the new user message:
+
+```json
+[
+  {
+    "role": "user",
+    "content": "What's the highest mountain in the world?"
+  },
+  {
+    "role": "assistant",
+    "content": "The highest mountain in the world is Mount Everest."
+  },
+  {
+    "role": "user",
+    "content": "What is the second?"
+  }
+]
+```
+
+For thinking-mode conversations, see [Thinking Mode](./thinking-mode.md) for when `reasoning_content` should be preserved.

--- a/llmsdk_docs/deepseek/docs/multi-round-chat.md
+++ b/llmsdk_docs/deepseek/docs/multi-round-chat.md
@@ -1,13 +1,10 @@
-# Multi-round Chat
+# Multi-round Conversation
 
-DeepSeek's `/chat/completions` API is stateless. The server does not store conversation history, so callers must send the needed prior messages on every request.
+This guide will introduce how to use the DeepSeek `/chat/completions` API for multi-turn conversations.
 
-## Conversation Pattern
+The DeepSeek `/chat/completions` API is a "stateless" API, meaning the server does not record the context of the user's requests. Therefore, the user must concatenate all previous conversation history and pass it to the chat API with each request.
 
-1. Send the first user message.
-2. Append the assistant response to the local `messages` list.
-3. Append the next user message.
-4. Send the full `messages` list again.
+The following code in Python demonstrates how to concatenate context to achieve multi-turn conversations.
 
 ```python
 from openai import OpenAI
@@ -35,36 +32,27 @@ messages.append(response.choices[0].message)
 print(f"Messages Round 2: {messages}")
 ```
 
-## Request Shape
+---
 
-The first request only needs the first user message:
-
-```json
-[
-  {
-    "role": "user",
-    "content": "What's the highest mountain in the world?"
-  }
-]
-```
-
-The next request includes the original user message, the assistant answer, and the new user message:
+In the first round of the request, the `messages` passed to the API are:
 
 ```json
 [
-  {
-    "role": "user",
-    "content": "What's the highest mountain in the world?"
-  },
-  {
-    "role": "assistant",
-    "content": "The highest mountain in the world is Mount Everest."
-  },
-  {
-    "role": "user",
-    "content": "What is the second?"
-  }
+    {"role": "user", "content": "What's the highest mountain in the world?"}
 ]
 ```
 
-For thinking-mode conversations, see [Thinking Mode](./thinking-mode.md) for when `reasoning_content` should be preserved.
+In the second round of the request:
+
+1. Add the model's output from the first round to the end of the `messages`.
+2. Add the new question to the end of the `messages`.
+
+The `messages` ultimately passed to the API are:
+
+```json
+[
+    {"role": "user", "content": "What's the highest mountain in the world?"},
+    {"role": "assistant", "content": "The highest mountain in the world is Mount Everest."},
+    {"role": "user", "content": "What is the second?"}
+]
+```

--- a/llmsdk_docs/deepseek/docs/thinking-mode.md
+++ b/llmsdk_docs/deepseek/docs/thinking-mode.md
@@ -1,0 +1,113 @@
+# Thinking Mode
+
+Thinking mode lets DeepSeek generate reasoning content before the final answer. In OpenAI-compatible responses, the reasoning is returned as `reasoning_content` alongside the final `content`.
+
+## Toggle and Effort
+
+| Purpose | OpenAI-compatible parameter | Anthropic-compatible parameter |
+| --- | --- | --- |
+| Enable or disable thinking | `{"thinking": {"type": "enabled"}}` or `{"thinking": {"type": "disabled"}}` | Same thinking object |
+| Control effort | `{"reasoning_effort": "high"}` or `{"reasoning_effort": "max"}` | `{"output_config": {"effort": "high"}}` or `{"output_config": {"effort": "max"}}` |
+
+Notes:
+
+- Thinking mode defaults to enabled.
+- In thinking mode, regular requests default to `high` effort.
+- Some complex agent requests may automatically use `max`.
+- `low` and `medium` map to `high`; `xhigh` maps to `max`.
+- Thinking mode ignores `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty`.
+
+With the OpenAI Python SDK, pass the DeepSeek-specific `thinking` setting through `extra_body`:
+
+```python
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+```
+
+## Non-streaming Response Handling
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
+
+messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+reasoning_content = response.choices[0].message.reasoning_content
+content = response.choices[0].message.content
+```
+
+If the assistant turn did not perform a tool call, prior `reasoning_content` does not need to be included in later context. If it is included anyway, the API ignores it.
+
+## Streaming Response Handling
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
+
+messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    stream=True,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+reasoning_content = ""
+content = ""
+
+for chunk in response:
+    delta = chunk.choices[0].delta
+    if getattr(delta, "reasoning_content", None):
+        reasoning_content += delta.reasoning_content
+    elif getattr(delta, "content", None):
+        content += delta.content
+```
+
+## Multi-turn Context
+
+For normal thinking-mode turns without tool calls, append the assistant message and the next user message as usual:
+
+```python
+messages.append(
+    {
+        "role": "assistant",
+        "reasoning_content": reasoning_content,
+        "content": content,
+    }
+)
+messages.append({"role": "user", "content": "How many Rs are there in strawberry?"})
+```
+
+The API ignores the old `reasoning_content` in this no-tool-call case.
+
+## Tool Calls in Thinking Mode
+
+Thinking mode supports tool calls. When a thinking-mode assistant turn performs a tool call, preserve and pass back that turn's full assistant message, including `reasoning_content`, in all subsequent requests. If `reasoning_content` is dropped for a tool-call turn, the API may return a `400` error.
+
+```python
+messages.append(response.choices[0].message)
+
+for tool_call in response.choices[0].message.tool_calls:
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": tool_call.id,
+            "content": run_tool(tool_call),
+        }
+    )
+```
+
+Appending `response.choices[0].message` preserves the assistant `content`, `reasoning_content`, and `tool_calls` fields together.

--- a/llmsdk_docs/deepseek/docs/thinking-mode.md
+++ b/llmsdk_docs/deepseek/docs/thinking-mode.md
@@ -1,40 +1,56 @@
 # Thinking Mode
 
-Thinking mode lets DeepSeek generate reasoning content before the final answer. In OpenAI-compatible responses, the reasoning is returned as `reasoning_content` alongside the final `content`.
+The DeepSeek model supports the thinking mode: before outputting the final answer, the model will first output a chain-of-thought reasoning to improve the accuracy of the final response.
 
-## Toggle and Effort
+## Thinking Mode Toggle and Effort Control
 
-| Purpose | OpenAI-compatible parameter | Anthropic-compatible parameter |
+|  | Control Parameter (OpenAI Format) | Control Parameter (Anthropic Format) |
 | --- | --- | --- |
-| Enable or disable thinking | `{"thinking": {"type": "enabled"}}` or `{"thinking": {"type": "disabled"}}` | Same thinking object |
-| Control effort | `{"reasoning_effort": "high"}` or `{"reasoning_effort": "max"}` | `{"output_config": {"effort": "high"}}` or `{"output_config": {"effort": "max"}}` |
+| Thinking Mode Toggle (1) | `{"thinking": {"type": "enabled/disabled"}}` | `{"thinking": {"type": "enabled/disabled"}}` |
+| Thinking Effort Control (2)(3) | `{"reasoning_effort": "high/max"}` | `{"output_config": {"effort": "high/max"}}` |
 
-Notes:
+(1) The thinking toggle defaults to `enabled`.
 
-- Thinking mode defaults to enabled.
-- In thinking mode, regular requests default to `high` effort.
-- Some complex agent requests may automatically use `max`.
-- `low` and `medium` map to `high`; `xhigh` maps to `max`.
-- Thinking mode ignores `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty`.
+(2) In thinking mode, the default effort is `high` for regular requests; for some complex agent requests (such as Claude Code, OpenCode), effort is automatically set to `max`.
 
-With the OpenAI Python SDK, pass the DeepSeek-specific `thinking` setting through `extra_body`:
+(3) In thinking mode, for compatibility, `low` and `medium` are mapped to `high`, and `xhigh` is mapped to `max`.
+
+When using the OpenAI SDK, you need to pass the `thinking` parameter within `extra_body`:
 
 ```python
 response = client.chat.completions.create(
     model="deepseek-v4-pro",
-    messages=messages,
+    # ...
     reasoning_effort="high",
     extra_body={"thinking": {"type": "enabled"}},
 )
 ```
 
-## Non-streaming Response Handling
+## Input and Output Parameters
+
+Thinking mode does not support the `temperature`, `top_p`, `presence_penalty`, or `frequency_penalty` parameters. Please note that, for compatibility with existing software, setting these parameters will not trigger an error but will also have no effect.
+
+In thinking mode, the chain-of-thought content is returned via the `reasoning_content` parameter, at the same level as `content`. When concatenating subsequent turns, you can selectively return `reasoning_content` to the API:
+
+- Between two `user` messages, if the model did not perform a tool call, the intermediate `assistant`'s `reasoning_content` does not need to participate in the context concatenation. If passed to the API in subsequent turns, it will be ignored. See [Multi-round Conversation](./multi-round-chat.md) for details.
+- Between two `user` messages, if the model performed a tool call, the intermediate `assistant`'s `reasoning_content` must participate in the context concatenation and must be passed back to the API in all subsequent user interaction turns. See [Tool Calls](./tool-calls.md) for details.
+
+## Multi-turn Conversation
+
+In each turn of the conversation, the model outputs the CoT (`reasoning_content`) and the final answer (`content`). If there is no tool call, the CoT content from previous turns will not be concatenated into the context in the next turn, as illustrated in the following diagram:
+
+### Sample Code
+
+The following code, using Python as an example, demonstrates how to access the CoT and the final answer, as well as how to concatenate context in multi-turn conversations.
+
+#### NoStreaming
 
 ```python
 from openai import OpenAI
 
 client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
 
+# Turn 1
 messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
 response = client.chat.completions.create(
     model="deepseek-v4-pro",
@@ -45,17 +61,28 @@ response = client.chat.completions.create(
 
 reasoning_content = response.choices[0].message.reasoning_content
 content = response.choices[0].message.content
+
+# Turn 2
+# The reasoning_content will be ignored by the API
+messages.append(response.choices[0].message)
+messages.append({"role": "user", "content": "How many Rs are there in the word 'strawberry'?"})
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+# ...
 ```
 
-If the assistant turn did not perform a tool call, prior `reasoning_content` does not need to be included in later context. If it is included anyway, the API ignores it.
-
-## Streaming Response Handling
+#### Streaming
 
 ```python
 from openai import OpenAI
 
 client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
 
+# Turn 1
 messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
 response = client.chat.completions.create(
     model="deepseek-v4-pro",
@@ -69,45 +96,195 @@ reasoning_content = ""
 content = ""
 
 for chunk in response:
-    delta = chunk.choices[0].delta
-    if getattr(delta, "reasoning_content", None):
-        reasoning_content += delta.reasoning_content
-    elif getattr(delta, "content", None):
-        content += delta.content
+    if chunk.choices[0].delta.reasoning_content:
+        reasoning_content += chunk.choices[0].delta.reasoning_content
+    else:
+        content += chunk.choices[0].delta.content
+
+# Turn 2
+# The reasoning_content will be ignored by the API
+messages.append({"role": "assistant", "reasoning_content": reasoning_content, "content": content})
+messages.append({"role": "user", "content": "How many Rs are there in the word 'strawberry'?"})
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    stream=True,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+# ...
 ```
 
-## Multi-turn Context
+## Tool Calls
 
-For normal thinking-mode turns without tool calls, append the assistant message and the next user message as usual:
+The DeepSeek model's thinking mode supports tool calls. Before outputting the final answer, the model can perform multiple turns of reasoning and tool calls to improve the quality of the response. The calling pattern is illustrated below:
+
+Please note that, unlike turns in thinking mode that do not involve tool calls, for turns that do perform tool calls, the `reasoning_content` must be fully passed back to the API in all subsequent requests.
+
+If your code does not correctly pass back `reasoning_content`, the API will return a 400 error. Please refer to the sample code below for the correct approach.
+
+### Sample Code
+
+Below is a simple sample code for tool calls in thinking mode:
+
+```python
+import json
+import os
+from datetime import datetime
+
+from openai import OpenAI
+
+# The definition of the tools
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_date",
+            "description": "Get the current date",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather of a location, the user should supply the location and date.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "The city name"},
+                    "date": {"type": "string", "description": "The date in format YYYY-mm-dd"},
+                },
+                "required": ["location", "date"],
+            },
+        },
+    },
+]
+
+
+# The mocked version of the tool calls
+def get_date_mock():
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def get_weather_mock(location, date):
+    return "Cloudy 7~13°C"
+
+
+TOOL_CALL_MAP = {
+    "get_date": get_date_mock,
+    "get_weather": get_weather_mock,
+}
+
+
+def run_turn(turn, messages):
+    sub_turn = 1
+    while True:
+        response = client.chat.completions.create(
+            model="deepseek-v4-pro",
+            messages=messages,
+            tools=tools,
+            reasoning_effort="high",
+            extra_body={"thinking": {"type": "enabled"}},
+        )
+        messages.append(response.choices[0].message)
+        reasoning_content = response.choices[0].message.reasoning_content
+        content = response.choices[0].message.content
+        tool_calls = response.choices[0].message.tool_calls
+        print(f"Turn {turn}.{sub_turn}\n{reasoning_content=}\n{content=}\n{tool_calls=}")
+        # If there is no tool calls, then the model should get a final answer and we need to stop the loop
+        if tool_calls is None:
+            break
+        for tool in tool_calls:
+            tool_function = TOOL_CALL_MAP[tool.function.name]
+            tool_result = tool_function(**json.loads(tool.function.arguments))
+            print(f"tool result for {tool.function.name}: {tool_result}\n")
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool.id,
+                    "content": tool_result,
+                }
+            )
+        sub_turn += 1
+    print()
+
+
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url=os.environ.get("DEEPSEEK_BASE_URL"),
+)
+
+# The user starts a question
+turn = 1
+messages = [
+    {
+        "role": "user",
+        "content": "How's the weather in Hangzhou Tomorrow",
+    }
+]
+run_turn(turn, messages)
+
+# The user starts a new question
+turn = 2
+messages.append(
+    {
+        "role": "user",
+        "content": "How's the weather in Guangzhou Tomorrow",
+    }
+)
+run_turn(turn, messages)
+```
+
+In each sub-request of Turn 1, the `reasoning_content` generated during that turn is sent to the API, allowing the model to continue its previous reasoning. `response.choices[0].message` contains all necessary fields for the `assistant` message, including `content`, `reasoning_content`, and `tool_calls`. For simplicity, you can directly append the message to the end of the messages list using the following code:
+
+```python
+messages.append(response.choices[0].message)
+```
+
+This line of code is equivalent to:
 
 ```python
 messages.append(
     {
         "role": "assistant",
-        "reasoning_content": reasoning_content,
-        "content": content,
+        "content": response.choices[0].message.content,
+        "reasoning_content": response.choices[0].message.reasoning_content,
+        "tool_calls": response.choices[0].message.tool_calls,
     }
 )
-messages.append({"role": "user", "content": "How many Rs are there in strawberry?"})
 ```
 
-The API ignores the old `reasoning_content` in this no-tool-call case.
+Additionally, in the Turn 2 request, we still pass the `reasoning_content` generated in Turn 1 to the API.
 
-## Tool Calls in Thinking Mode
+The sample output of this code is as follows:
 
-Thinking mode supports tool calls. When a thinking-mode assistant turn performs a tool call, preserve and pass back that turn's full assistant message, including `reasoning_content`, in all subsequent requests. If `reasoning_content` is dropped for a tool-call turn, the API may return a `400` error.
+```text
+Turn 1.1
+reasoning_content="The user is asking about the weather in Hangzhou tomorrow. I need to get tomorrow's date first, then call the weather function."
+content="Let me check tomorrow's weather in Hangzhou for you. First, let me get tomorrow's date."
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_kw66qNnNto11bSfJVIdlV5Oo', function=Function(arguments='{}', name='get_date'), type='function', index=0)]
+tool result for get_date: 2026-04-19
 
-```python
-messages.append(response.choices[0].message)
+Turn 1.2
+reasoning_content="Today is 2026-04-19, so tomorrow is 2026-04-20. Now I'll call the weather function for Hangzhou."
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_H2SCW6136vWJGq9SQlBuhVt4', function=Function(arguments='{"location": "Hangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
 
-for tool_call in response.choices[0].message.tool_calls:
-    messages.append(
-        {
-            "role": "tool",
-            "tool_call_id": tool_call.id,
-            "content": run_tool(tool_call),
-        }
-    )
+Turn 1.3
+reasoning_content='The weather result is in. Let me share this with the user.'
+content="Here's the weather forecast for **Hangzhou tomorrow (April 20, 2026)**:\n\n-  **Condition:** Cloudy  \n-  **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be on the cooler side, so you might want to bring a light jacket if you're heading out! Let me know if you need anything else."
+tool_calls=None
+
+Turn 2.1
+reasoning_content='The user is asking about the weather in Guangzhou tomorrow. Today is 2026-04-19, so tomorrow is 2026-04-20. I can directly call the weather function.'
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_8URkLt5NjmNkVKhDmMcNq9Mo', function=Function(arguments='{"location": "Guangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
+
+Turn 2.2
+reasoning_content='The weather result for Guangzhou is the same as Hangzhou. Let me share this with the user.'
+content="Here's the weather forecast for **Guangzhou tomorrow (April 20, 2026)**:\n\n-  **Condition:** Cloudy  \n-  **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be cool and cloudy, so a light jacket would be a good idea if you're going out. Let me know if there's anything else you'd like to know!"
+tool_calls=None
 ```
-
-Appending `response.choices[0].message` preserves the assistant `content`, `reasoning_content`, and `tool_calls` fields together.

--- a/llmsdk_docs/deepseek/docs/tool-calls.md
+++ b/llmsdk_docs/deepseek/docs/tool-calls.md
@@ -1,27 +1,32 @@
 # Tool Calls
 
-Tool calls let DeepSeek request external function execution. The model returns the function name and arguments; the application executes the function and sends the result back as a `tool` message.
+Tool Calls allows the model to call external tools to enhance its capabilities.
+
+---
 
 ## Non-thinking Mode
 
+### Sample Code
+
+Here is an example of using Tool Calls to get the current weather information of the user's location, demonstrated with complete Python code.
+
+For the specific API format of Tool Calls, please refer to the Chat Completion documentation.
+
 ```python
 from openai import OpenAI
-
 
 def send_messages(messages):
     response = client.chat.completions.create(
         model="deepseek-v4-pro",
         messages=messages,
-        tools=tools,
+        tools=tools
     )
     return response.choices[0].message
-
 
 client = OpenAI(
     api_key="<your api key>",
     base_url="https://api.deepseek.com",
 )
-
 tools = [
     {
         "type": "function",
@@ -36,89 +41,293 @@ tools = [
                         "description": "The city and state, e.g. San Francisco, CA",
                     }
                 },
-                "required": ["location"],
+                "required": ["location"]
             },
-        },
+        }
     },
 ]
-
 messages = [{"role": "user", "content": "How's the weather in Hangzhou, Zhejiang?"}]
 message = send_messages(messages)
 print(f"User>\t {messages[0]['content']}")
 
 tool = message.tool_calls[0]
 messages.append(message)
-messages.append({"role": "tool", "tool_call_id": tool.id, "content": "24 C"})
 
+messages.append({"role": "tool", "tool_call_id": tool.id, "content": "24℃"})
 message = send_messages(messages)
 print(f"Model>\t {message.content}")
 ```
 
-Execution flow:
+The execution flow of this example is as follows:
 
-1. The user asks about the weather.
-2. The model returns a `get_weather` tool call with arguments.
-3. The application executes `get_weather`.
-4. The application sends the result back with the matching `tool_call_id`.
-5. The model returns the final natural-language answer.
+1. User: Asks about the current weather in Hangzhou
+2. Model: Returns the function `get_weather({location: 'Hangzhou'})`
+3. User: Calls the function `get_weather({location: 'Hangzhou'})` and provides the result to the model
+4. Model: Returns in natural language, "The current temperature in Hangzhou is 24°C."
 
-The model does not execute tools itself. Tool execution is application-owned.
+Note: In the above code, the functionality of the `get_weather` function needs to be provided by the user. The model itself does not execute specific functions.
+
+---
 
 ## Thinking Mode
 
-DeepSeek supports tool calls in thinking mode. For tool-call turns, keep the full assistant message in the conversation history, including `reasoning_content`, `content`, and `tool_calls`. Dropping `reasoning_content` for those turns can cause a `400` response.
+From DeepSeek-V3.2, the API supports tool use in the thinking mode. For more details, please refer to [Thinking Mode](./thinking-mode.md).
 
-See [Thinking Mode](./thinking-mode.md) for the full thinking-mode context rule.
+---
 
-## Strict Mode
+## `strict` Mode (Beta)
 
-`strict` mode is a beta feature that makes the model follow the provided JSON Schema more closely when producing tool-call arguments. It works in both thinking and non-thinking mode.
+In `strict` mode, the model strictly adheres to the format requirements of the Function's JSON schema when outputting a tool call, ensuring that the model's output complies with the user's definition. It is supported by both thinking and non-thinking mode.
 
-To use it:
+To use `strict` mode, you need to::
 
-1. Use `base_url="https://api.deepseek.com/beta"`.
-2. Set `strict` to `true` on every `function` in `tools`.
-3. Ensure the supplied JSON Schema uses supported forms.
+1. Use `base_url="https://api.deepseek.com/beta"` to enable Beta features
+2. In the `tools` parameter, all `function` need to set the `strict` property to `true`
+3. The server will validate the JSON Schema of the Function provided by the user. If the schema does not conform to the specifications or contains JSON schema types that are not supported by the server, an error message will be returned
+
+The following is an example of a tool definition in the `strict` mode:
 
 ```json
 {
-  "type": "function",
-  "function": {
-    "name": "get_weather",
-    "strict": true,
-    "description": "Get weather of a location, the user should supply a location first.",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "location": {
-          "type": "string",
-          "description": "The city and state, e.g. San Francisco, CA"
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "strict": true,
+        "description": "Get weather of a location, the user should supply a location first.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA"
+                }
+            },
+            "required": ["location"],
+            "additionalProperties": false
         }
-      },
-      "required": ["location"],
-      "additionalProperties": false
     }
-  }
 }
 ```
 
-Supported JSON Schema types in strict mode:
+---
 
-- `object`
-- `string`
-- `number`
-- `integer`
-- `boolean`
-- `array`
-- `enum`
-- `anyOf`
+### Support Json Schema Types In `strict` Mode
 
-Object schemas must mark every property as required and set `additionalProperties` to `false`.
+- object
+- string
+- number
+- integer
+- boolean
+- array
+- enum
+- anyOf
 
-Supported string constraints include `pattern` and `format`. Supported formats include `email`, `hostname`, `ipv4`, `ipv6`, and `uuid`. `minLength` and `maxLength` are not supported.
+---
 
-Number and integer schemas support constraints such as `const`, `default`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, and `multipleOf`.
+#### object
 
-Array schemas do not support `minItems` or `maxItems`.
+The `object` defines a nested structure containing key-value pairs, where `properties` specifies the schema for each key (or property) within the object. All properties of every `object` must be set as `required`, and the `additionalProperties` attribute of the `object` must be set to `false`.
 
-`$def` and `$ref` can be used for reusable or recursive schema definitions.
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer" }
+    },
+    "required": ["name", "age"],
+    "additionalProperties": false
+}
+```
+
+---
+
+#### string
+
+Supported parameters:
+
+- `pattern`: Uses regular expressions to constrain the format of the string
+- `format`: Validates the string against predefined common formats. Currently supported formats:
+  - `email`: Email address
+  - `hostname`: Hostname
+  - `ipv4`: IPv4 address
+  - `ipv6`: IPv6 address
+  - `uuid`: UUID
+
+Unsupported parameters:
+
+- `minLength`
+- `maxLength`
+
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "user_email": {
+            "type": "string",
+            "description": "The user's email address",
+            "format": "email"
+        },
+        "zip_code": {
+            "type": "string",
+            "description": "Six digit postal code",
+            "pattern": "^\\d{6}$"
+        }
+    }
+}
+```
+
+---
+
+#### number/integer
+
+Supported parameters:
+
+- `const`: Specifies a constant numeric value
+- `default`: Defines the default value of the number
+- `minimum`: Specifies the minimum value
+- `maximum`: Specifies the maximum value
+- `exclusiveMinimum`: Defines a value that the number must be greater than
+- `exclusiveMaximum`: Defines a value that the number must be less than
+- `multipleOf`: Ensures that the number is a multiple of the specified value
+
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "score": {
+            "type": "integer",
+            "description": "A number from 1-5, which represents your rating, the higher, the better",
+            "minimum": 1,
+            "maximum": 5
+        }
+    },
+    "required": ["score"],
+    "additionalProperties": false
+}
+```
+
+---
+
+#### array
+
+Unsupported parameters:
+
+- minItems
+- maxItems
+
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "keywords": {
+            "type": "array",
+            "description": "Five keywords of the article, sorted by importance",
+            "items": {
+                "type": "string",
+                "description": "A concise and accurate keyword or phrase."
+            }
+        }
+    },
+    "required": ["keywords"],
+    "additionalProperties": false
+}
+```
+
+---
+
+#### enum
+
+The `enum` ensures that the output is one of the predefined options. For example, in the case of order status, it can only be one of a limited set of specified states.
+
+Example:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "order_status": {
+            "type": "string",
+            "description": "Ordering status",
+            "enum": ["pending", "processing", "shipped", "cancelled"]
+        }
+    }
+}
+```
+
+---
+
+#### anyOf
+
+Matches any one of the provided schemas, allowing fields to accommodate multiple valid formats. For example, a user's account could be either an email address or a phone number:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "account": {
+            "anyOf": [
+                { "type": "string", "format": "email", "description": "可以是电子邮件地址" },
+                { "type": "string", "pattern": "^\\d{11}$", "description": "或11位手机号码" }
+            ]
+        }
+    }
+}
+```
+
+---
+
+#### $ref and $def
+
+You can use `$def` to define reusable modules and then use `$ref` to reference them, reducing schema repetition and enabling modularization. Additionally, `$ref` can be used independently to define recursive structures.
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "report_date": {
+            "type": "string",
+            "description": "The date when the report was published"
+        },
+        "authors": {
+            "type": "array",
+            "description": "The authors of the report",
+            "items": {
+                "$ref": "#/$def/author"
+            }
+        }
+    },
+    "required": ["report_date", "authors"],
+    "additionalProperties": false,
+    "$def": {
+        "author": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "author's name"
+                },
+                "institution": {
+                    "type": "string",
+                    "description": "author's institution"
+                },
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "author's email"
+                }
+            },
+            "additionalProperties": false,
+            "required": ["name", "institution", "email"]
+        }
+    }
+}
+```

--- a/llmsdk_docs/deepseek/docs/tool-calls.md
+++ b/llmsdk_docs/deepseek/docs/tool-calls.md
@@ -1,0 +1,124 @@
+# Tool Calls
+
+Tool calls let DeepSeek request external function execution. The model returns the function name and arguments; the application executes the function and sends the result back as a `tool` message.
+
+## Non-thinking Mode
+
+```python
+from openai import OpenAI
+
+
+def send_messages(messages):
+    response = client.chat.completions.create(
+        model="deepseek-v4-pro",
+        messages=messages,
+        tools=tools,
+    )
+    return response.choices[0].message
+
+
+client = OpenAI(
+    api_key="<your api key>",
+    base_url="https://api.deepseek.com",
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather of a location, the user should supply a location first.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    }
+                },
+                "required": ["location"],
+            },
+        },
+    },
+]
+
+messages = [{"role": "user", "content": "How's the weather in Hangzhou, Zhejiang?"}]
+message = send_messages(messages)
+print(f"User>\t {messages[0]['content']}")
+
+tool = message.tool_calls[0]
+messages.append(message)
+messages.append({"role": "tool", "tool_call_id": tool.id, "content": "24 C"})
+
+message = send_messages(messages)
+print(f"Model>\t {message.content}")
+```
+
+Execution flow:
+
+1. The user asks about the weather.
+2. The model returns a `get_weather` tool call with arguments.
+3. The application executes `get_weather`.
+4. The application sends the result back with the matching `tool_call_id`.
+5. The model returns the final natural-language answer.
+
+The model does not execute tools itself. Tool execution is application-owned.
+
+## Thinking Mode
+
+DeepSeek supports tool calls in thinking mode. For tool-call turns, keep the full assistant message in the conversation history, including `reasoning_content`, `content`, and `tool_calls`. Dropping `reasoning_content` for those turns can cause a `400` response.
+
+See [Thinking Mode](./thinking-mode.md) for the full thinking-mode context rule.
+
+## Strict Mode
+
+`strict` mode is a beta feature that makes the model follow the provided JSON Schema more closely when producing tool-call arguments. It works in both thinking and non-thinking mode.
+
+To use it:
+
+1. Use `base_url="https://api.deepseek.com/beta"`.
+2. Set `strict` to `true` on every `function` in `tools`.
+3. Ensure the supplied JSON Schema uses supported forms.
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "get_weather",
+    "strict": true,
+    "description": "Get weather of a location, the user should supply a location first.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The city and state, e.g. San Francisco, CA"
+        }
+      },
+      "required": ["location"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+Supported JSON Schema types in strict mode:
+
+- `object`
+- `string`
+- `number`
+- `integer`
+- `boolean`
+- `array`
+- `enum`
+- `anyOf`
+
+Object schemas must mark every property as required and set `additionalProperties` to `false`.
+
+Supported string constraints include `pattern` and `format`. Supported formats include `email`, `hostname`, `ipv4`, `ipv6`, and `uuid`. `minLength` and `maxLength` are not supported.
+
+Number and integer schemas support constraints such as `const`, `default`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, and `multipleOf`.
+
+Array schemas do not support `minItems` or `maxItems`.
+
+`$def` and `$ref` can be used for reusable or recursive schema definitions.

--- a/llmsdk_docs/deepseek/quickstart.md
+++ b/llmsdk_docs/deepseek/quickstart.md
@@ -1,0 +1,111 @@
+# DeepSeek Quickstart
+
+DeepSeek provides OpenAI-compatible and Anthropic-compatible API formats. For OpenAI SDK usage, point the client at DeepSeek's base URL and pass a DeepSeek API key.
+
+## API Parameters
+
+| Parameter | Value |
+| --- | --- |
+| OpenAI `base_url` | `https://api.deepseek.com` |
+| Anthropic `base_url` | `https://api.deepseek.com/anthropic` |
+| API key | Create one in the DeepSeek platform |
+| Current models | `deepseek-v4-flash`, `deepseek-v4-pro` |
+| Compatibility model aliases | `deepseek-chat`, `deepseek-reasoner` |
+
+`deepseek-chat` and `deepseek-reasoner` are compatibility aliases scheduled for deprecation on 2026-07-24. They correspond to non-thinking and thinking mode on `deepseek-v4-flash`.
+
+## Invoke the Chat API
+
+The `/chat/completions` endpoint follows the OpenAI Chat Completions shape. Set `stream` to `true` for streaming responses.
+
+### curl
+
+```bash
+curl https://api.deepseek.com/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${DEEPSEEK_API_KEY}" \
+  -d '{
+        "model": "deepseek-v4-pro",
+        "messages": [
+          {"role": "system", "content": "You are a helpful assistant."},
+          {"role": "user", "content": "Hello!"}
+        ],
+        "thinking": {"type": "enabled"},
+        "reasoning_effort": "high",
+        "stream": false
+      }'
+```
+
+### Python
+
+Install the OpenAI SDK first:
+
+```bash
+pip install openai
+```
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ.get("DEEPSEEK_API_KEY"),
+    base_url="https://api.deepseek.com",
+)
+
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant"},
+        {"role": "user", "content": "Hello"},
+    ],
+    stream=False,
+    reasoning_effort="high",
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+print(response.choices[0].message.content)
+```
+
+When using the OpenAI Python SDK, pass the DeepSeek-specific `thinking` object through `extra_body`.
+
+### Node.js
+
+Install the OpenAI SDK first:
+
+```bash
+npm install openai
+```
+
+```ts
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  baseURL: "https://api.deepseek.com",
+  apiKey: process.env.DEEPSEEK_API_KEY,
+});
+
+async function main() {
+  const completion = await openai.chat.completions.create({
+    model: "deepseek-v4-pro",
+    messages: [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Hello!" },
+    ],
+    thinking: { type: "enabled" },
+    reasoning_effort: "high",
+    stream: false,
+  });
+
+  console.log(completion.choices[0].message.content);
+}
+
+main();
+```
+
+## Related Guides
+
+- [Thinking Mode](./docs/thinking-mode.md)
+- [Multi-round Chat](./docs/multi-round-chat.md)
+- [JSON Mode](./docs/json-mode.md)
+- [Tool Calls](./docs/tool-calls.md)

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -35,6 +35,7 @@ Choose a model ID from the table, set the API key and base URL using the environ
 | Kimi-K2.5 | SiliconFlow | `Pro/moonshotai/Kimi-K2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Qwen3 | OpenRouter | `qwen/qwen3-8b`, `qwen/qwen3-30b-a3b-thinking-2507` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
 | Qwen3 | SiliconFlow | `Qwen/Qwen3-8B` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
+| DeepSeek V4 | Official | `deepseek-v4-pro`, `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
 
 ## Basic Usage
 

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -33,6 +33,7 @@ Choose a model ID from the table, set the API key and base URL using the environ
 | Kimi-K2.5 | SiliconFlow | `Pro/moonshotai/Kimi-K2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Qwen3 | OpenRouter | `qwen/qwen3-8b`, `qwen/qwen3-30b-a3b-thinking-2507` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
 | Qwen3 | SiliconFlow | `Qwen/Qwen3-8B` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
+| DeepSeek V4 | Official | `deepseek-v4-pro`, `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
 
 ## Basic Usage
 

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -70,10 +70,15 @@ class AutoLLMClient(LLMClient):
             from .qwen3 import Qwen3Client
 
             return Qwen3Client(model=model, api_key=api_key, base_url=base_url)
+        elif "deepseek-v4-" in client_type:
+            from .deepseek_v4 import DeepSeekV4Client
+
+            return DeepSeekV4Client(model=model, api_key=api_key, base_url=base_url)
         else:
             raise ValueError(
                 f"{client_type} is not supported. "
-                "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3."
+                "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3, "
+                "deepseek-v4."
             )
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> Any:

--- a/src_py/agenthub/deepseek_v4/__init__.py
+++ b/src_py/agenthub/deepseek_v4/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .client import DeepSeekV4Client
+
+
+__all__ = ["DeepSeekV4Client"]

--- a/src_py/agenthub/deepseek_v4/client.py
+++ b/src_py/agenthub/deepseek_v4/client.py
@@ -175,8 +175,7 @@ class DeepSeekV4Client(LLMClient):
                 message["tool_calls"] = tool_calls
 
             if thinking:
-                message["reasoning_content"] = thinking  # vLLM & siliconflow compatibility
-                message["reasoning"] = thinking  # openrouter compatibility
+                message["reasoning_content"] = thinking
 
             # message may be empty for tool results
             if len(message.keys()) > 1:

--- a/src_py/agenthub/deepseek_v4/client.py
+++ b/src_py/agenthub/deepseek_v4/client.py
@@ -1,0 +1,342 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from typing import Any, AsyncIterator
+
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionChunk, ChatCompletionMessageParam
+
+from ..base_client import LLMClient
+from ..types import (
+    EventType,
+    FinishReason,
+    PartialContentItem,
+    PromptCaching,
+    ThinkingLevel,
+    ToolChoice,
+    UniConfig,
+    UniEvent,
+    UniMessage,
+    UsageMetadata,
+)
+
+
+class DeepSeekV4Client(LLMClient):
+    """DeepSeek V4-specific LLM client implementation using OpenAI-compatible Chat Completions."""
+
+    def __init__(self, model: str, api_key: str | None = None, base_url: str | None = None):
+        """Initialize DeepSeek client with model, API key, and caller-provided base URL."""
+        self._model = model
+        api_key = api_key or os.getenv("DEEPSEEK_API_KEY")
+        base_url = base_url or os.getenv("DEEPSEEK_BASE_URL")
+        if base_url is None:
+            raise ValueError("DeepSeek base_url is required. Pass base_url or set DEEPSEEK_BASE_URL.")
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self._history: list[UniMessage] = []
+
+    def _convert_thinking_level_to_config(self, thinking_level: ThinkingLevel) -> dict[str, str]:
+        """Convert ThinkingLevel enum to DeepSeek's thinking configuration."""
+        mapping = {
+            ThinkingLevel.NONE: {"type": "disabled"},
+            ThinkingLevel.LOW: {"type": "enabled"},
+            ThinkingLevel.MEDIUM: {"type": "enabled"},
+            ThinkingLevel.HIGH: {"type": "enabled"},
+        }
+        return mapping[thinking_level]
+
+    def _convert_reasoning_effort(self, thinking_level: ThinkingLevel) -> str | None:
+        """Convert ThinkingLevel enum to DeepSeek's reasoning_effort."""
+        mapping = {
+            ThinkingLevel.NONE: None,
+            ThinkingLevel.LOW: None,
+            ThinkingLevel.MEDIUM: "high",
+            ThinkingLevel.HIGH: "max",
+        }
+        return mapping[thinking_level]
+
+    def _convert_tool_choice(self, tool_choice: ToolChoice) -> str:
+        """Convert ToolChoice to DeepSeek's OpenAI-compatible tool_choice format."""
+        if tool_choice in ["auto", "none"]:
+            return tool_choice
+        raise ValueError("DeepSeek tool_choice config expected one of `auto` or `none`.")
+
+    def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
+        """
+        Transform universal configuration to DeepSeek-specific configuration.
+
+        Args:
+            config: Universal configuration dict
+
+        Returns:
+            DeepSeek configuration dictionary
+        """
+        if config.get("prompt_caching") is not None and config["prompt_caching"] != PromptCaching.ENABLE:
+            raise ValueError("prompt_caching must be ENABLE for DeepSeek.")
+
+        deepseek_config = {"model": self._model, "stream": True, "stream_options": {"include_usage": True}}
+
+        if config.get("max_tokens") is not None:
+            deepseek_config["max_tokens"] = config["max_tokens"]
+
+        if config.get("temperature") is not None:
+            raise ValueError("DeepSeek does not support temperature.")
+
+        thinking_level = config.get("thinking_level")
+        if thinking_level is not None:
+            deepseek_config["extra_body"] = {"thinking": self._convert_thinking_level_to_config(thinking_level)}
+            reasoning_effort = self._convert_reasoning_effort(thinking_level)
+            if reasoning_effort is not None:
+                deepseek_config["reasoning_effort"] = reasoning_effort
+
+        if config.get("tools") is not None:
+            deepseek_config["tools"] = [{"type": "function", "function": tool} for tool in config["tools"]]
+
+        if config.get("tool_choice") is not None:
+            deepseek_config["tool_choice"] = self._convert_tool_choice(config["tool_choice"])
+
+        return deepseek_config
+
+    def transform_uni_message_to_model_input(self, messages: list[UniMessage]) -> list[ChatCompletionMessageParam]:
+        """
+        Transform universal message format to DeepSeek's OpenAI-compatible message format.
+
+        Args:
+            messages: List of universal message dictionaries
+
+        Returns:
+            List of OpenAI-compatible message dictionaries
+        """
+        deepseek_messages = []
+
+        for msg in messages:
+            content_parts = []  # may be empty for tool results
+            tool_calls = []  # may be empty for no tool calls
+            thinking = ""
+            for item in msg["content_items"]:
+                if item["type"] == "text":
+                    content_parts.append({"type": "text", "text": item["text"]})
+                elif item["type"] == "image_url":
+                    raise ValueError("DeepSeek does not support image url inputs.")
+                elif item["type"] == "inline_data":
+                    raise ValueError("DeepSeek does not support inline data inputs.")
+                elif item["type"] == "thinking":
+                    thinking += item["thinking"]
+                elif item["type"] == "inline_thinking":
+                    raise ValueError("DeepSeek does not support inline thinking inputs.")
+                elif item["type"] == "tool_call":
+                    tool_calls.append(
+                        {
+                            "id": item["tool_call_id"],
+                            "type": "function",
+                            "function": {
+                                "name": item["name"],
+                                "arguments": json.dumps(item["arguments"], ensure_ascii=False),
+                            },
+                        }
+                    )
+                elif item["type"] == "tool_result":
+                    if "tool_call_id" not in item:
+                        raise ValueError("tool_call_id is required for tool result.")
+
+                    content = [{"type": "text", "text": item["text"]}]
+
+                    if "images" in item and item["images"]:
+                        raise ValueError("DeepSeek does not support images in tool results.")
+
+                    # Tool results are sent as separate messages
+                    deepseek_messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": item["tool_call_id"],
+                            "content": content,
+                        }
+                    )
+                else:
+                    raise ValueError(f"Unknown item type: {item['type']}")
+
+            message = {"role": msg["role"]}
+            if content_parts:
+                message["content"] = content_parts
+
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+
+            if thinking:
+                message["reasoning_content"] = thinking  # vLLM & siliconflow compatibility
+                message["reasoning"] = thinking  # openrouter compatibility
+
+            # message may be empty for tool results
+            if len(message.keys()) > 1:
+                deepseek_messages.append(message)
+
+        return deepseek_messages
+
+    def transform_model_output_to_uni_event(self, model_output: ChatCompletionChunk) -> UniEvent:
+        """
+        Transform DeepSeek streaming chunk to universal event format.
+
+        Args:
+            model_output: OpenAI-compatible streaming chunk
+
+        Returns:
+            Universal event dictionary
+        """
+        event_type: EventType | None = None
+        content_items: list[PartialContentItem] = []
+        usage_metadata: UsageMetadata | None = None
+        finish_reason: FinishReason | None = None
+
+        if len(model_output.choices) > 0:
+            choice = model_output.choices[0]
+            delta = choice.delta
+
+            if getattr(delta, "reasoning_content", None):
+                event_type = "delta"
+                content_items.append({"type": "thinking", "thinking": getattr(delta, "reasoning_content")})
+
+            if delta.content:
+                event_type = "delta"
+                content_items.append({"type": "text", "text": delta.content})
+
+            if delta.tool_calls:
+                event_type = "delta"
+                for tool_call in delta.tool_calls:
+                    content_item: PartialContentItem = {
+                        "type": "partial_tool_call",
+                        "name": tool_call.function.name or "",
+                        "arguments": tool_call.function.arguments or "",
+                        "tool_call_id": tool_call.id or "",
+                    }
+                    content_items.append(content_item)
+
+            if choice.finish_reason:
+                event_type = event_type or "stop"
+                finish_reason_mapping = {
+                    "stop": "stop",
+                    "length": "length",
+                    "tool_calls": "tool_call",
+                    "content_filter": "stop",
+                }
+                finish_reason = finish_reason_mapping.get(choice.finish_reason, "unknown")
+
+        if model_output.usage:
+            event_type = event_type or "stop"
+            completion_token_details = model_output.usage.completion_tokens_details
+            reasoning_tokens = (
+                getattr(completion_token_details, "reasoning_tokens", None) if completion_token_details else None
+            )
+            response_tokens = model_output.usage.completion_tokens - (reasoning_tokens or 0)
+
+            # usage.prompt_tokens = prompt_cache_hit_tokens + prompt_cache_miss_tokens
+            usage_metadata = {
+                "cached_tokens": model_output.usage.prompt_cache_hit_tokens,
+                "prompt_tokens": model_output.usage.prompt_cache_miss_tokens,
+                "thoughts_tokens": reasoning_tokens,
+                "response_tokens": response_tokens,
+            }
+
+        return {
+            "role": "assistant",
+            "event_type": event_type,
+            "content_items": content_items,
+            "usage_metadata": usage_metadata,
+            "finish_reason": finish_reason,
+        }
+
+    async def _streaming_response_internal(
+        self,
+        messages: list[UniMessage],
+        config: UniConfig,
+    ) -> AsyncIterator[UniEvent]:
+        """Stream generate using DeepSeek's OpenAI-compatible Chat Completions API."""
+        deepseek_config = self.transform_uni_config_to_model_config(config)
+        deepseek_messages = self.transform_uni_message_to_model_input(messages)
+
+        if config.get("system_prompt"):
+            deepseek_messages.insert(0, {"role": "system", "content": config["system_prompt"]})
+
+        stream = await self._client.chat.completions.create(**deepseek_config, messages=deepseek_messages)
+
+        partial_tool_call = {}
+        partial_usage = {}
+        async for chunk in stream:
+            event = self.transform_model_output_to_uni_event(chunk)
+            partial_usage["finish_reason"] = event["finish_reason"] or partial_usage.get("finish_reason")
+            partial_usage["usage_metadata"] = event["usage_metadata"] or partial_usage.get("usage_metadata")
+
+            if event["event_type"] == "delta":
+                for item in event["content_items"]:
+                    if item["type"] == "partial_tool_call":
+                        if not partial_tool_call:
+                            partial_tool_call = {
+                                "name": item["name"],
+                                "arguments": item["arguments"],
+                                "tool_call_id": item["tool_call_id"],
+                            }
+                        elif item["name"]:
+                            yield {
+                                "role": "assistant",
+                                "event_type": "delta",
+                                "content_items": [
+                                    {
+                                        "type": "tool_call",
+                                        "name": partial_tool_call["name"],
+                                        "arguments": json.loads(partial_tool_call["arguments"] or "{}"),
+                                        "tool_call_id": partial_tool_call["tool_call_id"],
+                                    }
+                                ],
+                                "usage_metadata": None,
+                                "finish_reason": None,
+                            }
+                            partial_tool_call = {
+                                "name": item["name"],
+                                "arguments": item["arguments"],
+                                "tool_call_id": item["tool_call_id"],
+                            }
+                        else:
+                            partial_tool_call["arguments"] += item["arguments"]
+                            partial_tool_call["tool_call_id"] = (
+                                item["tool_call_id"] or partial_tool_call["tool_call_id"]
+                            )
+
+                yield event
+            elif event["event_type"] == "stop":
+                if partial_tool_call:
+                    yield {
+                        "role": "assistant",
+                        "event_type": "delta",
+                        "content_items": [
+                            {
+                                "type": "tool_call",
+                                "name": partial_tool_call["name"],
+                                "arguments": json.loads(partial_tool_call["arguments"] or "{}"),
+                                "tool_call_id": partial_tool_call["tool_call_id"],
+                            }
+                        ],
+                        "usage_metadata": None,
+                        "finish_reason": None,
+                    }
+                    partial_tool_call = {}
+
+                if partial_usage.get("finish_reason") and partial_usage.get("usage_metadata"):
+                    yield {
+                        "role": "assistant",
+                        "event_type": "stop",
+                        "content_items": event["content_items"],
+                        "usage_metadata": partial_usage["usage_metadata"],
+                        "finish_reason": partial_usage["finish_reason"],
+                    }
+                    partial_usage = {}

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -123,7 +123,7 @@ def create_chat_app() -> Flask:
                 </div>
                 <div class="flex flex-col">
                     <label class="text-sm font-semibold text-gray-900 mb-1" for="temperatureInput">Temperature</label>
-                    <input type="number" id="temperatureInput" min="0" max="2" step="0.1" value="1.0" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                    <input type="number" id="temperatureInput" min="0" max="2" step="0.1" value="" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                 </div>
                 <div class="flex flex-col">
                     <label class="text-sm font-semibold text-gray-900 mb-1" for="maxTokensInput">Max Tokens</label>
@@ -335,9 +335,12 @@ def create_chat_app() -> Flask:
             function getConfig() {
                 const config = {
                     model: document.getElementById('modelSelect').value,
-                    temperature: parseFloat(document.getElementById('temperatureInput').value),
                     max_tokens: parseInt(document.getElementById('maxTokensInput').value)
                 };
+                temperature = document.getElementById('temperatureInput').value
+                if (temperature) {
+                    config.temperature = parseFloat(temperature);
+                }
 
                 const thinkingLevel = document.getElementById('thinkingLevelSelect').value;
                 if (thinkingLevel) {

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -115,6 +115,8 @@ def create_chat_app() -> Flask:
                         <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
                         <option value="kimi-k2.5">Kimi K2.5</option>
                         <option value="glm-5">GLM 5</option>
+                        <option value="deepseek-v4-pro">DeepSeek V4 Pro</option>
+                        <option value="deepseek-v4-flash">DeepSeek V4 Flash</option>
                         <option value="gemini-3.1-flash-image-preview">Gemini 3.1 Flash Image (Nano Banana 2)</option>
                         <option value="gemini-3.1-flash-tts-preview">Gemini 3.1 Flash TTS</option>
                     </datalist>

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -78,6 +78,10 @@ if os.getenv("ZAI_API_KEY"):
 if os.getenv("MOONSHOT_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="kimi-k2.5", support_temperature=False))
 
+if os.getenv("DEEPSEEK_API_KEY") and os.getenv("DEEPSEEK_BASE_URL"):
+    AVAILABLE_MODELS.append(Model(name="deepseek-v4-pro", support_temperature=False, support_image_understanding=False))
+    AVAILABLE_MODELS.append(Model(name="deepseek-v4-flash", support_temperature=False, support_image_understanding=False))
+
 if os.getenv("BEDROCK_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="global.anthropic.claude-sonnet-4-6", provider="bedrock"))
 

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -79,8 +79,12 @@ if os.getenv("MOONSHOT_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="kimi-k2.5", support_temperature=False))
 
 if os.getenv("DEEPSEEK_API_KEY") and os.getenv("DEEPSEEK_BASE_URL"):
-    AVAILABLE_MODELS.append(Model(name="deepseek-v4-pro", support_temperature=False, support_image_understanding=False))
-    AVAILABLE_MODELS.append(Model(name="deepseek-v4-flash", support_temperature=False, support_image_understanding=False))
+    AVAILABLE_MODELS.append(
+        Model(name="deepseek-v4-pro", support_temperature=False, support_image_understanding=False)
+    )
+    AVAILABLE_MODELS.append(
+        Model(name="deepseek-v4-flash", support_temperature=False, support_image_understanding=False)
+    )
 
 if os.getenv("BEDROCK_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="global.anthropic.claude-sonnet-4-6", provider="bedrock"))

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -19,6 +19,7 @@ import { GPT5_5Client } from "./gpt5_5";
 import { GLM5Client } from "./glm5";
 import { KimiK2_5Client } from "./kimi_k2_5";
 import { Qwen3Client } from "./qwen3";
+import { DeepSeekV4Client } from "./deepseek_v4";
 import { UniConfig, UniEvent, UniMessage } from "./types";
 
 /**
@@ -86,10 +87,12 @@ export class AutoLLMClient extends LLMClient {
       return new KimiK2_5Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("qwen3")) {
       return new Qwen3Client({ model, apiKey, baseUrl });
+    } else if (clientType.includes("deepseek-v4-")) {
+      return new DeepSeekV4Client({ model, apiKey, baseUrl });
     } else {
       throw new Error(
         `${clientType} is not supported. ` +
-          "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3.",
+          "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3, deepseek-v4.",
       );
     }
   }

--- a/src_ts/src/deepseek_v4/client.ts
+++ b/src_ts/src/deepseek_v4/client.ts
@@ -1,0 +1,409 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import OpenAI from "openai";
+import type {
+  ChatCompletionChunk,
+  ChatCompletionMessageParam,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions";
+import { LLMClient } from "../baseClient";
+import {
+  EventType,
+  FinishReason,
+  PartialContentItem,
+  PromptCaching,
+  ThinkingLevel,
+  ToolChoice,
+  UniConfig,
+  UniEvent,
+  UniMessage,
+  UsageMetadata,
+} from "../types";
+
+export class DeepSeekV4Client extends LLMClient {
+  protected _model: string;
+  private _client: OpenAI;
+
+  constructor(options: {
+    model: string;
+    apiKey?: string;
+    baseUrl?: string | null;
+    clientType?: string | null;
+  }) {
+    super();
+    this._model = options.model;
+    const key = options.apiKey || process.env.DEEPSEEK_API_KEY || undefined;
+    const url = options.baseUrl || process.env.DEEPSEEK_BASE_URL;
+    if (!url) {
+      throw new Error(
+        "DeepSeek base_url is required. Pass baseUrl or set DEEPSEEK_BASE_URL.",
+      );
+    }
+    this._client = new OpenAI({ apiKey: key, baseURL: url });
+  }
+
+  private _convertThinkingLevelToConfig(thinkingLevel: ThinkingLevel): {
+    type: string;
+  } {
+    const mapping: { [key: string]: { type: string } } = {
+      [ThinkingLevel.NONE]: { type: "disabled" },
+      [ThinkingLevel.LOW]: { type: "enabled" },
+      [ThinkingLevel.MEDIUM]: { type: "enabled" },
+      [ThinkingLevel.HIGH]: { type: "enabled" },
+    };
+    return mapping[thinkingLevel];
+  }
+
+  private _convertReasoningEffort(thinkingLevel: ThinkingLevel): string | null {
+    const mapping: { [key: string]: string | null } = {
+      [ThinkingLevel.NONE]: null,
+      [ThinkingLevel.LOW]: null,
+      [ThinkingLevel.MEDIUM]: "high",
+      [ThinkingLevel.HIGH]: "max",
+    };
+    return mapping[thinkingLevel];
+  }
+
+  private _convertToolChoice(toolChoice: ToolChoice): string {
+    if (toolChoice === "auto" || toolChoice === "none") {
+      return toolChoice;
+    }
+    throw new Error(
+      'DeepSeek tool_choice config expected one of "auto" or "none".',
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transformUniConfigToModelConfig(config: UniConfig): any {
+    if (
+      config.prompt_caching !== undefined &&
+      config.prompt_caching !== PromptCaching.ENABLE
+    ) {
+      throw new Error("prompt_caching must be ENABLE for DeepSeek.");
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deepseekConfig: any = {
+      model: this._model,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    if (config.max_tokens !== undefined) {
+      deepseekConfig.max_tokens = config.max_tokens;
+    }
+
+    if (config.temperature !== undefined) {
+      throw new Error("DeepSeek does not support temperature.");
+    }
+
+    if (config.thinking_level !== undefined) {
+      const thinkingConfig = this._convertThinkingLevelToConfig(
+        config.thinking_level,
+      );
+      deepseekConfig.extra_body = {
+        ...(deepseekConfig.extra_body || {}),
+        thinking: thinkingConfig,
+      };
+      const reasoningEffort = this._convertReasoningEffort(
+        config.thinking_level,
+      );
+      if (reasoningEffort !== null) {
+        deepseekConfig.reasoning_effort = reasoningEffort;
+      }
+    }
+
+    if (config.tools !== undefined) {
+      deepseekConfig.tools = config.tools.map((tool) => ({
+        type: "function",
+        function: tool,
+      }));
+    }
+
+    if (config.tool_choice !== undefined) {
+      deepseekConfig.tool_choice = this._convertToolChoice(config.tool_choice);
+    }
+
+    return deepseekConfig;
+  }
+
+  transformUniMessageToModelInput(
+    messages: UniMessage[],
+  ): ChatCompletionMessageParam[] {
+    const deepseekMessages: ChatCompletionMessageParam[] = [];
+
+    for (const msg of messages) {
+      const contentParts: Array<{
+        type: string;
+        text?: string;
+        image_url?: { url: string };
+      }> = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const toolCalls: any[] = [];
+      let thinking = "";
+
+      for (const item of msg.content_items) {
+        if (item.type === "text") {
+          contentParts.push({ type: "text", text: item.text });
+        } else if (item.type === "image_url") {
+          throw new Error("DeepSeek does not support image url inputs.");
+        } else if (item.type === "inline_data") {
+          throw new Error("DeepSeek does not support inline data inputs.");
+        } else if (item.type === "thinking") {
+          thinking += item.thinking;
+        } else if (item.type === "inline_thinking") {
+          throw new Error("DeepSeek does not support inline thinking inputs.");
+        } else if (item.type === "tool_call") {
+          toolCalls.push({
+            id: item.tool_call_id,
+            type: "function",
+            function: {
+              name: item.name,
+              arguments: JSON.stringify(item.arguments, null, 0),
+            },
+          });
+        } else if (item.type === "tool_result") {
+          if (!item.tool_call_id) {
+            throw new Error("tool_call_id is required for tool result.");
+          }
+
+          if (item.images && item.images.length > 0) {
+            throw new Error("DeepSeek does not support images in tool results.");
+          }
+
+          deepseekMessages.push({
+            role: "tool",
+            tool_call_id: item.tool_call_id,
+            content: [{ type: "text" as const, text: item.text }],
+          });
+        } else {
+          throw new Error(
+            `Unknown item type: ${(item as { type: string }).type}`,
+          );
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const message: any = { role: msg.role };
+      if (contentParts.length > 0) {
+        message.content = contentParts;
+      }
+
+      if (toolCalls.length > 0) {
+        message.tool_calls = toolCalls;
+      }
+
+      if (thinking) {
+        message.reasoning_content = thinking;
+      }
+
+      if (Object.keys(message).length > 1) {
+        deepseekMessages.push(message);
+      }
+    }
+
+    return deepseekMessages;
+  }
+
+  transformModelOutputToUniEvent(modelOutput: ChatCompletionChunk): UniEvent {
+    let eventType: EventType | null = null;
+    const contentItems: PartialContentItem[] = [];
+    let usageMetadata: UsageMetadata | null = null;
+    let finishReason: FinishReason | null = null;
+
+    if (modelOutput.choices.length > 0) {
+      const choice = modelOutput.choices[0];
+      const delta = choice?.delta;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((delta as any)?.reasoning_content) {
+        eventType = "delta";
+        contentItems.push({
+          type: "thinking",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          thinking: (delta as any).reasoning_content,
+        });
+      }
+
+      if (delta?.content) {
+        eventType = "delta";
+        contentItems.push({ type: "text", text: delta.content });
+      }
+
+      if (delta?.tool_calls) {
+        eventType = "delta";
+        for (const toolCall of delta.tool_calls) {
+          contentItems.push({
+            type: "partial_tool_call",
+            name: toolCall.function?.name || "",
+            arguments: toolCall.function?.arguments || "",
+            tool_call_id: toolCall.id || "",
+          });
+        }
+      }
+
+      if (choice?.finish_reason) {
+        eventType = eventType || "stop";
+        const finishReasonMapping: { [key: string]: FinishReason } = {
+          stop: "stop",
+          length: "length",
+          tool_calls: "tool_call",
+          content_filter: "stop",
+        };
+        finishReason = finishReasonMapping[choice.finish_reason] || "unknown";
+      }
+    }
+
+    if (modelOutput.usage) {
+      eventType = eventType || "stop";
+      const completionTokenDetails = modelOutput.usage.completion_tokens_details;
+      const reasoningTokens = completionTokenDetails
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (completionTokenDetails as any).reasoning_tokens ?? null
+        : null;
+      const responseTokens =
+        modelOutput.usage.completion_tokens - (reasoningTokens || 0);
+
+      // usage.prompt_tokens = prompt_cache_hit_tokens + prompt_cache_miss_tokens
+      usageMetadata = {
+        cached_tokens:
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (modelOutput.usage as any).prompt_cache_hit_tokens ?? null,
+        prompt_tokens:
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (modelOutput.usage as any).prompt_cache_miss_tokens ?? null,
+        thoughts_tokens: reasoningTokens,
+        response_tokens: responseTokens,
+      };
+    }
+
+    return {
+      role: "assistant",
+      event_type: eventType as EventType,
+      content_items: contentItems,
+      usage_metadata: usageMetadata,
+      finish_reason: finishReason,
+    };
+  }
+
+  async *_streamingResponseInternal(options: {
+    messages: UniMessage[];
+    config: UniConfig;
+  }): AsyncGenerator<UniEvent> {
+    const deepseekConfig = this.transformUniConfigToModelConfig(options.config);
+    const deepseekMessages = this.transformUniMessageToModelInput(
+      options.messages,
+    );
+
+    if (options.config.system_prompt) {
+      deepseekMessages.unshift({
+        role: "system",
+        content: options.config.system_prompt,
+      });
+    }
+
+    const params: ChatCompletionCreateParamsStreaming = {
+      ...deepseekConfig,
+      messages: deepseekMessages,
+      stream: true,
+    };
+
+    const stream = await this._client.chat.completions.create(params);
+
+    const partialToolCall: {
+      name?: string;
+      arguments?: string;
+      tool_call_id?: string;
+    } = {};
+    let partialUsage: {
+      finish_reason?: FinishReason | null;
+      usage_metadata?: UsageMetadata | null;
+    } = {};
+
+    for await (const chunk of stream) {
+      const event = this.transformModelOutputToUniEvent(chunk);
+      partialUsage.finish_reason =
+        event.finish_reason || partialUsage.finish_reason;
+      partialUsage.usage_metadata =
+        event.usage_metadata || partialUsage.usage_metadata;
+
+      if (event.event_type === "delta") {
+        for (const item of event.content_items) {
+          if (item.type === "partial_tool_call") {
+            if (!partialToolCall.name) {
+              partialToolCall.name = item.name;
+              partialToolCall.arguments = item.arguments;
+              partialToolCall.tool_call_id = item.tool_call_id;
+            } else if (item.name) {
+              yield {
+                role: "assistant",
+                event_type: "delta",
+                content_items: [
+                  {
+                    type: "tool_call",
+                    name: partialToolCall.name,
+                    arguments: JSON.parse(partialToolCall.arguments || "{}"),
+                    tool_call_id: partialToolCall.tool_call_id || "",
+                  },
+                ],
+                usage_metadata: null,
+                finish_reason: null,
+              };
+              partialToolCall.name = item.name;
+              partialToolCall.arguments = item.arguments;
+              partialToolCall.tool_call_id = item.tool_call_id;
+            } else {
+              partialToolCall.arguments =
+                (partialToolCall.arguments || "") + item.arguments;
+            }
+          }
+        }
+        yield event;
+      } else if (event.event_type === "stop") {
+        if (partialToolCall.name) {
+          yield {
+            role: "assistant",
+            event_type: "delta",
+            content_items: [
+              {
+                type: "tool_call",
+                name: partialToolCall.name,
+                arguments: JSON.parse(partialToolCall.arguments || "{}"),
+                tool_call_id: partialToolCall.tool_call_id || "",
+              },
+            ],
+            usage_metadata: null,
+            finish_reason: null,
+          };
+          partialToolCall.name = undefined;
+          partialToolCall.arguments = undefined;
+          partialToolCall.tool_call_id = undefined;
+        }
+
+        if (partialUsage.finish_reason && partialUsage.usage_metadata) {
+          yield {
+            role: "assistant",
+            event_type: "stop",
+            content_items: [],
+            usage_metadata: partialUsage.usage_metadata,
+            finish_reason: partialUsage.finish_reason,
+          };
+          partialUsage.finish_reason = null;
+          partialUsage.usage_metadata = null;
+        }
+      }
+    }
+  }
+}

--- a/src_ts/src/deepseek_v4/index.ts
+++ b/src_ts/src/deepseek_v4/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { DeepSeekV4Client } from "./client";

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -98,11 +98,13 @@ export function createChatApp(): Express {
                       <option value="glm-5">GLM 5</option>
                       <option value="gemini-3.1-flash-image-preview">Gemini 3.1 Flash Image (Nano Banana 2)</option>
                       <option value="gemini-3.1-flash-tts-preview">Gemini 3.1 Flash TTS</option>
+                      <option value="deepseek-v4-pro">DeepSeek V4 Pro</option>
+                      <option value="deepseek-v4-flash">DeepSeek V4 Flash</option>
                   </datalist>
               </div>
               <div class="flex flex-col">
                   <label class="text-sm font-semibold text-gray-900 mb-1" for="temperatureInput">Temperature</label>
-                  <input type="number" id="temperatureInput" min="0" max="2" step="0.1" value="1.0" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                  <input type="number" id="temperatureInput" min="0" max="2" step="0.1" value="" class="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
               </div>
               <div class="flex flex-col">
                   <label class="text-sm font-semibold text-gray-900 mb-1" for="maxTokensInput">Max Tokens</label>
@@ -314,9 +316,12 @@ export function createChatApp(): Express {
           function getConfig() {
               const config = {
                   model: document.getElementById('modelSelect').value,
-                  temperature: parseFloat(document.getElementById('temperatureInput').value),
                   max_tokens: parseInt(document.getElementById('maxTokensInput').value)
               };
+                temperature = document.getElementById('temperatureInput').value
+                if (temperature) {
+                    config.temperature = parseFloat(temperature);
+                }
 
               const thinkingLevel = document.getElementById('thinkingLevelSelect').value;
               if (thinkingLevel) {

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -117,6 +117,28 @@ if (process.env.MOONSHOT_API_KEY) {
   });
 }
 
+if (process.env.DEEPSEEK_API_KEY && process.env.DEEPSEEK_BASE_URL) {
+  AVAILABLE_MODELS.push({
+    name: "deepseek-v4-pro",
+    supportTextGeneration: true,
+    supportTemperature: false,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: false,
+    provider: "official",
+  });
+
+  AVAILABLE_MODELS.push({
+    name: "deepseek-v4-flash",
+    supportTextGeneration: true,
+    supportTemperature: false,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: false,
+    provider: "official",
+  });
+}
+
 if (process.env.BEDROCK_API_KEY) {
   AVAILABLE_MODELS.push({
     name: "global.anthropic.claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Add DeepSeek V4 support across AgentHub Python and TypeScript clients, covering `deepseek-v4-pro` and `deepseek-v4-flash`.

## Changes

- Add DeepSeek V4 provider clients for Python and TypeScript.
- Route `deepseek-v4-*` model IDs through `AutoLLMClient`.
- Fix playground config handling so `temperature` is omitted unless explicitly set.
- Add DeepSeek SDK/API documentation and list the supported DeepSeek V4 models in README and AgentHub skills.
