### PR TITLE
Update AgentHub skills and temperature handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.
 
+Using a coding agent? Install the AgentHub SKILL files from [`skills/`](skills/) so it can use AgentHub correctly in generated code.
+
 📢 Follow us on X: [![Twitter](https://img.shields.io/twitter/follow/prismshadow_ai)](https://twitter.com/prismshadow_ai) or join our [Discord Community](https://discord.gg/4TQ2bsSb)
 
 ## Why AgentHub?

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agenthub-python
-description: Guidance for using the AgentHub Python SDK (`agenthub-python`). Use this skill when developing agents that need to invoke different LLM APIs, or when a unified interface for different LLM providers is required. Also use this skill if the user mentions AgentHub, requests the use of the `agenthub-python` library, or when `agenthub-python` is already imported in the project.
+description: Guidance for using the AgentHub Python SDK (`agenthub-python`). Use when developing agents that call different LLM APIs, need a unified interface for LLM providers, mention AgentHub, request `agenthub-python`, or already import it.
 ---
 
 # AgentHub Python
 
-This skill provides guidance for using AgentHub's Python SDK (`agenthub-python`). AgentHub is a unified and precise LLM API hub for autonomous agents, providing a consistent interface across LLMs, reliable multi-step tool-call handling, and lightweight tracing for debugging and auditing executions.
+AgentHub is a unified SDK for calling LLMs across providers with shared data models, tool calling, tracing, and playground support.
 
 ## Installation
 
@@ -15,304 +15,185 @@ uv add agenthub-python
 pip install agenthub-python
 ```
 
-## How to specify models
+## Model Selection
 
-Choose a model ID from the table, set the API key and base URL using the environment variables that the routed Python client reads automatically, then create the client with `AutoLLMClient(model=model_id)`. Alternatively, pass them explicitly without relying on environment variables: `AutoLLMClient(model=model_id, api_key=your_api_key, base_url=your_base_url)`.
+Use exact model IDs. Create with `AutoLLMClient(model=model_id)`, or pass credentials directly: `AutoLLMClient(model=model_id, api_key=key, base_url=url)`. If a model ID is not listed, ask the user to confirm the exact ID before using it.
 
-| Model name | Vendor | Model IDs | API Key | Base URL |
+| Family | Provider | Model IDs | API Key | Base URL |
 | --- | --- | --- | --- | --- |
-| Gemini 3 / Gemini 3.1 LLM | Official / Google Vertex AI | `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| Gemini 3.1 image generation | Official / Google Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| Gemini 3.1 TTS | Official / Google Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 | Official / Vertex AI | `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.1-flash-lite` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 Image | Official / Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 TTS | Official / Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini Embedding | Official / Vertex AI | `gemini-embedding-2` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Claude 4.6 | Official / ModelVerse | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
-| Claude 4.6 | Amazon Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
-| GPT-5.4 / GPT-5.5 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
-| GLM-5 | Official | `glm-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5 | OpenRouter | `z-ai/glm-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5 | SiliconFlow | `Pro/zai-org/GLM-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| Kimi-K2.5 | Official | `kimi-k2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Kimi-K2.5 | OpenRouter | `moonshotai/kimi-k2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Kimi-K2.5 | SiliconFlow | `Pro/moonshotai/Kimi-K2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Qwen3 | OpenRouter | `qwen/qwen3-8b`, `qwen/qwen3-30b-a3b-thinking-2507` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
-| Qwen3 | SiliconFlow | `Qwen/Qwen3-8B` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
+| Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.7 | Bedrock | `global.anthropic.claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
+| Kimi-K2.6 | OpenRouter | `moonshotai/kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
+| Kimi-K2.6 | SiliconFlow | `Pro/moonshotai/Kimi-K2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | DeepSeek V4 | Official | `deepseek-v4-pro`, `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| DeepSeek V4 | OpenRouter | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| DeepSeek V4 | SiliconFlow | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| GLM-5.1 | Official | `glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.1 | OpenRouter | `z-ai/glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.1 | SiliconFlow | `Pro/zai-org/GLM-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| Qwen3.6 | OpenRouter | `qwen/qwen3.6-35b-a3b` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
+| Qwen3.6 | SiliconFlow | `Qwen/Qwen3.6-35B-A3B` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
 
-## Basic Usage
+Common gateway base URLs:
 
-Use `AutoLLMClient` and its methods for all LLM interaction and conversation tasks.
+- OpenRouter: `https://openrouter.ai/api/v1`
+- SiliconFlow: `https://api.siliconflow.cn/v1`
+- ModelVerse: `https://api.modelverse.cn/v1` (`https://api.modelverse.cn/` for Claude)
+- vLLM: `http://127.0.0.1:8000/v1/`
 
-```python
-import asyncio
-import os
+## Data Models
 
-from agenthub import AutoLLMClient
-
-os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
-
-
-async def main() -> None:
-    client = AutoLLMClient(model="gpt-5.5")
-    message = {  # UniMessage
-        "role": "user",
-        "content_items": [{"type": "text", "text": "Say 'Hello, World!'"}],
-    }
-    config = {"temperature": 1.0}  # UniConfig
-
-    async for event in client.streaming_response_stateful(
-        message=message,
-        config=config,
-    ):
-        # UniEvent
-        print(event)
-
-
-asyncio.run(main())
-```
-
-## APIs
-
-`AutoLLMClient` is the main class for interacting with the AgentHub SDK. Prefer `streaming_response_stateful` for agent loops.
-
-After declaring `client = AutoLLMClient(...)`, you can use the following `AutoLLMClient` methods:
-
-```python
-async def streaming_response(
-    messages: list[UniMessage],
-    config: UniConfig,
-) -> AsyncIterator[UniEvent]:
-    """Stream one response without using client history.
-
-    Call as `async for event in client.streaming_response(messages, config)`.
-    Provide the complete ordered conversation in `messages`; the client yields
-    universal stream events and leaves stateful history unchanged.
-
-    Args:
-        messages: Complete ordered conversation to send for this request.
-        config: Request options such as tools, temperature, or trace_id.
-
-    Yields:
-        UniEvent: Stream event in AgentHub's universal event format.
-    """
-```
-
-
-```python
-async def streaming_response_stateful(
-    message: UniMessage,
-    config: UniConfig,
-) -> AsyncIterator[UniEvent]:
-    """Stream one response while the client manages conversation history.
-
-    Call as `async for event in client.streaming_response_stateful(message, config)`.
-    Pass only the next message; the client combines it with stored history and
-    records the completed turn after a successful response.
-
-    Args:
-        message: New user or assistant message for the next turn.
-        config: Request options such as tools, temperature, or trace_id.
-
-    Yields:
-        UniEvent: Stream event in AgentHub's universal event format.
-    """
-```
-
-
-```python
-def clear_history() -> None:
-    """Reset the stored stateful conversation history.
-
-    Call as `client.clear_history()` before starting an unrelated conversation
-    with the same model client.
-
-    Returns:
-        None.
-    """
-```
-
-
-```python
-def get_history() -> list[UniMessage]:
-    """Return the current stateful conversation history.
-
-    Call as `history = client.get_history()` to inspect or persist messages
-    accumulated by `streaming_response_stateful`.
-
-    Returns:
-        list[UniMessage]: Copy of the client's stored conversation list.
-    """
-```
-
-
-```python
-def set_history(history: list[UniMessage]) -> None:
-    """Replace the stored stateful conversation history.
-
-    Call as `client.set_history(history)` when restoring a conversation or
-    transferring history between clients. Pass a complete ordered message list.
-
-    Args:
-        history: Complete ordered conversation to store on the client.
-
-    Returns:
-        None.
-    """
-```
-
-## Data Model: UniConfig, UniMessage and UniEvent
-
-Use AgentHub's universal data model instead of provider-native response payloads.
+AgentHub uses `UniConfig`, `UniMessage`, and `UniEvent` to represent request options, conversation history, and streamed outputs across providers.
 
 ### UniConfig
 
-`UniConfig` is the request configuration passed as the `config` argument to `streaming_response` and `streaming_response_stateful`.
-
-Example:
+`UniConfig` is the request config for `streaming_response` and `streaming_response_stateful`. All fields are optional.
 
 ```python
 config = {
-  "max_tokens": 1024,
-  "temperature": 1.0,
-  "tools": [
-    {
-      "name": "get_current_weather",
-      "description": "Get the current weather in a given location",
-      "parameters": {
-          "type": "object",
-          "properties": {
-              "location": {
-                  "type": "string",
-                  "description": "The city and state, e.g. San Francisco, CA"
-              }
-          },
-          "required": ["location"]
-      }
-    }
-  ],
-  "thinking_summary": True,
-  "thinking_level": "high",
-  "tool_choice": "auto",
-  "system_prompt": "You are a helpful assistant.",
-  "prompt_caching": "enable",
-  "image_config": {"aspect_ratio": "4:3", "image_size": "1K"},
-  "tts_config": [{"voice": "Kore"}],
-  "trace_id": "agent1/conversation_001",
+    "max_tokens": 1024,
+    "temperature": 1.0,
+    "tools": [{
+        "name": "get_weather",
+        "description": "Get weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string", "description": "City name."}},
+            "required": ["location"],
+        },
+    }],
+    "tool_choice": "auto",
+    "thinking_summary": True,
+    "thinking_level": "high",
+    "system_prompt": "You are helpful.",
+    "prompt_caching": "enable",
+    "image_config": {"aspect_ratio": "4:3", "image_size": "1K"},
+    "tts_config": [{"voice": "Kore"}],
+    "embedding_config": {"dimensions": 768},
+    "trace_id": "agent1/conversation_001",
 }
 ```
 
-All fields of `UniConfig` are optional.
-
 Fields:
 
-- `max_tokens` (`int`): Output-token limit. Caps generated output length when the provider supports it.
-- `temperature` (`float`): Sampling temperature. Controls randomness when the provider supports it.
-- `tools` (`list[ToolSchema]`): List of tools available to the model. Each tool requires `name: str` and `description: str`, and may include `parameters: dict[str, Any]` as a JSON Schema Python dict.
-- `thinking_summary` (`bool`): Indicates whether the model should return its thinking process.
-- `thinking_level` (`ThinkingLevel`): Reasoning effort level, one of `"none"`, `"low"`, `"medium"`, or `"high"`.
-- `tool_choice` (`Literal["auto", "required", "none"] | list[str]`): Tool-calling configuration, one of `"auto"`, `"required"`, `"none"`, or a list of allowed tool names such as `["tool_a"]`. Only meaningful when `tools` is provided.
+- `max_tokens` (`int`): Output token limit.
+- `temperature` (`float`): Sampling temperature; support varies by model.
+- `tools` (`list[ToolSchema]`): Tools with `name`, `description`, and optional JSON Schema `parameters`.
+- `thinking_summary` (`bool`): Request a thinking summary when supported.
+- `thinking_level` (`ThinkingLevel`): `none`, `low`, `medium`, `high`, or `xhigh`.
+- `tool_choice` (`ToolChoice`): `auto`, `required`, `none`, or a list of tool names; support varies by model.
 - `system_prompt` (`str`): System instruction text.
-- `prompt_caching` (`PromptCaching`): Prompt cache mode, one of `"enable"`, `"disable"`, or `"enhance"`.
-- `image_config` (`ImageConfig`): Image-generation configuration with optional `aspect_ratio: AspectRatio` and `image_size: ImageSize`. `AspectRatio` is one of `"1:1"`, `"2:3"`, `"3:2"`, `"3:4"`, `"4:3"`, `"9:16"`, `"16:9"`, or `"21:9"`; `ImageSize` is `"1K"` or `"2K"`.
-- `tts_config` (`list[SpeakerConfig]`): Speech-generation configuration. Each item requires `voice: str` and may include `speaker: str`; use one item for single-speaker TTS and two items with `speaker` names for multi-speaker TTS.
-- `trace_id` (`str`): Stable trace identifier. Saves conversation history under this ID for the tracer.
+- `prompt_caching` (`PromptCaching`): `enable`, `disable`, or `enhance`.
+- `image_config` (`ImageConfig`): `aspect_ratio` (`1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `9:16`, `16:9`, `21:9`) and `image_size` (`1K`, `2K`).
+- `tts_config` (`list[SpeakerConfig]`): Voice config; each item has `voice` and optional `speaker`.
+- `embedding_config` (`EmbeddingConfig`): Embedding config, currently `dimensions`.
+- `trace_id` (`str`): Stable ID for tracer output.
 
 ### UniMessage
 
-`UniMessage` is the durable conversation message shape, passed as `message` to `streaming_response_stateful`, as an element of `messages` to `streaming_response`, and returned by `get_history`.
-
-Example:
+`UniMessage` is the durable message shape used in history.
 
 ```python
 message = {
-  "role": "user",
-  "content_items": [
-    {"type": "text", "text": "How are you doing?"},
-    {"type": "image_url", "image_url": "https://example.com/image.jpg"},
-    {"type": "inline_data", "mime_type": "image/jpeg", "data": b"<bytes>"},
-    {"type": "thinking", "thinking": "I am thinking.", "signature": "0x123456"},
-    {"type": "inline_thinking", "mime_type": "image/jpeg", "data": b"<bytes>"},
-    {"type": "tool_call", "name": "math", "arguments": {"expression": "2 + 3"}, "tool_call_id": "123"},
-    {"type": "tool_result", "text": "2 + 3 = 5", "images": [], "tool_call_id": "123"}
-  ]
+    "role": "user",
+    "content_items": [
+        {"type": "text", "text": "Hello", "phase": None, "signature": "sig"},
+        {"type": "image_url", "image_url": "https://example.com/image.jpg"},
+        {"type": "inline_data", "data": b"...", "mime_type": "image/png", "signature": "sig"},
+        {"type": "thinking", "thinking": "Reasoning", "signature": "sig"},
+        {"type": "inline_thinking", "data": b"...", "mime_type": "image/png", "signature": "sig"},
+        {"type": "tool_call", "name": "get_weather", "arguments": {"location": "Paris"}, "tool_call_id": "call_1", "signature": "sig"},
+        {"type": "tool_result", "text": "22 C", "tool_call_id": "call_1"},
+        {"type": "embedding", "embedding": [0.1, 0.2]},
+    ],
 }
 ```
 
 Fields:
 
-- `role` (`Role`): Message author, either `"user"` or `"assistant"`.
-- `content_items` (`list[ContentItem]`): Durable message payload stored in history and trace records.
-- `usage_metadata` (`UsageMetadata | None`): Optional token usage for completed assistant messages.
-- `finish_reason` (`FinishReason | None`): Stop reason for a completed assistant message, one of `"stop"`, `"length"`, `"tool_call"`, `"unknown"`, or `None`.
-- `created_at` (`int`): Message creation timestamp in milliseconds since epoch.
+- `role` (`Role`): `user` or `assistant`.
+- `content_items` (`list[ContentItem]`): Message payload.
+- `usage_metadata` (`UsageMetadata | None`): Optional token counts on completed assistant messages.
+- `finish_reason` (`FinishReason | None`): `stop`, `length`, `tool_call`, `unknown`, or `None`.
+- `created_at` (`int`): Unix milliseconds.
 
-Durable `content_items` types:
+Content items:
 
-- `text`: Plain text content. Required properties: `type: Literal["text"]`, `text: str`.
-- `image_url`: External image URL or data URI. Required properties: `type: Literal["image_url"]`, `image_url: str`.
-- `inline_data`: Inline binary image or audio content. Required properties: `type: Literal["inline_data"]`, `data: bytes`, `mime_type: str`.
-- `thinking`: Text reasoning content returned by the model. Required properties: `type: Literal["thinking"]`, `thinking: str`.
-- `inline_thinking`: Binary reasoning artifact, such as generated-image thinking data. Required properties: `type: Literal["inline_thinking"]`, `data: bytes`, `mime_type: str`.
-- `tool_call`: Complete tool invocation. Required properties: `type: Literal["tool_call"]`, `name: str`, `arguments: dict[str, Any]`.
-- `tool_result`: Tool execution result to send back to the model. Required properties: `type: Literal["tool_result"]`, `text: str`, `tool_call_id: str`. Optional property: `images: list[str]`.
+- `text`: Text chunk; `phase` marks sub-stage; `signature` verifies signed content.
+- `image_url`: Image URL or data URI.
+- `inline_data`: Inline media bytes with MIME type; may carry `signature`.
+- `thinking`: Text reasoning content; may carry `signature`.
+- `inline_thinking`: Binary reasoning artifact; may carry `signature`.
+- `tool_call`: Complete model tool request with name, args, ID, and optional `signature`.
+- `tool_result`: Tool output text for a `tool_call_id`; may include image URLs.
+- `embedding`: Numeric embedding vector.
 
-The `text`, `inline_data`, `thinking`, `inline_thinking`, `tool_call`, and `partial_tool_call` items may carry an optional `signature` field. Do not strip or modify `signature` fields.
+Preserve `phase` and `signature`; never drop either field.
 
 ### UniEvent
 
-`UniEvent` is the streamed output shape, yielded from `streaming_response` and `streaming_response_stateful`.
-
-Example:
+`UniEvent` is the streamed output shape. Read token counts from `usage_metadata` here.
 
 ```python
 event = {
-  "role": "assistant",
-  "event_type": "start",
-  "content_items": [
-    {"type": "partial_tool_call", "name": "math", "arguments": "", "tool_call_id": "123"}
-  ],
-  "usage_metadata": {
-    "cached_tokens": None,
-    "prompt_tokens": 10,
-    "thoughts_tokens": None,
-    "response_tokens": 1
-  },
-  "finish_reason": None,
-  "created_at": 1694502400000
+    "role": "assistant",
+    "event_type": "delta",
+    "content_items": [
+        {"type": "partial_tool_call", "name": "get_weather", "arguments": "{\"location\":\"Par", "tool_call_id": "call_1"}
+    ],
+    "usage_metadata": {"cached_tokens": 0, "prompt_tokens": 10, "thoughts_tokens": None, "response_tokens": 1},
+    "finish_reason": None,
+    "created_at": 1694502400000,
 }
 ```
 
 Fields:
 
-- `role` (`Role`): Event author, either `"user"` or `"assistant"`.
-- `event_type` (`EventType`): Stream lifecycle marker, including `start`, `stop`, and `unused`. Indicates where the event sits in the stream lifecycle.
-- `content_items` (`list[PartialContentItem]`): Stream payload. Same as `UniMessage.content_items`, plus event-only `partial_tool_call`.
-- `usage_metadata` (`UsageMetadata | None`): Stream token accounting, or `None`.
-- `finish_reason` (`FinishReason | None`): Stream stop reason, one of `"stop"`, `"length"`, `"tool_call"`, `"unknown"`, or `None`.
-- `created_at` (`int`): Event creation timestamp in milliseconds since epoch.
+- `role` (`Role`): `user` or `assistant`.
+- `event_type` (`EventType`): `start`, `delta`, `stop`, or `unused`.
+- `content_items` (`list[PartialContentItem]`): Stream payload; includes `ContentItem` plus `partial_tool_call`.
+- `usage_metadata` (`UsageMetadata | None`): Token counts: `cached_tokens`, `prompt_tokens`, `thoughts_tokens`, `response_tokens`.
+  Token math: `input = cached_tokens + prompt_tokens`; `output = thoughts_tokens + response_tokens`; treat `None` as `0`.
+- `finish_reason` (`FinishReason | None`): `stop`, `length`, `tool_call`, `unknown`, or `None`.
+- `created_at` (`int`): Unix milliseconds.
 
-Event-only `content_items` type:
+Event-only content item:
 
-- `partial_tool_call`: Streamed tool-call fragment. Required properties: `type: Literal["partial_tool_call"]`, `name: str`, `arguments: str`, `tool_call_id: str`. `arguments` carries partial JSON string content, and `tool_call_id` links the later complete `tool_call`.
+- `partial_tool_call`: Streaming tool-call fragment with `name`, partial JSON `arguments`, and `tool_call_id`.
 
-## Token Usage Calculation
+## APIs
 
-AgentHub provides token usage information through the `usage_metadata` field in `UniMessage` and `UniEvent`.
+`AutoLLMClient` exposes five basic APIs. Prefer the stateful stream for agent loops.
 
-`UsageMetadata` contains four fields:
+```python
+async def streaming_response(messages: list[UniMessage], config: UniConfig) -> AsyncIterator[UniEvent]:
+    """Stream one stateless response from a full message list."""
 
-- `cached_tokens` (`int | None`): Cached input tokens.
-- `prompt_tokens` (`int | None`): Non-cached input tokens.
-- `thoughts_tokens` (`int | None`): Chain-of-thought output tokens.
-- `response_tokens` (`int | None`): Non-chain-of-thought output tokens.
+async def streaming_response_stateful(message: UniMessage, config: UniConfig) -> AsyncIterator[UniEvent]:
+    """Stream one stateful response and update client history."""
 
-Calculate total token usage as:
+def get_history() -> list[UniMessage]:
+    """Return a copy of stateful history."""
 
-- `input_tokens = (cached_tokens or 0) + (prompt_tokens or 0)`
-- `output_tokens = (thoughts_tokens or 0) + (response_tokens or 0)`
-- `total_tokens = input_tokens + output_tokens`
+def set_history(history: list[UniMessage]) -> None:
+    """Replace stateful history with a copy."""
 
-## Usage Example
+def clear_history() -> None:
+    """Clear stateful history."""
+```
 
-Tool calling example:
+## Basic Usage
+
+This example asks GPT to call a weather tool, runs the tool, then sends the result back.
 
 ```python
 import asyncio
@@ -385,33 +266,32 @@ asyncio.run(main())
 ```
 
 
-## Tracer Usage
+## Tracer
 
-Use Tracer to save AgentHub conversation history and inspect it in a local web UI.
+Tracer saves trace files and serves a local UI for inspecting conversations.
 
-Set `trace_id` in `config` to save trace files:
+Set `trace_id` to save trace files:
 
 ```python
 from agenthub import AutoLLMClient
 
 client = AutoLLMClient(model="gpt-5.5")
 
-# Add trace_id to config
 config = {"trace_id": "agent1/conversation_001"}
 
 async for event in client.streaming_response_stateful(
     message={"role": "user", "content_items": [{"type": "text", "text": "Hello"}]},
     config=config
 ):
-    pass  # Conversation is automatically saved
+    pass
 ```
 
-The default cache directory is `cache`; change it by setting the `AGENTHUB_CACHE_DIR` environment variable. With `trace_id="agent1/conversation_001"`, AgentHub creates:
+Default cache dir: `cache`, or `AGENTHUB_CACHE_DIR`. For `trace_id="agent1/conversation_001"`, AgentHub writes:
 
 - `cache/agent1/conversation_001.json`: Structured trace data with the full history and config.
 - `cache/agent1/conversation_001.txt`: Human-readable conversation transcript.
 
-Browse traces from Python using the default cache directory:
+Browse traces:
 
 ```python
 from agenthub.integration.tracer import Tracer
@@ -419,17 +299,19 @@ from agenthub.integration.tracer import Tracer
 Tracer().start_web_server(host="127.0.0.1", port=25750)
 ```
 
-Or start the tracer from the CLI:
+Or CLI:
 
 ```bash
 python -m agenthub.integration.tracer --cache_dir ./cache --host 127.0.0.1 --port 25750
 ```
 
-After starting the server, open `http://127.0.0.1:25750` in a browser to inspect traces.
+Open Tracer at `http://127.0.0.1:25750`.
 
-## Playground Usage
+## Playground
 
-Use Playground when a manual chat web UI is needed or when chatting with LLMs manually.
+Playground starts a local chat UI for manual model checks.
+
+Start Playground for manual chat:
 
 ```python
 from agenthub.integration.playground import start_playground_server
@@ -437,11 +319,11 @@ from agenthub.integration.playground import start_playground_server
 start_playground_server(host="127.0.0.1", port=25751)
 ```
 
-After starting the server, open `http://127.0.0.1:25751` in a browser to chat.
+Open Playground at `http://127.0.0.1:25751`.
 
 ## Notes
 
 Agent loop rules:
 
 - Send every tool result with the exact `tool_call_id` from its originating `tool_call`. Do not invent, normalize, or reuse IDs across unrelated tool calls.
-- Preserve `thinking` and `inline_thinking` items. Do not strip `signature` fields from any content item.
+- Preserve `thinking` and `inline_thinking` items. Do not strip `phase` or `signature` fields.

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agenthub-typescript
-description: Guidance for using the AgentHub TypeScript SDK (`@prismshadow/agenthub`). Use this skill when developing agents that need to invoke different LLM APIs, or when a unified interface for different LLM providers is required. Also use this skill if the user mentions AgentHub, requests the use of the `@prismshadow/agenthub` package, or when `@prismshadow/agenthub` is already imported in the project.
+description: Guidance for using the AgentHub TypeScript SDK (`@prismshadow/agenthub`). Use when developing agents that call different LLM APIs, need a unified interface for LLM providers, mention AgentHub, request `@prismshadow/agenthub`, or already import it.
 ---
 
 # AgentHub TypeScript
 
-This skill provides guidance for using AgentHub's TypeScript SDK (`@prismshadow/agenthub`). AgentHub is a unified and precise LLM API hub for autonomous agents, providing a consistent interface across LLMs, reliable multi-step tool-call handling, and lightweight tracing for debugging and auditing executions.
+AgentHub is a unified SDK for calling LLMs across providers with shared data models, tool calling, tracing, and playground support.
 
 ## Installation
 
@@ -13,268 +13,142 @@ This skill provides guidance for using AgentHub's TypeScript SDK (`@prismshadow/
 npm install @prismshadow/agenthub
 ```
 
-## How to specify models
+## Model Selection
 
-Choose a model ID from the table, set the API key and base URL using the environment variables that the routed TypeScript client reads automatically, then create the client with `new AutoLLMClient({ model: modelId })`. Alternatively, pass them explicitly without relying on environment variables: `new AutoLLMClient({ model: modelId, apiKey: yourApiKey, baseUrl: yourBaseUrl })`.
+Use exact model IDs. Create with `new AutoLLMClient({ model: modelId })`, or pass credentials directly: `new AutoLLMClient({ model: modelId, apiKey: key, baseUrl: url })`. If a model ID is not listed, ask the user to confirm the exact ID before using it.
 
-| Model name | Vendor | Model IDs | API Key | Base URL |
+| Family | Provider | Model IDs | API Key | Base URL |
 | --- | --- | --- | --- | --- |
-| Gemini 3 / Gemini 3.1 LLM | Official / Google Vertex AI | `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| Gemini 3.1 image generation | Official / Google Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| Gemini 3.1 TTS | Official / Google Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 | Official / Vertex AI | `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.1-flash-lite` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 Image | Official / Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini 3 TTS | Official / Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
+| Gemini Embedding | Official / Vertex AI | `gemini-embedding-2` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Claude 4.6 | Official / ModelVerse | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
-| Claude 4.6 | Amazon Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
-| GPT-5.4 / GPT-5.5 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
-| GLM-5 | Official | `glm-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5 | OpenRouter | `z-ai/glm-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5 | SiliconFlow | `Pro/zai-org/GLM-5` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| Kimi-K2.5 | Official | `kimi-k2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Kimi-K2.5 | OpenRouter | `moonshotai/kimi-k2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Kimi-K2.5 | SiliconFlow | `Pro/moonshotai/Kimi-K2.5` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
-| Qwen3 | OpenRouter | `qwen/qwen3-8b`, `qwen/qwen3-30b-a3b-thinking-2507` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
-| Qwen3 | SiliconFlow | `Qwen/Qwen3-8B` | `QWEN3_API_KEY` | `QWEN3_BASE_URL` |
+| Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.7 | Bedrock | `global.anthropic.claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
+| Kimi-K2.6 | OpenRouter | `moonshotai/kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
+| Kimi-K2.6 | SiliconFlow | `Pro/moonshotai/Kimi-K2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | DeepSeek V4 | Official | `deepseek-v4-pro`, `deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| DeepSeek V4 | OpenRouter | `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| DeepSeek V4 | SiliconFlow | `deepseek-ai/DeepSeek-V4-Pro`, `deepseek-ai/DeepSeek-V4-Flash` | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` |
+| GLM-5.1 | Official | `glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.1 | OpenRouter | `z-ai/glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.1 | SiliconFlow | `Pro/zai-org/GLM-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| Qwen3.6 | OpenRouter | `qwen/qwen3.6-35b-a3b` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
+| Qwen3.6 | SiliconFlow | `Qwen/Qwen3.6-35B-A3B` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
 
-## Basic Usage
+Common gateway base URLs:
 
-Use `AutoLLMClient` and its methods for all LLM interaction and conversation tasks.
+- OpenRouter: `https://openrouter.ai/api/v1`
+- SiliconFlow: `https://api.siliconflow.cn/v1`
+- ModelVerse: `https://api.modelverse.cn/v1` (`https://api.modelverse.cn/` for Claude)
+- vLLM: `http://127.0.0.1:8000/v1/`
 
-```typescript
-import { AutoLLMClient } from "@prismshadow/agenthub";
+## Data Models
 
-process.env.OPENAI_API_KEY = "your-openai-api-key";
-
-async function main(): Promise<void> {
-  const client = new AutoLLMClient({ model: "gpt-5.5" });
-  const message = { // UniMessage
-    role: "user",
-    content_items: [{ type: "text", text: "Say 'Hello, World!'" }],
-  };
-  const config = { temperature: 1.0 }; // UniConfig
-
-  for await (const event of client.streamingResponseStateful({
-    message,
-    config,
-  })) {
-    // UniEvent
-    console.log(event);
-  }
-}
-
-void main();
-```
-
-## APIs
-
-`AutoLLMClient` is the main class for interacting with the AgentHub SDK. Prefer `streamingResponseStateful` for agent loops.
-
-After declaring `const client = new AutoLLMClient({ ... })`, you can use the following `AutoLLMClient` methods:
-
-```typescript
-/**
- * Stream one response without using client history.
- *
- * Call as `for await (const event of client.streamingResponse({ messages, config }))`.
- * Provide the complete ordered conversation in `messages`; the client yields
- * universal stream events and leaves stateful history unchanged.
- *
- * Args:
- *   options.messages: Complete ordered conversation to send for this request.
- *   options.config: Request options such as tools, temperature, or trace_id.
- *
- * Yields:
- *   UniEvent: Stream event in AgentHub's universal event format.
- */
-streamingResponse(options: {
-  messages: UniMessage[];
-  config: UniConfig;
-}): AsyncGenerator<UniEvent>;
-```
-
-
-```typescript
-/**
- * Stream one response while the client manages conversation history.
- *
- * Call as `for await (const event of client.streamingResponseStateful({ message, config }))`.
- * Pass only the next message; the client combines it with stored history and
- * records the completed turn after a successful response.
- *
- * Args:
- *   options.message: New user or assistant message for the next turn.
- *   options.config: Request options such as tools, temperature, or trace_id.
- *
- * Yields:
- *   UniEvent: Stream event in AgentHub's universal event format.
- */
-streamingResponseStateful(options: {
-  message: UniMessage;
-  config: UniConfig;
-}): AsyncGenerator<UniEvent>;
-```
-
-
-```typescript
-/**
- * Reset the stored stateful conversation history.
- *
- * Call as `client.clearHistory()` before starting an unrelated conversation
- * with the same model client.
- *
- * Returns:
- *   void.
- */
-clearHistory(): void;
-```
-
-
-```typescript
-/**
- * Return the current stateful conversation history.
- *
- * Call as `const history = client.getHistory()` to inspect or persist messages
- * accumulated by `streamingResponseStateful`.
- *
- * Returns:
- *   UniMessage[]: Copy of the client's stored conversation list.
- */
-getHistory(): UniMessage[];
-```
-
-
-```typescript
-/**
- * Replace the stored stateful conversation history.
- *
- * Call as `client.setHistory(history)` when restoring a conversation or
- * transferring history between clients. Pass a complete ordered message list.
- *
- * Args:
- *   history: Complete ordered conversation to store on the client.
- *
- * Returns:
- *   void.
- */
-setHistory(history: UniMessage[]): void;
-```
-
-## Data Model: UniConfig, UniMessage and UniEvent
-
-Use AgentHub's universal data model instead of provider-native response payloads.
+AgentHub uses `UniConfig`, `UniMessage`, and `UniEvent` to represent request options, conversation history, and streamed outputs across providers.
 
 ### UniConfig
 
-`UniConfig` is the request configuration passed as the `config` argument to `streamingResponse` and `streamingResponseStateful`.
-
-Example:
+`UniConfig` is the request config for `streamingResponse` and `streamingResponseStateful`. All fields are optional.
 
 ```typescript
 const config = {
   max_tokens: 1024,
   temperature: 1.0,
-  tools: [
-    {
-      name: "get_current_weather",
-      description: "Get the current weather in a given location",
-      parameters: {
-        type: "object",
-        properties: {
-          location: {
-            type: "string",
-            description: "The city and state, e.g. San Francisco, CA",
-          },
-        },
-        required: ["location"],
-      },
+  tools: [{
+    name: "get_weather",
+    description: "Get weather.",
+    parameters: {
+      type: "object",
+      properties: { location: { type: "string", description: "City name." } },
+      required: ["location"],
     },
-  ],
+  }],
+  tool_choice: "auto",
   thinking_summary: true,
   thinking_level: ThinkingLevel.HIGH,
-  tool_choice: "auto",
-  system_prompt: "You are a helpful assistant.",
+  system_prompt: "You are helpful.",
   prompt_caching: PromptCaching.ENABLE,
   image_config: { aspect_ratio: "4:3", image_size: "1K" },
   tts_config: [{ voice: "Kore" }],
+  embedding_config: { dimensions: 768 },
   trace_id: "agent1/conversation_001",
 };
 ```
 
-All fields of `UniConfig` are optional.
-
 Fields:
 
-- `max_tokens` (`number`): Output-token limit. Caps generated output length when the provider supports it.
-- `temperature` (`number`): Sampling temperature. Controls randomness when the provider supports it.
-- `tools` (`ToolSchema[]`): List of tools available to the model. Each tool requires `name: string` and `description: string`, and may include `parameters: Record<string, any>` as a JSON Schema object.
-- `thinking_summary` (`boolean`): Indicates whether the model should return its thinking process.
-- `thinking_level` (`ThinkingLevel`): Reasoning effort level, one of `ThinkingLevel.NONE`, `ThinkingLevel.LOW`, `ThinkingLevel.MEDIUM`, or `ThinkingLevel.HIGH`.
-- `tool_choice` (`ToolChoice`): Tool-calling configuration, one of `"auto"`, `"required"`, `"none"`, or a list of allowed tool names such as `["tool_a"]`. Only meaningful when `tools` is provided.
+- `max_tokens` (`number`): Output token limit.
+- `temperature` (`number`): Sampling temperature; support varies by model.
+- `tools` (`ToolSchema[]`): Tools with `name`, `description`, and optional JSON Schema `parameters`.
+- `thinking_summary` (`boolean`): Request a thinking summary when supported.
+- `thinking_level` (`ThinkingLevel`): `NONE`, `LOW`, `MEDIUM`, `HIGH`, or `XHIGH`.
+- `tool_choice` (`ToolChoice`): `auto`, `required`, `none`, or a list of tool names; support varies by model.
 - `system_prompt` (`string`): System instruction text.
-- `prompt_caching` (`PromptCaching`): Prompt cache mode, one of `PromptCaching.ENABLE`, `PromptCaching.DISABLE`, or `PromptCaching.ENHANCE`.
-- `image_config` (`ImageConfig`): Image-generation configuration with optional `aspect_ratio: AspectRatio` and `image_size: ImageSize`. `AspectRatio` is one of `"1:1"`, `"2:3"`, `"3:2"`, `"3:4"`, `"4:3"`, `"9:16"`, `"16:9"`, or `"21:9"`; `ImageSize` is `"1K"` or `"2K"`.
-- `tts_config` (`SpeakerConfig[]`): Speech-generation configuration. Each item requires `voice: string` and may include `speaker: string`; use one item for single-speaker TTS and two items with `speaker` names for multi-speaker TTS.
-- `trace_id` (`string`): Stable trace identifier. Saves conversation history under this ID for the tracer.
+- `prompt_caching` (`PromptCaching`): `ENABLE`, `DISABLE`, or `ENHANCE`.
+- `image_config` (`ImageConfig`): `aspect_ratio` (`1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `9:16`, `16:9`, `21:9`) and `image_size` (`1K`, `2K`).
+- `tts_config` (`SpeakerConfig[]`): Voice config; each item has `voice` and optional `speaker`.
+- `embedding_config` (`EmbeddingConfig`): Embedding config, currently `dimensions`.
+- `trace_id` (`string`): Stable ID for tracer output.
 
 ### UniMessage
 
-`UniMessage` is the durable conversation message shape, passed as `message` to `streamingResponseStateful`, as an element of `messages` to `streamingResponse`, and returned by `getHistory`.
-
-Example:
+`UniMessage` is the durable message shape used in history.
 
 ```typescript
 const message = {
   role: "user",
   content_items: [
-    { type: "text", text: "How are you doing?" },
+    { type: "text", text: "Hello", phase: null, signature: "sig" },
     { type: "image_url", image_url: "https://example.com/image.jpg" },
-    { type: "inline_data", mime_type: "image/jpeg", data: Buffer.from("...") },
-    { type: "thinking", thinking: "I am thinking.", signature: "0x123456" },
-    { type: "inline_thinking", mime_type: "image/jpeg", data: Buffer.from("...") },
-    { type: "tool_call", name: "math", arguments: { expression: "2 + 3" }, tool_call_id: "123" },
-    { type: "tool_result", text: "2 + 3 = 5", images: [], tool_call_id: "123" },
+    { type: "inline_data", data: Buffer.from("..."), mime_type: "image/png", signature: "sig" },
+    { type: "thinking", thinking: "Reasoning", signature: "sig" },
+    { type: "inline_thinking", data: Buffer.from("..."), mime_type: "image/png", signature: "sig" },
+    { type: "tool_call", name: "get_weather", arguments: { location: "Paris" }, tool_call_id: "call_1", signature: "sig" },
+    { type: "tool_result", text: "22 C", tool_call_id: "call_1" },
+    { type: "embedding", embedding: [0.1, 0.2] },
   ],
 };
 ```
 
 Fields:
 
-- `role` (`Role`): Message author, either `"user"` or `"assistant"`.
-- `content_items` (`ContentItem[]`): Durable message payload stored in history and trace records.
-- `usage_metadata` (`UsageMetadata | null`): Optional token usage for completed assistant messages.
-- `finish_reason` (`FinishReason | null`): Stop reason for a completed assistant message, one of `"stop"`, `"length"`, `"tool_call"`, `"unknown"`, or `null`.
-- `created_at` (`number`): Message creation timestamp in milliseconds since epoch.
+- `role` (`Role`): `user` or `assistant`.
+- `content_items` (`ContentItem[]`): Message payload.
+- `usage_metadata` (`UsageMetadata | null`): Optional token counts on completed assistant messages.
+- `finish_reason` (`FinishReason | null`): `stop`, `length`, `tool_call`, `unknown`, or `null`.
+- `created_at` (`number`): Unix milliseconds.
 
-Durable `content_items` types:
+Content items:
 
-- `text`: Plain text content. Required properties: `type: "text"`, `text: string`. Optional property: `phase: string | null`.
-- `image_url`: External image URL or data URI. Required properties: `type: "image_url"`, `image_url: string`.
-- `inline_data`: Inline binary image or audio content. Required properties: `type: "inline_data"`, `data: Buffer`, `mime_type: string`.
-- `thinking`: Text reasoning content returned by the model. Required properties: `type: "thinking"`, `thinking: string`.
-- `inline_thinking`: Binary reasoning artifact, such as generated-image thinking data. Required properties: `type: "inline_thinking"`, `data: Buffer`, `mime_type: string`.
-- `tool_call`: Complete tool invocation. Required properties: `type: "tool_call"`, `name: string`, `arguments: Record<string, any>`, `tool_call_id: string`.
-- `tool_result`: Tool execution result to send back to the model. Required properties: `type: "tool_result"`, `text: string`, `tool_call_id: string`. Optional property: `images: string[]`.
+- `text`: Text chunk; `phase` marks sub-stage; `signature` verifies signed content.
+- `image_url`: Image URL or data URI.
+- `inline_data`: Inline media bytes with MIME type; may carry `signature`.
+- `thinking`: Text reasoning content; may carry `signature`.
+- `inline_thinking`: Binary reasoning artifact; may carry `signature`.
+- `tool_call`: Complete model tool request with name, args, ID, and optional `signature`.
+- `tool_result`: Tool output text for a `tool_call_id`; may include image URLs.
+- `embedding`: Numeric embedding vector.
 
-The `text`, `inline_data`, `thinking`, `inline_thinking`, `tool_call`, and `partial_tool_call` items may carry an optional `signature` field. Do not strip or modify `signature` fields.
+Preserve `phase` and `signature`; never drop either field.
 
 ### UniEvent
 
-`UniEvent` is the streamed output shape, yielded from `streamingResponse` and `streamingResponseStateful`.
-
-Example:
+`UniEvent` is the streamed output shape. Read token counts from `usage_metadata` here.
 
 ```typescript
 const event = {
   role: "assistant",
-  event_type: "start",
+  event_type: "delta",
   content_items: [
-    { type: "partial_tool_call", name: "math", arguments: "", tool_call_id: "123" },
+    { type: "partial_tool_call", name: "get_weather", arguments: "{\"location\":\"Par", tool_call_id: "call_1" },
   ],
-  usage_metadata: {
-    cached_tokens: null,
-    prompt_tokens: 10,
-    thoughts_tokens: null,
-    response_tokens: 1,
-  },
+  usage_metadata: { cached_tokens: 0, prompt_tokens: 10, thoughts_tokens: null, response_tokens: 1 },
   finish_reason: null,
   created_at: 1694502400000,
 };
@@ -282,37 +156,42 @@ const event = {
 
 Fields:
 
-- `role` (`Role`): Event author, either `"user"` or `"assistant"`.
-- `event_type` (`EventType`): Stream lifecycle marker, including `start`, `stop`, and `unused`. Indicates where the event sits in the stream lifecycle.
-- `content_items` (`PartialContentItem[]`): Stream payload. Same as `UniMessage.content_items`, plus event-only `partial_tool_call`.
-- `usage_metadata` (`UsageMetadata | null`): Stream token accounting, or `null`.
-- `finish_reason` (`FinishReason | null`): Stream stop reason, one of `"stop"`, `"length"`, `"tool_call"`, `"unknown"`, or `null`.
-- `created_at` (`number`): Event creation timestamp in milliseconds since epoch.
+- `role` (`Role`): `user` or `assistant`.
+- `event_type` (`EventType`): `start`, `delta`, `stop`, or `unused`.
+- `content_items` (`PartialContentItem[]`): Stream payload; includes `ContentItem` plus `partial_tool_call`.
+- `usage_metadata` (`UsageMetadata | null`): Token counts: `cached_tokens`, `prompt_tokens`, `thoughts_tokens`, `response_tokens`.
+  Token math: `input = cached_tokens + prompt_tokens`; `output = thoughts_tokens + response_tokens`; treat `null` as `0`.
+- `finish_reason` (`FinishReason | null`): `stop`, `length`, `tool_call`, `unknown`, or `null`.
+- `created_at` (`number`): Unix milliseconds.
 
-Event-only `content_items` type:
+Event-only content item:
 
-- `partial_tool_call`: Streamed tool-call fragment. Required properties: `type: "partial_tool_call"`, `name: string`, `arguments: string`, `tool_call_id: string`. `arguments` carries partial JSON string content, and `tool_call_id` links the later complete `tool_call`.
+- `partial_tool_call`: Streaming tool-call fragment with `name`, partial JSON `arguments`, and `tool_call_id`.
 
-## Token Usage Calculation
+## APIs
 
-AgentHub provides token usage information through the `usage_metadata` field in `UniMessage` and `UniEvent`.
+`AutoLLMClient` exposes five basic APIs. Prefer the stateful stream for agent loops.
 
-`UsageMetadata` contains four fields:
+```typescript
+/** Stream one stateless response from a full message list. */
+streamingResponse(options: { messages: UniMessage[]; config: UniConfig }): AsyncGenerator<UniEvent>;
 
-- `cached_tokens` (`number | null`): Cached input tokens.
-- `prompt_tokens` (`number | null`): Non-cached input tokens.
-- `thoughts_tokens` (`number | null`): Chain-of-thought output tokens.
-- `response_tokens` (`number | null`): Non-chain-of-thought output tokens.
+/** Stream one stateful response and update client history. */
+streamingResponseStateful(options: { message: UniMessage; config: UniConfig }): AsyncGenerator<UniEvent>;
 
-Calculate total token usage as:
+/** Return a copy of stateful history. */
+getHistory(): UniMessage[];
 
-- `input_tokens = (cached_tokens ?? 0) + (prompt_tokens ?? 0)`
-- `output_tokens = (thoughts_tokens ?? 0) + (response_tokens ?? 0)`
-- `total_tokens = input_tokens + output_tokens`
+/** Replace stateful history with a copy. */
+setHistory(history: UniMessage[]): void;
 
-## Usage Example
+/** Clear stateful history. */
+clearHistory(): void;
+```
 
-Tool calling example:
+## Basic Usage
+
+This example asks GPT to call a weather tool, runs the tool, then sends the result back.
 
 ```typescript
 import { AutoLLMClient } from "@prismshadow/agenthub";
@@ -387,18 +266,17 @@ void main();
 ```
 
 
-## Tracer Usage
+## Tracer
 
-Use Tracer to save AgentHub conversation history and inspect it in a local web UI.
+Tracer saves trace files and serves a local UI for inspecting conversations.
 
-Set `trace_id` in `config` to save trace files:
+Set `trace_id` to save trace files:
 
 ```typescript
 import { AutoLLMClient } from "@prismshadow/agenthub";
 
 const client = new AutoLLMClient({ model: "gpt-5.5" });
 
-// Add trace_id to config
 const config = { trace_id: "agent1/conversation_001" };
 
 for await (const event of client.streamingResponseStateful({
@@ -412,12 +290,12 @@ for await (const event of client.streamingResponseStateful({
 }
 ```
 
-The default cache directory is `cache`; change it by setting the `AGENTHUB_CACHE_DIR` environment variable. With `trace_id="agent1/conversation_001"`, AgentHub creates:
+Default cache dir: `cache`, or `AGENTHUB_CACHE_DIR`. For `trace_id="agent1/conversation_001"`, AgentHub writes:
 
 - `cache/agent1/conversation_001.json`: Structured trace data with the full history and config.
 - `cache/agent1/conversation_001.txt`: Human-readable conversation transcript.
 
-Browse traces from TypeScript using the default cache directory:
+Browse traces:
 
 ```typescript
 import { Tracer } from "@prismshadow/agenthub/integration/tracer";
@@ -426,13 +304,13 @@ const tracer = new Tracer();
 tracer.startWebServer("127.0.0.1", 25750);
 ```
 
-After starting the server, open `http://127.0.0.1:25750` in a browser to inspect traces.
+Open Tracer at `http://127.0.0.1:25750`.
 
-## Playground Usage
+## Playground
 
-Use Playground when a manual chat web UI is needed or when chatting with LLMs manually.
+Playground starts a local chat UI for manual model checks.
 
-Use the playground for manual model checks:
+Start Playground for manual chat:
 
 ```typescript
 import { startPlaygroundServer } from "@prismshadow/agenthub/integration/playground";
@@ -440,11 +318,11 @@ import { startPlaygroundServer } from "@prismshadow/agenthub/integration/playgro
 startPlaygroundServer("127.0.0.1", 25751);
 ```
 
-After starting the server, open `http://127.0.0.1:25751` in a browser to chat.
+Open Playground at `http://127.0.0.1:25751`.
 
 ## Notes
 
 Keep these points in mind for agent loops:
 
 - Send every tool result with the exact `tool_call_id` from its originating `tool_call`. Do not invent, normalize, or reuse IDs across unrelated tool calls.
-- Preserve `thinking` and `inline_thinking` items. Do not strip `signature` fields from any content item.
+- Preserve `thinking` and `inline_thinking` items. Do not strip `phase` or `signature` fields.

--- a/src_py/agenthub/claude4_7/client.py
+++ b/src_py/agenthub/claude4_7/client.py
@@ -148,7 +148,7 @@ class Claude4_7Client(LLMClient):
         else:
             claude_config["max_tokens"] = 32768  # Claude requires max_tokens to be specified
 
-        if config.get("temperature") is not None:
+        if config.get("temperature") is not None and config["temperature"] != 1.0:
             raise ValueError("Claude 4.7 does not support setting temperature.")
 
         if config.get("thinking_level") is not None:

--- a/src_py/agenthub/deepseek_v4/client.py
+++ b/src_py/agenthub/deepseek_v4/client.py
@@ -88,7 +88,7 @@ class DeepSeekV4Client(LLMClient):
         if config.get("max_tokens") is not None:
             deepseek_config["max_tokens"] = config["max_tokens"]
 
-        if config.get("temperature") is not None:
+        if config.get("temperature") is not None and config["temperature"] != 1.0:
             raise ValueError("DeepSeek V4 does not support setting temperature.")
 
         thinking_level = config.get("thinking_level")

--- a/src_ts/src/claude4_7/client.ts
+++ b/src_ts/src/claude4_7/client.ts
@@ -198,7 +198,7 @@ export class Claude4_7Client extends LLMClient {
       claudeConfig.max_tokens = 32768;
     }
 
-    if (config.temperature !== undefined) {
+    if (config.temperature !== undefined && config.temperature !== 1.0) {
       throw new Error("Claude 4.7 does not support setting temperature.");
     }
 

--- a/src_ts/src/deepseek_v4/client.ts
+++ b/src_ts/src/deepseek_v4/client.ts
@@ -98,7 +98,7 @@ export class DeepSeekV4Client extends LLMClient {
       deepseekConfig.max_tokens = config.max_tokens;
     }
 
-    if (config.temperature !== undefined) {
+    if (config.temperature !== undefined && config.temperature !== 1.0) {
       throw new Error("DeepSeek V4 does not support setting temperature.");
     }
 


### PR DESCRIPTION
## Summary
- refresh AgentHub Python and TypeScript skill docs with concise structure, new model IDs, data model guidance, and Tracer/Playground sections
- add README guidance for installing AgentHub SKILL files for coding agents
- allow temperature=1.0 as the default value for models that otherwise reject custom temperature settings

## Tests
- cd src_py && make test
- cd src_ts && make test