### PR TITLE
Add Gemini embedding support

### DIFF
--- a/llmsdk_docs/gemini3/docs/embeddings.md
+++ b/llmsdk_docs/gemini3/docs/embeddings.md
@@ -1,0 +1,844 @@
+<br />
+
+> [!IMPORTANT]
+> We have updated our [Terms of Service](https://ai.google.dev/gemini-api/terms).
+
+The Gemini API offers embedding models to generate embeddings for text, images,
+video, and other content. These resulting embeddings can then be used for tasks
+such as semantic search, classification, and clustering, providing more accurate,
+context-aware results than keyword-based approaches.
+
+The latest model, `gemini-embedding-2`, is the first multimodal
+embedding model in the Gemini API. It maps text, images,
+video, audio, and documents into a unified embedding space, enabling cross-modal
+search, classification, and clustering across over 100 languages. See the
+[multimodal embeddings section](https://ai.google.dev/gemini-api/docs/embeddings#multimodal) to learn more. For text-only
+use cases, `gemini-embedding-001` remains available.
+
+Building Retrieval Augmented Generation (RAG) systems is a common use case for
+AI products. Embeddings play a key role in significantly enhancing model outputs
+with improved factual accuracy, coherence, and contextual richness. If you prefer
+to use a managed RAG solution, we built the [File Search](https://ai.google.dev/gemini-api/docs/file-search)
+tool which makes doing RAG easier to manage and more cost effective.
+
+## Generating embeddings
+
+Use the `embedContent` method to generate text embeddings:
+
+### Python
+
+    from google import genai
+
+    client = genai.Client()
+
+    result = client.models.embed_content(
+            model="gemini-embedding-2",
+            contents="What is the meaning of life?"
+    )
+
+    print(result.embeddings)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+
+    async function main() {
+
+        const ai = new GoogleGenAI({});
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: 'What is the meaning of life?',
+        });
+
+        console.log(response.embeddings);
+    }
+
+    main();
+
+
+> [!NOTE]
+> **Note:** While `gemini-embedding-001` lets you generate individual embeddings for a list of strings, Gemini Embedding 2 produces a single aggregated embedding for multiple inputs. You can find more information in [Embedding aggregation](https://ai.google.dev/gemini-api/docs/embeddings#embedding-aggregation), or you can use the [Batch API](https://ai.google.dev/gemini-api/docs/batch-api#batch-embedding) if you want to generate multiple embeddings at once.
+
+## Specify task type to improve performance
+
+You can use embeddings for a wide range of tasks from classification to document
+search. Specifying the right task type helps optimize the embeddings for the
+intended relationships, maximizing accuracy and efficiency.
+
+### Task types with Embeddings 2
+
+For text-only tasks with `gemini-embedding-2`, we strongly recommend you
+add the task instruction in your prompt. This can be done by formatting the
+query and the document with the correct task prefix.
+
+The following tables show examples of how to format queries and documents for
+symmetric and asymmetric use cases using the `gemini-embedding-2` model.
+
+**Retrieval use cases (Asymmetric format)**
+
+In asymmetric use cases, add the task prefix to the query and apply
+the document structure for the content you want to embed and retrieve.
+
+| Use case | Query structure | Document structure |
+|---|---|---|
+| Search query | `task: search result | query: {content}` | `title: {title} | text: {content}` If there is no title, use `title: none`. |
+| Question answering | `task: question answering | query: {content}` | `title: {title} | text: {content}` |
+| Fact checking | `task: fact checking | query: {content}` | `title: {title} | text: {content}` |
+| Code retrieval | `task: code retrieval | query: {content}` | `title: {title} | text: {content}` |
+
+**Example usage**
+
+### Python
+
+    # Generate embedding for a task's query. Use your correct task here:
+    def prepare_query(query):
+        # return f"task: question answering | query: {query}"
+        # return f"task: fact checking | query: {query}"
+        # return f"task: code retrieval | query: {query}"
+        return f"task: search result | query: {query}"
+
+    # Generate embedding for document of an asymmetric retrieval task:
+    def prepare_document(content, title=None):
+        if title is None:
+            title = "none"
+        return f"title: {title} | text: {content}"
+
+**Single-input use cases (Symmetric format)**
+
+In symmetric use cases, for the same task, use the same formatting
+for the query and the document.
+
+| Use case | Input structure |
+|---|---|
+| Classification | `task: classification | query: {content}` |
+| Clustering | `task: clustering | query: {content}` |
+| Semantic similarity | `task: sentence similarity | query: {content}` Do not use this for search or retrieval. It is intended for semantic textual similarity. |
+
+**Example usage**
+
+### Python
+
+    # Generate embedding for query & document of your task.
+    def prepare_query_and_document(content):
+        # return f'task: clustering | query: {content}'
+        # return f'task: sentence similarity | query: {content}'
+        return f'task: classification | query: {content}'
+
+It is important that the task is used consistently. E.g., if documents are
+embedded with `f'task: classification | query: {content}'`, the query should
+also be embedded following this task format.
+
+### Task types with Embeddings 1
+
+For `gemini-embedding-001`, you can specify the `task_type` in the `embedContent`
+method. For a complete list of supported task types, see the [Supported task types](https://ai.google.dev/gemini-api/docs/embeddings#supported-task-types)
+table.
+
+> [!NOTE]
+> **Note:** You cannot use the `task_type` field for the `gemini-embedding-2` model. Instead, include the task as an instruction in your prompt, as detailed in the [above section](https://ai.google.dev/gemini-api/docs/embeddings#task-types-embeddings-2).
+
+The following example shows how you can use `SEMANTIC_SIMILARITY` to check how
+similar in meaning strings of texts are.
+
+### Python
+
+    from google import genai
+    from google.genai import types
+    import pandas as pd
+    from sklearn.metrics.pairwise import cosine_similarity
+
+    client = genai.Client()
+
+    texts = [
+        "What is the meaning of life?",
+        "What is the purpose of existence?",
+        "How do I bake a cake?",
+    ]
+
+    result = client.models.embed_content(
+        model="gemini-embedding-001",
+        contents=texts,
+        config=types.EmbedContentConfig(task_type="SEMANTIC_SIMILARITY")
+    )
+
+    # Create a 3x3 table to show the similarity matrix
+    df = pd.DataFrame(
+        cosine_similarity([e.values for e in result.embeddings]),
+        index=texts,
+        columns=texts,
+    )
+
+    print(df)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    // npm i compute-cosine-similarity
+    import * as cosineSimilarity from "compute-cosine-similarity";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const texts = [
+            "What is the meaning of life?",
+            "What is the purpose of existence?",
+            "How do I bake a cake?",
+        ];
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-001',
+            contents: texts,
+            config: { taskType: 'SEMANTIC_SIMILARITY' },
+        });
+
+        const embeddings = response.embeddings.map(e => e.values);
+
+        for (let i = 0; i < texts.length; i++) {
+            for (let j = i + 1; j < texts.length; j++) {
+                const text1 = texts[i];
+                const text2 = texts[j];
+                const similarity = cosineSimilarity(embeddings[i], embeddings[j]);
+                console.log(`Similarity between '${text1}' and '${text2}': ${similarity.toFixed(4)}`);
+            }
+        }
+    }
+
+    main();
+
+
+The code snippets will show how similar the different chunks of text are to one
+another when run.
+
+> [!NOTE]
+> **Note:** Cosine similarity is a good distance metric because it focuses on direction rather than magnitude, which more accurately reflects conceptual closeness. Values range from -1 (opposite) to 1 (greatest similarity).
+
+#### Supported task types
+
+Supported task types for `gemini-embedding-001`:
+
+| Task type | Description | Examples |
+|---|---|---|
+| **SEMANTIC_SIMILARITY** | Embeddings optimized to assess text similarity. | Recommendation systems, duplicate detection |
+| **CLASSIFICATION** | Embeddings optimized to classify texts according to preset labels. | Sentiment analysis, spam detection |
+| **CLUSTERING** | Embeddings optimized to cluster texts based on their similarities. | Document organization, market research, anomaly detection |
+| **RETRIEVAL_DOCUMENT** | Embeddings optimized for document search. | Indexing articles, books, or web pages for search. |
+| **RETRIEVAL_QUERY** | Embeddings optimized for general search queries. Use `RETRIEVAL_QUERY` for queries; `RETRIEVAL_DOCUMENT` for documents to be retrieved. | Custom search |
+| **CODE_RETRIEVAL_QUERY** | Embeddings optimized for retrieval of code blocks based on natural language queries. Use `CODE_RETRIEVAL_QUERY` for queries; `RETRIEVAL_DOCUMENT` for code blocks to be retrieved. | Code suggestions and search |
+| **QUESTION_ANSWERING** | Embeddings for questions in a question-answering system, optimized for finding documents that answer the question. Use `QUESTION_ANSWERING` for questions; `RETRIEVAL_DOCUMENT` for documents to be retrieved. | Chatbox |
+| **FACT_VERIFICATION** | Embeddings for statements that need to be verified, optimized for retrieving documents that contain evidence supporting or refuting the statement. Use `FACT_VERIFICATION` for the target text; `RETRIEVAL_DOCUMENT` for documents to be retrieved | Automated fact-checking systems |
+
+## Controlling embedding size
+
+Both `gemini-embedding-001` and `gemini-embedding-2` are trained using
+the Matryoshka Representation Learning (MRL) technique which teaches a model to
+learn high-dimensional embeddings that have initial segments (or prefixes) which
+are also useful, simpler versions of the same data.
+
+Use the `output_dimensionality` parameter to control the size of
+the output embedding vector. Selecting a smaller output dimensionality can save
+storage space and increase computational efficiency for downstream applications,
+while sacrificing little in terms of quality. By default, both models output a
+3072-dimensional embedding, but you can truncate it to a smaller size without
+losing quality to save storage space. We recommend using 768, 1536, or 3072
+output dimensions.
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+
+    result = client.models.embed_content(
+        model="gemini-embedding-2",
+        contents="What is the meaning of life?",
+        config=types.EmbedContentConfig(output_dimensionality=768)
+    )
+
+    [embedding_obj] = result.embeddings
+    embedding_length = len(embedding_obj.values)
+
+    print(f"Length of embedding: {embedding_length}")
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: 'What is the meaning of life?',
+            config: { outputDimensionality: 768 },
+        });
+
+        const embeddingLength = response.embeddings[0].values.length;
+        console.log(`Length of embedding: ${embeddingLength}`);
+    }
+
+    main();
+
+
+Example output from the code snippet:
+
+    Length of embedding: 768
+
+## Ensuring quality for smaller dimensions
+
+> [!NOTE]
+> **Note:** `gemini-embedding-2` introduces automatic renormalization for non-default dimensions.
+
+While the default 3072-dimension embeddings are always normalized, Gemini
+Embedding 2 also auto-normalizes truncated dimensions (e.g., 768, 1536). This
+ensures semantic similarity is calculated via vector direction rather than
+magnitude, providing more accurate results out of the box.
+
+**Older Models** : If you are using `gemini-embedding-001`, you must manually
+normalize non-3072 dimensions as follows:
+
+### Python
+
+    import numpy as np
+    from numpy.linalg import norm
+
+    # Only for embeddings from `gemini-embedding-001`
+    embedding_values_np = np.array(embedding_obj.values)
+    normed_embedding = embedding_values_np / np.linalg.norm(embedding_values_np)
+
+    print(f"Normed embedding length: {len(normed_embedding)}")
+    print(f"Norm of normed embedding: {np.linalg.norm(normed_embedding):.6f}") # Should be very close to 1
+
+Example output from this code snippet:
+
+    Normed embedding length: 768
+    Norm of normed embedding: 1.000000
+
+The following table shows the MTEB scores, a commonly used benchmark for
+embeddings, for different dimensions. Notably, the result shows that performance
+is not strictly tied to the size of the embedding dimension, with lower
+dimensions achieving scores comparable to their higher dimension counterparts.
+
+| MRL Dimension | MTEB Score (Gemini Embedding 001) |
+|---|---|
+| 2048 | 68.16 |
+| 1536 | 68.17 |
+| 768 | 67.99 |
+| 512 | 67.55 |
+| 256 | 66.19 |
+| 128 | 63.31 |
+
+## Multimodal embeddings
+
+The `gemini-embedding-2` model supports multimodal input, allowing you
+to embed images, video, audio, and documents content alongside text. All modalities
+are mapped into the same embedding space, enabling cross-modal search and
+comparison.
+
+### Supported modalities and limits
+
+The overall maximum input tokens limit is 8192 tokens.
+
+| Modality | Specifications and limits |
+|---|---|
+| **Text** | Supports up to 8,192 tokens. |
+| **Image** | Maximum of 6 images per request. Supported formats: PNG, JPEG. |
+| **Audio** | Maximum duration of 180 seconds. Supported formats: MP3, WAV. |
+| **Video** | Maximum duration of 120 seconds. Supported formats: MP4, MOV. Supported codecs: H264, H265, AV1, VP9. The system processes a maximum of 32 frames per video: short videos (≤32s) are sampled at 1 fps, while longer videos are uniformly sampled to 32 frames. Audio tracks are not processed in video files. |
+| **Documents (PDF)** | Maximum of 6 pages. |
+
+### Embedding images
+
+The following example shows how to embed an image using
+`gemini-embedding-2`.
+
+Images can be provided as inline data or as uploaded files
+through the [Files API](https://ai.google.dev/gemini-api/docs/files).
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    with open('example.png', 'rb') as f:
+        image_bytes = f.read()
+
+    client = genai.Client()
+
+    result = client.models.embed_content(
+        model='gemini-embedding-2',
+        contents=[
+            types.Part.from_bytes(
+                data=image_bytes,
+                mime_type='image/png',
+            ),
+        ]
+    )
+
+    print(result.embeddings)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const imgBase64 = fs.readFileSync("example.png", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [{
+                inlineData: {
+                    mimeType: 'image/png',
+                    data: imgBase64,
+                },
+            }],
+        });
+
+        console.log(response.embeddings);
+    }
+
+    main();
+
+
+### Embedding aggregation
+
+When working with multimodal content, how you structure your input affects the
+embedding output:
+
+- **Multiple parts (aggregated):** Adding multiple inputs directly to the `contents` parameter produces one aggregated embedding for all inputs.
+- **Multiple `Content` objects (separate):** Wrapping each input in a `Content` object and passing them in the `contents` parameter returns separate embeddings for each entry.
+- **Post-level representation:** For complex objects like social media posts with multiple media items, we recommend aggregating separate embeddings (for example, by averaging) to create a coherent post-level representation.
+
+The following example shows how to create one aggregated embedding for text and
+image input. Simply add multiple inputs to the `contents` parameter:
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+
+    with open('dog.png', 'rb') as f:
+        image_bytes = f.read()
+
+    result = client.models.embed_content(
+        model='gemini-embedding-2',
+        contents=[
+            "An image of a dog",
+            types.Part.from_bytes(
+                data=image_bytes,
+                mime_type='image/png',
+            ),
+        ]
+    )
+
+    # This produces one embedding
+    for embedding in result.embeddings:
+        print(embedding.values)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const imgBase64 = fs.readFileSync("dog.png", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [
+                'An image of a dog',
+                {
+                    inlineData: {
+                        mimeType: 'image/png',
+                        data: imgBase64,
+                    },
+                },
+            ],
+        });
+
+        // This produces one embedding
+        for (const embedding of response.embeddings) {
+            console.log(embedding.values);
+        }
+    }
+
+    main();
+
+
+On the other hand, if you use `Content` objects inside the `contents` parameter,
+it returns separate embeddings. This example creates multiple embeddings in one
+embedding call:
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+
+    with open('dog.png', 'rb') as f:
+        image_bytes = f.read()
+
+    result = client.models.embed_content(
+        model="gemini-embedding-2",
+        contents=[
+            types.Content(parts=[types.Part.from_text(text="An image of a dog")]),
+            types.Content(
+                parts=[
+                    types.Part.from_bytes(
+                        data=image_bytes,
+                        mime_type="image/png",
+                    ),
+                ]
+            ),
+        ],
+    )
+
+    # This produces two embeddings
+    for embedding in result.embeddings:
+        print(embedding.values)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const imgBase64 = fs.readFileSync("dog.png", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [
+                { parts: [{ text: 'An image of a dog' }] },
+                {
+                    parts: [{
+                        inlineData: {
+                            mimeType: 'image/png',
+                            data: imgBase64,
+                        },
+                    }],
+                },
+            ],
+        });
+
+        // This produces two embeddings
+        for (const embedding of response.embeddings) {
+            console.log(embedding.values);
+        }
+    }
+
+    main();
+
+
+### Embedding audio
+
+The following example shows how to embed an audio file using
+`gemini-embedding-2`.
+
+Audio files can be provided as inline data or as uploaded files
+through the [Files API](https://ai.google.dev/gemini-api/docs/files).
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    with open('example.mp3', 'rb') as f:
+        audio_bytes = f.read()
+
+    client = genai.Client()
+
+    result = client.models.embed_content(
+        model='gemini-embedding-2',
+        contents=[
+            types.Part.from_bytes(
+                data=audio_bytes,
+                mime_type='audio/mpeg',
+            ),
+        ]
+    )
+
+    print(result.embeddings)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const audioBase64 = fs.readFileSync("example.mp3", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [{
+                inlineData: {
+                    mimeType: 'audio/mpeg',
+                    data: audioBase64,
+                },
+            }],
+        });
+
+        console.log(response.embeddings);
+    }
+
+    main();
+
+
+### Embedding video
+
+The following example shows how to embed a video using
+`gemini-embedding-2`.
+
+Videos can be provided as inline data or as uploaded files
+through the [Files API](https://ai.google.dev/gemini-api/docs/files).
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+
+    with open('example.mp4', 'rb') as f:
+        video_bytes = f.read()
+
+    result = client.models.embed_content(
+        model='gemini-embedding-2',
+        contents=[
+            types.Part.from_bytes(
+                data=video_bytes,
+                mime_type='video/mp4',
+            ),
+        ]
+    )
+
+    print(result.embeddings[0].values)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const videoBase64 = fs.readFileSync("example.mp4", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [{
+                inlineData: {
+                    mimeType: 'video/mp4',
+                    data: videoBase64,
+                },
+            }],
+        });
+
+        console.log(response.embeddings);
+    }
+
+    main();
+
+
+If you need to embed videos \>120 seconds, you can chunk the video into
+overlapping segments and embed those chunks individually.
+
+### Embedding documents
+
+documents in PDF format can be embedded directly. The model processes the visual and text
+content of each page.
+
+PDFs can be provided as inline data or as uploaded files
+through the [Files API](https://ai.google.dev/gemini-api/docs/files).
+
+### Python
+
+    from google import genai
+    from google.genai import types
+
+    with open('example.pdf', 'rb') as f:
+        pdf_bytes = f.read()
+
+    client = genai.Client()
+
+    result = client.models.embed_content(
+        model='gemini-embedding-2',
+        contents=[
+            types.Part.from_bytes(
+                data=pdf_bytes,
+                mime_type='application/pdf',
+            ),
+        ]
+    )
+
+    print(result.embeddings)
+
+### JavaScript
+
+    import { GoogleGenAI } from "@google/genai";
+    import * as fs from "node:fs";
+
+    async function main() {
+        const ai = new GoogleGenAI({});
+
+        const pdfBase64 = fs.readFileSync("example.pdf", { encoding: "base64" });
+
+        const response = await ai.models.embedContent({
+            model: 'gemini-embedding-2',
+            contents: [{
+                inlineData: {
+                    mimeType: 'application/pdf',
+                    data: pdfBase64,
+                },
+            }],
+        });
+
+        console.log(response.embeddings);
+    }
+
+    main();
+
+
+## Use cases
+
+Text embeddings are crucial for a variety of common AI use cases, such as:
+
+- **Retrieval-Augmented Generation (RAG):** Embeddings enhance the quality of generated text by retrieving and incorporating relevant information into the context of a model.
+- **Information retrieval:** Search for the most semantically similar text or
+  documents given a piece of input text.
+
+  [Document search tutorial](https://github.com/google-gemini/cookbook/blob/main/examples/Talk_to_documents_with_embeddings.ipynb)
+- **Search reranking**: Prioritize the most relevant items by semantically
+  scoring initial results against the query.
+
+  [Search reranking tutorial](https://github.com/google-gemini/cookbook/blob/main/examples/Search_reranking_using_embeddings.ipynb)
+- **Anomaly detection:** Comparing groups of embeddings can help identify
+  hidden trends or outliers.
+
+  [Anomaly detection tutorial](https://github.com/google-gemini/cookbook/blob/main/examples/Anomaly_detection_with_embeddings.ipynb)
+- **Classification:** Automatically categorize text based on its content, such
+  as sentiment analysis or spam detection
+
+  [Classification tutorial](https://github.com/google-gemini/cookbook/blob/main/examples/Classify_text_with_embeddings.ipynb)
+- **Clustering:** Effectively grasp complex relationships by creating clusters
+  and visualizations of your embeddings.
+
+  [Clustering visualization tutorial](https://github.com/google-gemini/cookbook/blob/main/examples/clustering_with_embeddings.ipynb)
+
+## Storing embeddings
+
+As you take embeddings to production, it is common to
+use **vector databases** to efficiently store, index, and retrieve
+high-dimensional embeddings. Google Cloud offers managed data services that
+can be used for this purpose including
+[Gemini Enterprise Agent Platform Vector Search 2.0](https://docs.cloud.google.com/gemini-enterprise-agent-platform/BUILD/vector-search-2),
+[BigQuery](https://cloud.google.com/bigquery/docs/introduction),
+[AlloyDB](https://cloud.google.com/alloydb/docs/overview), and
+[Cloud SQL](https://cloud.google.com/sql/docs/postgres/introduction).
+
+The following tutorials show how to use other third party vector databases
+with Gemini Embedding.
+
+- [ChromaDB tutorials](https://docs.trychroma.com/integrations/embedding-models/google-gemini)
+- [QDrant tutorials](https://qdrant.tech/documentation/embeddings/gemini/)
+- [Weaviate tutorials](https://docs.weaviate.io/weaviate/model-providers/google)
+- [Pinecone tutorials](https://github.com/google-gemini/cookbook/blob/main/examples/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb)
+
+## Model versions
+
+### Gemini Embedding 2
+
+| Property | Description |
+|---|---|
+| Model code | **Gemini API** `gemini-embedding-2` |
+| Supported data types | **Input** Text, image, video, audio, PDF **Output** Text embeddings |
+| Token limits^[\[\*\]](https://ai.google.dev/gemini-api/docs/tokens)^ | **Input token limit** 8,192 **Output dimension size** Flexible, supports: 128 - 3072, Recommended: 768, 1536, 3072 |
+| Versions | Read the [model version patterns](https://ai.google.dev/gemini-api/docs/models/gemini#model-versions) for more details. - Stable: `gemini-embedding-2` |
+| Latest update | April 2026 |
+
+### Gemini Embedding
+
+| Property | Description |
+|---|---|
+| Model code | **Gemini API** `gemini-embedding-001` |
+| Supported data types | **Input** Text **Output** Text embeddings |
+| Token limits^[\[\*\]](https://ai.google.dev/gemini-api/docs/tokens)^ | **Input token limit** 2,048 **Output dimension size** Flexible, supports: 128 - 3072, Recommended: 768, 1536, 3072 |
+| Versions | Read the [model version patterns](https://ai.google.dev/gemini-api/docs/models/gemini#model-versions) for more details. - Stable: `gemini-embedding-001` |
+| Latest update | June 2025 |
+
+For deprecated Embeddings models, visit the [Deprecations](https://ai.google.dev/gemini-api/docs/deprecations) page
+
+## Migration from gemini-embedding-001
+
+The embedding spaces between `gemini-embedding-001` and
+`gemini-embedding-2` are **incompatible** . This means you cannot
+directly compare embeddings generated by one model with embeddings generated by
+the other. If you are upgrading to `gemini-embedding-2`, you must
+re-embed all of your existing data.
+
+Beyond incompatibility, there are several other notable differences between
+the two models:
+
+- **Task type specification:** With `gemini-embedding-001`, you specify the
+  task type using the `task_type` parameter (e.g., `SEMANTIC_SIMILARITY`,
+  `RETRIEVAL_DOCUMENT`). With `gemini-embedding-2`, the `task_type`
+  parameter is not supported. Instead, you should include task instructions
+  directly in the prompt for text-only tasks. See
+  [Task types with Embeddings 2](https://ai.google.dev/gemini-api/docs/embeddings#task-types-embeddings-2) for details on how
+  to format prompts for different use cases.
+
+- **Embedding aggregation:** `gemini-embedding-001` generates individual
+  embeddings for each string in a list of inputs. In contrast,
+  `gemini-embedding-2` produces a single, aggregated embedding when multiple
+  inputs (like text and images) are provided directly in one request. To
+  generate separate embeddings for individual inputs, wrap each input in a
+  `Content` object, or use the
+  [Batch API](https://ai.google.dev/gemini-api/docs/batch-api#batch-embedding). See
+  [Embedding aggregation](https://ai.google.dev/gemini-api/docs/embeddings#embedding-aggregation) for more information.
+
+- **Normalization:** If you use `output_dimensionality` to request embeddings
+  with fewer than 3072 dimensions, `gemini-embedding-2` automatically
+  normalizes these truncated embeddings. With `gemini-embedding-001`, you
+  need to perform manual normalization for dimensions other than 3072. See
+  [Ensuring quality for smaller dimensions](https://ai.google.dev/gemini-api/docs/embeddings#quality-for-smaller-dimensions)
+  for details.
+
+## Batch embeddings
+
+If latency is not a concern, try using the Gemini Embeddings models with
+[Batch API](https://ai.google.dev/gemini-api/docs/batch-api#batch-embedding). This
+allows for much higher throughput at 50% of the default Embedding price.
+Find examples on how to get started in the [Batch API cookbook](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Batch_mode.ipynb).
+
+## Responsible use notice
+
+Unlike generative AI models that create new content, the Gemini Embedding model
+is only intended to transform the format of your input data into a numerical
+representation. While Google is responsible for providing an embedding model
+that transforms the format of your input data to the numerical-format requested,
+users retain full responsibility for the data they input and the resulting
+embeddings. By using the Gemini Embedding model you confirm that you have the
+necessary rights to any content that you upload. Do not generate content that
+infringes on others' intellectual property or privacy rights. Your use of this
+service is subject to our [Prohibited Use
+Policy](https://policies.google.com/terms/generative-ai/use-policy) and
+[Google's Terms of Service](https://ai.google.dev/gemini-api/terms).
+
+## Start building with embeddings
+
+Check out the [embeddings quickstart
+notebook](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Embeddings.ipynb)
+to explore the model capabilities and learn how to customize and visualize your
+embeddings.

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -16,7 +16,7 @@ import os
 from typing import Any, AsyncIterator
 
 from .base_client import LLMClient
-from .types import UniConfig, UniEvent, UniMessage
+from .types import EmbeddingInputContentItem, EmbeddingResponse, UniConfig, UniEmbeddingConfig, UniEvent, UniMessage
 
 
 class AutoLLMClient(LLMClient):
@@ -46,7 +46,9 @@ class AutoLLMClient(LLMClient):
     ) -> LLMClient:
         """Create the appropriate client for the given model."""
         client_type = client_type or os.getenv("CLIENT_TYPE", model.lower())
-        if "gemini-3-" in client_type or "gemini-3.1-" in client_type:  # e.g., gemini-3-flash-preview
+        if any(
+            prefix in client_type for prefix in ("gemini-3-", "gemini-3.1-", "gemini-embedding")
+        ):  # e.g., gemini-3-flash-preview, gemini-embedding-2
             from .gemini3 import Gemini3Client
 
             return Gemini3Client(model=model, api_key=api_key, base_url=base_url)
@@ -73,7 +75,7 @@ class AutoLLMClient(LLMClient):
         else:
             raise ValueError(
                 f"{client_type} is not supported. "
-                "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3."
+                "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3, gemini-embedding-2."
             )
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> Any:
@@ -87,6 +89,13 @@ class AutoLLMClient(LLMClient):
     def transform_model_output_to_uni_event(self, model_output: Any) -> UniEvent:
         """Delegate to underlying client's transform_model_output_to_uni_event."""
         return self._client.transform_model_output_to_uni_event(model_output)
+
+    async def embed_content(
+        self,
+        inputs: list[EmbeddingInputContentItem],
+        config: UniEmbeddingConfig | None = None,
+    ) -> EmbeddingResponse:
+        return await self._client.embed_content(inputs, config)
 
     async def _streaming_response_internal(
         self,

--- a/src_py/agenthub/base_client.py
+++ b/src_py/agenthub/base_client.py
@@ -16,7 +16,17 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator
 
-from .types import ContentItem, FinishReason, UniConfig, UniEvent, UniMessage, UsageMetadata
+from .types import (
+    ContentItem,
+    EmbeddingInputContentItem,
+    EmbeddingResponse,
+    FinishReason,
+    UniConfig,
+    UniEmbeddingConfig,
+    UniEvent,
+    UniMessage,
+    UsageMetadata,
+)
 
 
 class LLMClient(ABC):
@@ -68,6 +78,28 @@ class LLMClient(ABC):
             Universal event dictionary
         """
         pass
+
+    async def embed_content(
+        self,
+        inputs: list[EmbeddingInputContentItem],
+        config: UniEmbeddingConfig | None = None,
+    ) -> EmbeddingResponse:
+        """Generate embeddings for the given inputs.
+
+        The default implementation raises NotImplementedError. Provider clients
+        that support embedding override this method.
+
+        Args:
+            inputs: List of embedding input items (text, image_url, or inline_data)
+            config: Embedding configuration
+
+        Returns:
+            Embedding response containing model name and embedding vectors
+
+        Raises:
+            NotImplementedError: If the provider does not support embedding.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support embedding.")
 
     def concat_uni_events_to_uni_message(self, events: list[UniEvent]) -> UniMessage:
         """

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -363,10 +363,12 @@ class Gemini3Client(LLMClient):
         if config and config.get("dimensions") is not None:
             gemini_config = types.EmbedContentConfig(output_dimensionality=config["dimensions"])
 
-        if len(parts) == 1 and parts[0].text is not None:
-            contents = parts[0].text
+        if config and config.get("aggregate") and len(parts) > 1:
+            # Aggregate multiple input parts and output a single vector
+            contents = types.Content(parts=parts)
         else:
-            contents = parts
+            # Each input part is embedded as a separate vector
+            contents = [types.Content(parts=[p]) for p in parts]
 
         result = await self._client.aio.models.embed_content(
             model=model,

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -26,6 +26,8 @@ from google.oauth2 import service_account
 
 from ..base_client import LLMClient
 from ..types import (
+    EmbeddingInputContentItem,
+    EmbeddingResponse,
     EventType,
     FinishReason,
     PartialContentItem,
@@ -33,6 +35,7 @@ from ..types import (
     ThinkingLevel,
     ToolChoice,
     UniConfig,
+    UniEmbeddingConfig,
     UniEvent,
     UniMessage,
     UsageMetadata,
@@ -332,6 +335,48 @@ class Gemini3Client(LLMClient):
             "content_items": content_items,
             "usage_metadata": usage_metadata,
             "finish_reason": finish_reason,
+        }
+
+    async def embed_content(
+        self,
+        inputs: list[EmbeddingInputContentItem],
+        config: UniEmbeddingConfig | None = None,
+    ) -> EmbeddingResponse:
+        model = config.get("model", self._model) if config else self._model
+
+        if "embedding" not in model.lower():
+            raise ValueError(f"Model '{model}' is not an embedding model.")
+
+        parts = []
+        for item in inputs:
+            if item["type"] == "text":
+                parts.append(types.Part(text=item["text"]))
+            elif item["type"] == "image_url":
+                image_data = await self._get_image_bytes_and_mime_type(item["image_url"])
+                parts.append(types.Part.from_bytes(**image_data))
+            elif item["type"] == "inline_data":
+                parts.append(types.Part.from_bytes(data=item["data"], mime_type=item["mime_type"]))
+            else:
+                raise ValueError(f"Unknown embedding item type: {item['type']}")
+
+        gemini_config = None
+        if config and config.get("dimensions") is not None:
+            gemini_config = types.EmbedContentConfig(output_dimensionality=config["dimensions"])
+
+        if len(parts) == 1 and parts[0].text is not None:
+            contents = parts[0].text
+        else:
+            contents = parts
+
+        result = await self._client.aio.models.embed_content(
+            model=model,
+            contents=contents,
+            config=gemini_config,
+        )
+
+        return {
+            "data": [{"embedding": list(e.values)} for e in result.embeddings] if result.embeddings else [],
+            "model": model,
         }
 
     async def _streaming_response_internal(

--- a/src_py/agenthub/types.py
+++ b/src_py/agenthub/types.py
@@ -193,3 +193,4 @@ class EmbeddingResponse(TypedDict):
 class UniEmbeddingConfig(TypedDict):
     model: NotRequired[str]
     dimensions: NotRequired[int]
+    aggregate: NotRequired[bool]

--- a/src_py/agenthub/types.py
+++ b/src_py/agenthub/types.py
@@ -176,3 +176,20 @@ class UniConfig(TypedDict):
     image_config: NotRequired[ImageConfig]
     tts_config: NotRequired[list[SpeakerConfig]]
     trace_id: NotRequired[str]
+
+
+EmbeddingInputContentItem = TextContentItem | ImageContentItem | InlineDataContentItem
+
+
+class EmbeddingResult(TypedDict):
+    embedding: list[float]
+
+
+class EmbeddingResponse(TypedDict):
+    data: list[EmbeddingResult]
+    model: str
+
+
+class UniEmbeddingConfig(TypedDict):
+    model: NotRequired[str]
+    dimensions: NotRequired[int]

--- a/src_py/examples/embedding_example.py
+++ b/src_py/examples/embedding_example.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example demonstrating text embedding with dimensions configuration.
+
+This example shows how to use embed_content to generate embeddings for
+multiple texts with a specified output dimensionality.
+"""
+
+import asyncio
+import os
+
+from agenthub import AutoLLMClient
+
+
+async def main():
+    """Example of text embedding with dimensionality configuration."""
+    print("=" * 60)
+    print("Text Embedding Example")
+    print("=" * 60)
+
+    model = os.getenv("MODEL", "gemini-embedding-2")
+    print(f"Using model: {model}")
+
+    client = AutoLLMClient(model=model)
+
+    texts = [
+        "What is the meaning of life?",
+        "What is the purpose of existence?",
+        "How do I bake a cake?",
+    ]
+
+    print(f"Generating embeddings for {len(texts)} texts with dimensions=768...")
+    result = await client.embed_content(
+        inputs=[{"type": "text", "text": t} for t in texts],
+        config={"dimensions": 768},
+    )
+
+    for i, item in enumerate(result["data"]):
+        print(f'\nText {i}: "{texts[i]}"')
+        print(f"  Embedding dimension: {len(item['embedding'])}")
+        print(f"  First 5 values: {item['embedding'][:5]}")
+
+    print(f"\nModel: {result['model']}")
+    print("\n" + "=" * 60)
+    print("Text embedding complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -37,6 +37,8 @@ class Model:
     support_image_understanding: bool = True
     support_image_generation: bool = False
     support_tts: bool = False
+    support_embedding: bool = False
+    support_image_embedding: bool = False
     provider: Literal["official", "bedrock", "vertex", "siliconflow", "openrouter", "modelverse"] = "official"
 
     def __repr__(self) -> str:
@@ -63,6 +65,16 @@ if os.getenv("GEMINI_API_KEY"):
             support_temperature=False,
             support_image_understanding=False,
             support_tts=True,
+        )
+    )
+    AVAILABLE_MODELS.append(
+        Model(
+            name="gemini-embedding-2",
+            support_text=False,
+            support_temperature=False,
+            support_image_understanding=False,
+            support_embedding=True,
+            support_image_embedding=True,
         )
     )
 
@@ -314,6 +326,8 @@ async def test_clear_history(model: Model):
 @pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=[str(model) for model in AVAILABLE_MODELS])
 async def test_concat_uni_events_to_uni_message(model: Model):
     """Test concatenation of events into a single message."""
+    if model.support_embedding:
+        pytest.skip(f"Embedding model {model.name} do not need concatenation.")
     client = await _create_client(model)
     messages = [
         {
@@ -649,6 +663,50 @@ async def test_tts_generation_single_speaker(model: Model):
     assert inline_items, f"No inline data returned for TTS output by {model.name}"
     assert any("audio/" in item["mime_type"] for item in inline_items)
     assert all(isinstance(item["data"], bytes) and item["data"] for item in inline_items)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=[str(model) for model in AVAILABLE_MODELS])
+async def test_embed_content_text(model: Model):
+    """Test text embedding with dimensions configuration."""
+    if not model.support_embedding:
+        pytest.skip(f"Embedding is not supported by {model.name}.")
+
+    client = await _create_client(model)
+    texts = ["Hello world", "Goodbye world"]
+
+    result = await client.embed_content(
+        inputs=[{"type": "text", "text": t} for t in texts],
+        config={"dimensions": 768},
+    )
+
+    assert result["model"] == model.name
+    assert len(result["data"]) == 2
+    for item in result["data"]:
+        assert len(item["embedding"]) == 768
+        assert all(isinstance(v, float) for v in item["embedding"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=[str(model) for model in AVAILABLE_MODELS])
+async def test_embed_content_multimodal(model: Model):
+    """Test multimodal embedding with text and image URL data."""
+    if not model.support_image_embedding:
+        pytest.skip(f"Image embedding is not supported by {model.name}.")
+
+    client = await _create_client(model)
+
+    result = await client.embed_content(
+        inputs=[
+            {"type": "image_url", "image_url": IMAGE},
+        ],
+    )
+
+    assert result["model"] == model.name
+    assert len(result["data"]) == 1
+    for item in result["data"]:
+        assert len(item["embedding"]) > 0
+        assert all(isinstance(v, float) for v in item["embedding"])
 
 
 if __name__ == "__main__":

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -709,6 +709,30 @@ async def test_embed_content_multimodal(model: Model):
         assert all(isinstance(v, float) for v in item["embedding"])
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", AVAILABLE_MODELS, ids=[str(model) for model in AVAILABLE_MODELS])
+async def test_embed_content_aggregate(model: Model):
+    """Test aggregated embedding: multiple inputs fused into a single vector."""
+    if not model.support_embedding:
+        pytest.skip(f"Embedding is not supported by {model.name}.")
+
+    client = await _create_client(model)
+
+    result = await client.embed_content(
+        inputs=[
+            {"type": "text", "text": "Hello world"},
+            {"type": "text", "text": "Goodbye world"},
+        ],
+        config={"aggregate": True},
+    )
+
+    assert result["model"] == model.name
+    assert len(result["data"]) == 1
+    item = result["data"][0]
+    assert len(item["embedding"]) > 0
+    assert all(isinstance(v, float) for v in item["embedding"])
+
+
 if __name__ == "__main__":
     import asyncio
 

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -19,7 +19,14 @@ import { GPT5_5Client } from "./gpt5_5";
 import { GLM5Client } from "./glm5";
 import { KimiK2_5Client } from "./kimi_k2_5";
 import { Qwen3Client } from "./qwen3";
-import { UniConfig, UniEvent, UniMessage } from "./types";
+import {
+  EmbeddingInputContentItem,
+  EmbeddingResponse,
+  UniConfig,
+  UniEmbeddingConfig,
+  UniEvent,
+  UniMessage,
+} from "./types";
 
 /**
  * Auto-routing LLM client that dispatches to appropriate model-specific client.
@@ -70,7 +77,8 @@ export class AutoLLMClient extends LLMClient {
 
     if (
       clientType.includes("gemini-3-") ||
-      clientType.includes("gemini-3.1-")
+      clientType.includes("gemini-3.1-") ||
+      clientType.includes("gemini-embedding")
     ) {
       return new Gemini3Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("claude") && clientType.includes("4-6")) {
@@ -89,7 +97,7 @@ export class AutoLLMClient extends LLMClient {
     } else {
       throw new Error(
         `${clientType} is not supported. ` +
-          "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3.",
+          "Supported client types: gemini-3, claude-4-6, gpt-5.4, gpt-5.5, glm-5, kimi-k2.5, qwen3, gemini-embedding-2.",
       );
     }
   }
@@ -116,6 +124,13 @@ export class AutoLLMClient extends LLMClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformModelOutputToUniEvent(modelOutput: any): UniEvent {
     return this._client.transformModelOutputToUniEvent(modelOutput);
+  }
+
+  async embedContent(
+    inputs: EmbeddingInputContentItem[],
+    config?: UniEmbeddingConfig,
+  ): Promise<EmbeddingResponse> {
+    return this._client.embedContent(inputs, config);
   }
 
   /**

--- a/src_ts/src/baseClient.ts
+++ b/src_ts/src/baseClient.ts
@@ -15,7 +15,10 @@
 import {
   FinishReason,
   ContentItem,
+  EmbeddingInputContentItem,
+  EmbeddingResponse,
   UniConfig,
+  UniEmbeddingConfig,
   UniEvent,
   UniMessage,
   UsageMetadata,
@@ -62,6 +65,15 @@ export abstract class LLMClient {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   abstract transformModelOutputToUniEvent(modelOutput: any): UniEvent;
+
+  async embedContent(
+    _inputs: EmbeddingInputContentItem[],
+    _config?: UniEmbeddingConfig,
+  ): Promise<EmbeddingResponse> {
+    throw new Error(
+      `${this.constructor.name} does not support embedding.`,
+    );
+  }
 
   /**
    * Concatenate a stream of universal events into a single universal message.

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -520,13 +520,10 @@ export class Gemini3Client extends LLMClient {
         ? { outputDimensionality: config.dimensions }
         : undefined;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let contents: any;
-    if (parts.length === 1 && parts[0].text != null) {
-      contents = parts[0].text;
-    } else {
-      contents = parts;
-    }
+    const contents: Content[] | Content =
+      config?.aggregate && parts.length > 1
+        ? ({ parts } as Content)
+        : parts.map((p) => ({ parts: [p] } as Content));
 
     const result = await this._client.models.embedContent({
       model,

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -34,10 +34,13 @@ import {
   FunctionResponseBlob,
   FunctionResponse,
   VoiceConfig,
+  EmbedContentConfig,
 } from "@google/genai";
 import * as path from "path";
 import { LLMClient } from "../baseClient";
 import {
+  EmbeddingInputContentItem,
+  EmbeddingResponse,
   EventType,
   FinishReason,
   PartialContentItem,
@@ -45,6 +48,7 @@ import {
   ThinkingLevel,
   ToolChoice,
   UniConfig,
+  UniEmbeddingConfig,
   UniEvent,
   UniMessage,
   UsageMetadata,
@@ -472,6 +476,70 @@ export class Gemini3Client extends LLMClient {
       content_items: contentItems,
       usage_metadata: usageMetadata,
       finish_reason: finishReason,
+    };
+  }
+
+  async embedContent(
+    inputs: EmbeddingInputContentItem[],
+    config?: UniEmbeddingConfig,
+  ): Promise<EmbeddingResponse> {
+    const model = config?.model ?? this._model;
+
+    if (!model.toLowerCase().includes("embedding")) {
+      throw new Error(`Model '${model}' is not an embedding model.`);
+    }
+
+    const parts: Part[] = [];
+    for (const item of inputs) {
+      if (item.type === "text") {
+        parts.push({ text: item.text } as Part);
+      } else if (item.type === "image_url") {
+        const imageData = await this._getImageBytesAndMimeType(item.image_url);
+        parts.push({
+          inlineData: {
+            mimeType: imageData.mimeType,
+            data: imageData.data.toString("base64"),
+          },
+        } as Part);
+      } else if (item.type === "inline_data") {
+        parts.push({
+          inlineData: {
+            mimeType: item.mime_type,
+            data: item.data.toString("base64"),
+          },
+        } as Part);
+      } else {
+        throw new Error(
+          `Unknown embedding item type: ${(item as { type: string }).type}`,
+        );
+      }
+    }
+
+    const geminiConfig: EmbedContentConfig | undefined =
+      config?.dimensions != null
+        ? { outputDimensionality: config.dimensions }
+        : undefined;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let contents: any;
+    if (parts.length === 1 && parts[0].text != null) {
+      contents = parts[0].text;
+    } else {
+      contents = parts;
+    }
+
+    const result = await this._client.models.embedContent({
+      model,
+      contents,
+      config: geminiConfig,
+    });
+
+    return {
+      data:
+        result.embeddings?.map((e) => ({
+          embedding: e.values ?? [],
+        })) ?? [],
+      model,
     };
   }
 

--- a/src_ts/src/types.ts
+++ b/src_ts/src/types.ts
@@ -207,4 +207,5 @@ export interface EmbeddingResponse {
 export interface UniEmbeddingConfig {
   model?: string;
   dimensions?: number;
+  aggregate?: boolean;
 }

--- a/src_ts/src/types.ts
+++ b/src_ts/src/types.ts
@@ -189,3 +189,22 @@ export interface UniConfig {
   tts_config?: SpeakerConfig[];
   trace_id?: string;
 }
+
+export type EmbeddingInputContentItem =
+  | TextContentItem
+  | ImageContentItem
+  | InlineDataContentItem;
+
+export interface EmbeddingResult {
+  embedding: number[];
+}
+
+export interface EmbeddingResponse {
+  data: EmbeddingResult[];
+  model: string;
+}
+
+export interface UniEmbeddingConfig {
+  model?: string;
+  dimensions?: number;
+}

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -26,6 +26,8 @@ interface Model {
   supportImageUnderstanding: boolean;
   supportImageGeneration: boolean;
   supportAudioGeneration: boolean;
+  supportEmbedding: boolean;
+  supportImageEmbedding: boolean;
   provider:
     | "official"
     | "bedrock"
@@ -45,6 +47,8 @@ if (process.env.GEMINI_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 
@@ -55,6 +59,8 @@ if (process.env.GEMINI_API_KEY) {
     supportImageUnderstanding: false,
     supportImageGeneration: true,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 
@@ -65,6 +71,20 @@ if (process.env.GEMINI_API_KEY) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: true,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
+    provider: "official",
+  });
+
+  AVAILABLE_MODELS.push({
+    name: "gemini-embedding-2",
+    supportTextGeneration: false,
+    supportTemperature: false,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: false,
+    supportEmbedding: true,
+    supportImageEmbedding: true,
     provider: "official",
   });
 }
@@ -77,6 +97,8 @@ if (process.env.ANTHROPIC_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 }
@@ -89,6 +111,8 @@ if (process.env.OPENAI_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 }
@@ -101,6 +125,8 @@ if (process.env.ZAI_API_KEY) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 }
@@ -113,6 +139,8 @@ if (process.env.MOONSHOT_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 }
@@ -125,6 +153,8 @@ if (process.env.BEDROCK_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "bedrock",
   });
 }
@@ -137,6 +167,8 @@ if (process.env.VERTEX_API_KEY) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "vertex",
   });
 
@@ -147,6 +179,8 @@ if (process.env.VERTEX_API_KEY) {
     supportImageUnderstanding: false,
     supportImageGeneration: true,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "vertex",
   });
 
@@ -157,6 +191,8 @@ if (process.env.VERTEX_API_KEY) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: true,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "vertex",
   });
 }
@@ -171,6 +207,8 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -180,6 +218,8 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -189,6 +229,8 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "openrouter",
   });
 }
@@ -201,6 +243,8 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "siliconflow",
   });
   AVAILABLE_MODELS.push({
@@ -210,6 +254,8 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "siliconflow",
   });
   AVAILABLE_MODELS.push({
@@ -219,6 +265,8 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "siliconflow",
   });
 }
@@ -231,6 +279,8 @@ if (process.env.MODELVERSE_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "modelverse",
   });
   AVAILABLE_MODELS.push({
@@ -240,6 +290,8 @@ if (process.env.MODELVERSE_API_KEY && RUN_SLOW_TEST) {
     supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "modelverse",
   });
 }
@@ -915,6 +967,46 @@ if (AVAILABLE_MODELS.length > 0) {
       ).toBe(true);
       expect(inlineItems.every((item) => item.data.length > 0)).toBe(true);
     }, 180000);
+
+    test("should embed text content", async () => {
+      if (!model.supportEmbedding) {
+        return;
+      }
+
+      const client = createClient(model);
+      const texts = ["Hello world", "Goodbye world"];
+
+      const result = await client.embedContent(
+        texts.map((t) => ({ type: "text" as const, text: t })),
+        { dimensions: 768 },
+      );
+
+      expect(result.model).toBe(model.name);
+      expect(result.data.length).toBe(2);
+      for (const item of result.data) {
+        expect(item.embedding.length).toBe(768);
+        expect(item.embedding.every((v) => typeof v === "number")).toBe(true);
+      }
+    }, 60000);
+
+    test("should embed multimodal content", async () => {
+      if (!model.supportImageEmbedding) {
+        return;
+      }
+
+      const client = createClient(model);
+
+      const result = await client.embedContent([
+        { type: "image_url" as const, image_url: IMAGE },
+      ]);
+
+      expect(result.model).toBe(model.name);
+      expect(result.data.length).toBe(1);
+      for (const item of result.data) {
+        expect(item.embedding.length).toBeGreaterThan(0);
+        expect(item.embedding.every((v) => typeof v === "number")).toBe(true);
+      }
+    }, 60000);
   });
 }
 

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -1007,6 +1007,28 @@ if (AVAILABLE_MODELS.length > 0) {
         expect(item.embedding.every((v) => typeof v === "number")).toBe(true);
       }
     }, 60000);
+
+    test("should aggregate multiple inputs into a single embedding", async () => {
+      if (!model.supportEmbedding) {
+        return;
+      }
+
+      const client = createClient(model);
+
+      const result = await client.embedContent(
+        [
+          { type: "text" as const, text: "Hello world" },
+          { type: "text" as const, text: "Goodbye world" },
+        ],
+        { aggregate: true },
+      );
+
+      expect(result.model).toBe(model.name);
+      expect(result.data.length).toBe(1);
+      const item = result.data[0];
+      expect(item.embedding.length).toBeGreaterThan(0);
+      expect(item.embedding.every((v) => typeof v === "number")).toBe(true);
+    }, 60000);
   });
 }
 

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -153,6 +153,8 @@ if (process.env.DEEPSEEK_API_KEY && process.env.DEEPSEEK_BASE_URL) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 
@@ -163,6 +165,8 @@ if (process.env.DEEPSEEK_API_KEY && process.env.DEEPSEEK_BASE_URL) {
     supportImageUnderstanding: false,
     supportImageGeneration: false,
     supportAudioGeneration: false,
+    supportEmbedding: false,
+    supportImageEmbedding: false,
     provider: "official",
   });
 }


### PR DESCRIPTION
## Summary
Add Gemini embedding support across the Python and TypeScript SDK surfaces.

## Changes
- Add shared embedding types and base client embedding methods.
- Route `gemini-embedding-*` models through the Gemini 3 client in `AutoLLMClient`.
- Implement Gemini text, image URL, and inline data embedding calls with optional output dimensionality.
- Add Python embedding example and Gemini embedding API docs.
- Extend Python and TypeScript client tests for text and multimodal embedding behavior.