### PR TITLE
Add abort support to playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions.
 
+- [2026-05-28] Add abort support and agent skills.
+
 - [2026-05-27] Support Gemini 3.5, Gemini Embedding 2, Claude 4.7, Kimi-K2.6, GLM-5.1, DeepSeek V4 and Qwen3.6 models. Qwen3 models are deprecated.
 
 - [2026-04-28] Release version 0.3.1.

--- a/src_py/agenthub/abort_signal.py
+++ b/src_py/agenthub/abort_signal.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import suppress
+from typing import Any, Awaitable, TypeVar
+
+
+T = TypeVar("T")
+
+
+class AbortSignal:
+    """Abort signal that can also trigger its own aborted state."""
+
+    def __init__(self) -> None:
+        self._aborted = False
+        self._reason: Any = None
+        self._waiters: set[asyncio.Future[None]] = set()
+
+    @property
+    def aborted(self) -> bool:
+        return self._aborted
+
+    @property
+    def reason(self) -> Any:
+        return self._reason
+
+    def abort(self, reason: Any = None) -> None:
+        if self._aborted:
+            return
+
+        self._aborted = True
+        self._reason = reason
+
+        waiters = tuple(self._waiters)
+        self._waiters.clear()
+        for waiter in waiters:
+            loop = waiter.get_loop()
+            if loop.is_running():
+                loop.call_soon_threadsafe(_set_waiter_result, waiter)
+            else:
+                _set_waiter_result(waiter)
+
+    async def wait(self) -> None:
+        if self._aborted:
+            return
+
+        loop = asyncio.get_running_loop()
+        waiter = loop.create_future()
+        self._waiters.add(waiter)
+        if self._aborted:
+            self._waiters.discard(waiter)
+            _set_waiter_result(waiter)
+        try:
+            await waiter
+        finally:
+            self._waiters.discard(waiter)
+
+    def throw_if_aborted(self) -> None:
+        if self._aborted:
+            raise _cancelled_error(self._reason)
+
+
+async def run_with_abort(awaitable: Awaitable[T], signal: AbortSignal) -> T:
+    """Run an awaitable and cancel it when the signal is aborted."""
+
+    task = asyncio.ensure_future(awaitable)
+
+    if signal.aborted:
+        task.cancel(signal.reason)
+        with suppress(asyncio.CancelledError):
+            await task
+        raise _cancelled_error(signal.reason)
+
+    abort_task = asyncio.create_task(signal.wait())
+
+    try:
+        done, _ = await asyncio.wait((task, abort_task), return_when=asyncio.FIRST_COMPLETED)
+        if task in done:
+            return await task
+
+        task.cancel(signal.reason)
+        with suppress(asyncio.CancelledError):
+            await task
+        raise _cancelled_error(signal.reason)
+    except asyncio.CancelledError:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        raise
+    finally:
+        if not abort_task.done():
+            abort_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await abort_task
+
+
+def _set_waiter_result(waiter: asyncio.Future[None]) -> None:
+    if not waiter.done():
+        waiter.set_result(None)
+
+
+def _cancelled_error(reason: Any) -> asyncio.CancelledError:
+    if reason is None:
+        return asyncio.CancelledError()
+
+    return asyncio.CancelledError(reason)

--- a/src_py/agenthub/abort_signal.py
+++ b/src_py/agenthub/abort_signal.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import threading
 from contextlib import suppress
 from typing import Any, Awaitable, TypeVar
 
@@ -24,52 +25,56 @@ class AbortSignal:
     """Abort signal that can also trigger its own aborted state."""
 
     def __init__(self) -> None:
+        self._lock = threading.Lock()
         self._aborted = False
         self._reason: Any = None
         self._waiters: set[asyncio.Future[None]] = set()
 
     @property
     def aborted(self) -> bool:
-        return self._aborted
+        with self._lock:
+            return self._aborted
 
     @property
     def reason(self) -> Any:
-        return self._reason
+        with self._lock:
+            return self._reason
 
     def abort(self, reason: Any = None) -> None:
-        if self._aborted:
-            return
+        with self._lock:
+            if self._aborted:
+                return
 
-        self._aborted = True
-        self._reason = reason
+            self._aborted = True
+            self._reason = reason
+            waiters = tuple(self._waiters)
+            self._waiters.clear()
 
-        waiters = tuple(self._waiters)
-        self._waiters.clear()
         for waiter in waiters:
-            loop = waiter.get_loop()
-            if loop.is_running():
-                loop.call_soon_threadsafe(_set_waiter_result, waiter)
-            else:
-                _set_waiter_result(waiter)
+            _notify_waiter(waiter)
 
     async def wait(self) -> None:
-        if self._aborted:
-            return
-
         loop = asyncio.get_running_loop()
         waiter = loop.create_future()
-        self._waiters.add(waiter)
-        if self._aborted:
-            self._waiters.discard(waiter)
-            _set_waiter_result(waiter)
+        with self._lock:
+            if self._aborted:
+                return
+
+            self._waiters.add(waiter)
+
         try:
             await waiter
         finally:
-            self._waiters.discard(waiter)
+            with self._lock:
+                self._waiters.discard(waiter)
 
     def throw_if_aborted(self) -> None:
-        if self._aborted:
-            raise _cancelled_error(self._reason)
+        with self._lock:
+            aborted = self._aborted
+            reason = self._reason
+
+        if aborted:
+            raise _cancelled_error(reason)
 
 
 async def run_with_abort(awaitable: Awaitable[T], signal: AbortSignal) -> T:
@@ -110,6 +115,17 @@ async def run_with_abort(awaitable: Awaitable[T], signal: AbortSignal) -> T:
 def _set_waiter_result(waiter: asyncio.Future[None]) -> None:
     if not waiter.done():
         waiter.set_result(None)
+
+
+def _notify_waiter(waiter: asyncio.Future[None]) -> None:
+    loop = waiter.get_loop()
+    if loop.is_closed():
+        return
+
+    if loop.is_running():
+        loop.call_soon_threadsafe(_set_waiter_result, waiter)
+    else:
+        _set_waiter_result(waiter)
 
 
 def _cancelled_error(reason: Any) -> asyncio.CancelledError:

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -15,6 +15,7 @@
 import os
 from typing import Any, AsyncIterator
 
+from .abort_signal import AbortSignal
 from .base_client import LLMClient
 from .types import UniConfig, UniEvent, UniMessage
 
@@ -109,11 +110,13 @@ class AutoLLMClient(LLMClient):
         self,
         messages: list[UniMessage],
         config: UniConfig,
+        signal: AbortSignal | None = None,
     ) -> AsyncIterator[UniEvent]:
         """Route to underlying client's streaming_response."""
         async for event in self._client.streaming_response(
             messages=messages,
             config=config,
+            signal=signal,
         ):
             yield event
 
@@ -121,11 +124,13 @@ class AutoLLMClient(LLMClient):
         self,
         message: UniMessage,
         config: UniConfig,
+        signal: AbortSignal | None = None,
     ) -> AsyncIterator[UniEvent]:
         """Route to underlying client's streaming_response_stateful."""
         async for event in self._client.streaming_response_stateful(
             message=message,
             config=config,
+            signal=signal,
         ):
             yield event
 

--- a/src_py/agenthub/base_client.py
+++ b/src_py/agenthub/base_client.py
@@ -16,6 +16,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator
 
+from .abort_signal import AbortSignal, run_with_abort
 from .types import (
     ContentItem,
     FinishReason,
@@ -163,6 +164,7 @@ class LLMClient(ABC):
         self,
         messages: list[UniMessage],
         config: UniConfig,
+        signal: AbortSignal | None = None,
     ) -> AsyncIterator[UniEvent]:
         """
         Generate content in streaming mode (stateless).
@@ -174,6 +176,7 @@ class LLMClient(ABC):
         Args:
             messages: List of universal message dictionaries containing conversation history
             config: Universal configuration dict
+            signal: Optional abort signal used to cancel the active request
 
         Yields:
             Universal events from the streaming response
@@ -185,11 +188,20 @@ class LLMClient(ABC):
 
         last_event: UniEvent | None = None
         events = []
-        async for event in self._streaming_response_internal(messages, config):
-            event["created_at"] = int(time.time() * 1000)
-            last_event = event
-            events.append(event)
-            yield event
+        stream = self._streaming_response_internal(messages, config)
+        try:
+            while True:
+                try:
+                    event = await anext(stream) if signal is None else await run_with_abort(anext(stream), signal)
+                except StopAsyncIteration:
+                    break
+
+                event["created_at"] = int(time.time() * 1000)
+                last_event = event
+                events.append(event)
+                yield event
+        finally:
+            await stream.aclose()
 
         self._validate_last_event(last_event)
 
@@ -205,6 +217,7 @@ class LLMClient(ABC):
         self,
         message: UniMessage,
         config: UniConfig,
+        signal: AbortSignal | None = None,
     ) -> AsyncIterator[UniEvent]:
         """
         Generate content in streaming mode (stateful).
@@ -216,6 +229,7 @@ class LLMClient(ABC):
         Args:
             message: Latest universal message dictionary to add to conversation
             config: Universal configuration dict
+            signal: Optional abort signal used to cancel the active request
 
         Yields:
             Universal events from the streaming response
@@ -225,7 +239,7 @@ class LLMClient(ABC):
 
         # Collect all events for history
         events = []
-        async for event in self.streaming_response(messages=temp_messages, config=config):
+        async for event in self.streaming_response(messages=temp_messages, config=config, signal=signal):
             events.append(event)
             yield event
 

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -23,6 +23,7 @@ showing token usage and stop reasons.
 
 import asyncio
 import base64
+import concurrent.futures
 import json
 import threading
 from typing import Any
@@ -32,6 +33,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from .. import AutoLLMClient
+from ..abort_signal import AbortSignal
 from .tracer import Tracer
 
 
@@ -40,6 +42,7 @@ _event_loop: asyncio.AbstractEventLoop | None = None
 _loop_lock = threading.Lock()
 _session_clients: dict[str, AutoLLMClient] = {}
 _session_client_options: dict[str, tuple[str, str | None, str | None]] = {}
+_session_abort_signals: dict[str, AbortSignal] = {}
 
 
 def _get_event_loop() -> asyncio.AbstractEventLoop:
@@ -353,8 +356,9 @@ def create_chat_app() -> Flask:
             <div class="flex gap-3 max-w-5xl mx-auto">
                 <input type="file" id="imageInput" accept="image/*" multiple class="hidden" onchange="handleImageSelect(event)">
                 <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" onclick="document.getElementById('imageInput').click()">📎 Image</button>
-                <textarea id="messageInput" class="flex-1 px-4 py-3 border border-gray-300 rounded-md text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Type your message here..." rows="1"></textarea>
+                <textarea id="messageInput" class="flex-1 px-4 py-3 border border-gray-300 rounded-md text-sm resize-none overflow-y-hidden focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Type your message here..." rows="1"></textarea>
                 <button class="bg-green-600 hover:bg-green-700 disabled:bg-green-300 disabled:cursor-not-allowed text-white px-6 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" id="sendButton" onclick="sendMessage()">Send</button>
+                <button class="hidden bg-orange-600 hover:bg-orange-700 disabled:bg-orange-300 disabled:cursor-not-allowed text-white px-6 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" id="stopButton" onclick="stopGeneration()" disabled>Stop</button>
                 <button class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-md text-sm font-semibold transition-colors" onclick="clearChat()">Clear</button>
             </div>
         </div>
@@ -364,6 +368,7 @@ def create_chat_app() -> Flask:
             let sessionId = Math.random().toString(36).substring(7);
             let selectedImages = [];
             let lastMessageTimestamp = null;
+            let currentAbortController = null;
 
             function escapeHtml(text) {
                 const div = document.createElement('div');
@@ -711,18 +716,59 @@ def create_chat_app() -> Flask:
                 return card;
             }
 
+            function setStreamingControls(streaming) {
+                const sendButton = document.getElementById('sendButton');
+                const stopButton = document.getElementById('stopButton');
+                sendButton.disabled = streaming;
+                stopButton.disabled = !streaming;
+                stopButton.classList.toggle('hidden', !streaming);
+            }
+
+            function stopGeneration() {
+                if (!isStreaming) return;
+
+                fetch('/api/abort', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        session_id: sessionId
+                    }),
+                    keepalive: true
+                }).catch(error => {
+                    console.error('Error interrupting chat:', error);
+                });
+
+                if (currentAbortController) {
+                    currentAbortController.abort();
+                }
+            }
+
+            function markInterrupted(contentDiv) {
+                if (!contentDiv.textContent.trim() && contentDiv.children.length === 0) {
+                    contentDiv.textContent = 'Interrupted.';
+                    return;
+                }
+
+                const interruptedDiv = document.createElement('div');
+                interruptedDiv.className = 'mt-3 text-xs font-semibold text-orange-600';
+                interruptedDiv.textContent = 'Interrupted';
+                contentDiv.appendChild(interruptedDiv);
+            }
+
             async function sendMessage() {
                 const input = document.getElementById('messageInput');
-                const sendButton = document.getElementById('sendButton');
                 const container = document.getElementById('messagesContainer');
                 const message = input.value.trim();
 
                 if ((!message && selectedImages.length === 0) || isStreaming) return;
 
                 isStreaming = true;
-                sendButton.disabled = true;
+                currentAbortController = new AbortController();
+                setStreamingControls(true);
                 input.value = '';
-                input.style.height = 'auto';
+                resizeMessageInput();
 
                 const currentImages = [...selectedImages];
                 selectedImages = [];
@@ -759,7 +805,8 @@ def create_chat_app() -> Flask:
                             },
                             config: config,
                             session_id: sessionId
-                        })
+                        }),
+                        signal: currentAbortController.signal
                     });
 
                     if (!response.ok || !response.body) {
@@ -920,13 +967,18 @@ def create_chat_app() -> Flask:
                     }
 
                 } catch (error) {
-                    contentDiv.textContent = `Error: ${error.message}`;
-                    console.error('Error:', error);
+                    if (error.name === 'AbortError') {
+                        markInterrupted(contentDiv);
+                    } else {
+                        contentDiv.textContent = `Error: ${error.message}`;
+                        console.error('Error:', error);
+                    }
                     lastMessageTimestamp = Date.now();
+                } finally {
+                    isStreaming = false;
+                    currentAbortController = null;
+                    setStreamingControls(false);
                 }
-
-                isStreaming = false;
-                sendButton.disabled = false;
             }
 
             function clearChat() {
@@ -963,10 +1015,15 @@ def create_chat_app() -> Flask:
             });
 
             const textarea = document.getElementById('messageInput');
-            textarea.addEventListener('input', function() {
-                this.style.height = 'auto';
-                this.style.height = Math.min(this.scrollHeight, 200) + 'px';
-            });
+            function resizeMessageInput() {
+                const maxHeight = 200;
+                textarea.style.height = 'auto';
+                const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
+                textarea.style.height = nextHeight + 'px';
+                textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+            }
+            textarea.addEventListener('input', resizeMessageInput);
+            resizeMessageInput();
 
         </script>
     </body>
@@ -991,6 +1048,13 @@ def create_chat_app() -> Flask:
 
         def generate():
             """Generate streaming response using the persistent event loop."""
+            signal = AbortSignal()
+            previous_signal = _session_abort_signals.get(session_id)
+            if previous_signal is not None:
+                previous_signal.abort("replaced")
+            _session_abort_signals[session_id] = signal
+            async_gen = None
+            loop = _get_event_loop()
             try:
                 # Get or create client for this session
                 client_options = _get_client_options(config)
@@ -1002,12 +1066,13 @@ def create_chat_app() -> Flask:
                 client = _session_clients[session_id]
                 request_config = _get_request_config(config)
 
-                # Get the persistent event loop
-                loop = _get_event_loop()
-
                 # Create async function to collect events
                 async def stream_events():
-                    async for event in client.streaming_response_stateful(message=message, config=request_config):
+                    async for event in client.streaming_response_stateful(
+                        message=message,
+                        config=request_config,
+                        signal=signal,
+                    ):
                         # Serialize event to handle bytes objects
                         serialized_event = _serialize_for_json(event)
                         yield f"data: {json.dumps(serialized_event, ensure_ascii=False)}\n\n"
@@ -1020,6 +1085,17 @@ def create_chat_app() -> Flask:
                     except StopAsyncIteration:
                         break
 
+                yield "data: [DONE]\n\n"
+            except (asyncio.CancelledError, concurrent.futures.CancelledError):
+                yield "data: [DONE]\n\n"
+            except GeneratorExit:
+                signal.abort("client disconnected")
+                if async_gen is not None:
+                    try:
+                        asyncio.run_coroutine_threadsafe(async_gen.aclose(), loop).result(timeout=1)
+                    except Exception:
+                        pass
+                raise
             except Exception as e:
                 error_event = {
                     "role": "assistant",
@@ -1028,14 +1104,34 @@ def create_chat_app() -> Flask:
                 }
                 yield f"data: {json.dumps(error_event, ensure_ascii=False)}\n\n"
                 yield "data: [DONE]\n\n"
+            finally:
+                signal.abort("request ended")
+                if _session_abort_signals.get(session_id) is signal:
+                    del _session_abort_signals[session_id]
 
         return Response(generate(), mimetype="text/event-stream")
+
+    @app.route("/api/abort", methods=["POST"])
+    def abort() -> Response:
+        """Interrupt the active streaming response for a session."""
+        data = request.json or {}
+        session_id = data.get("session_id", "default")
+        signal = _session_abort_signals.get(session_id)
+        if signal is None:
+            return jsonify({"status": "idle"})
+
+        signal.abort("interrupted")
+        return jsonify({"status": "aborted"})
 
     @app.route("/api/clear", methods=["POST"])
     def clear() -> Response:
         """Clear chat history for a session."""
-        data = request.json
+        data = request.json or {}
         session_id = data.get("session_id", "default")
+
+        signal = _session_abort_signals.pop(session_id, None)
+        if signal is not None:
+            signal.abort("cleared")
 
         # Clear the client history if it exists
         if session_id in _session_clients:

--- a/src_py/tests/test_abort_signal.py
+++ b/src_py/tests/test_abort_signal.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import threading
 from typing import Any, AsyncIterator
 
 import pytest
@@ -89,6 +90,22 @@ async def test_abort_signal_waits_until_aborted() -> None:
 
     await asyncio.wait_for(waiter, timeout=1)
     assert signal.aborted
+
+
+@pytest.mark.asyncio
+async def test_abort_signal_can_abort_from_another_thread() -> None:
+    signal = AbortSignal()
+    waiter = asyncio.create_task(signal.wait())
+
+    await asyncio.sleep(0)
+
+    thread = threading.Thread(target=lambda: signal.abort("thread-stop"))
+    thread.start()
+    thread.join(timeout=1)
+
+    await asyncio.wait_for(waiter, timeout=1)
+    assert signal.aborted
+    assert signal.reason == "thread-stop"
 
 
 @pytest.mark.asyncio

--- a/src_py/tests/test_abort_signal.py
+++ b/src_py/tests/test_abort_signal.py
@@ -1,0 +1,180 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+
+from agenthub.abort_signal import AbortSignal, run_with_abort
+from agenthub.base_client import LLMClient
+from agenthub.types import UniConfig, UniEvent, UniMessage
+
+
+class SlowStreamingClient(LLMClient):
+    def __init__(self) -> None:
+        self._model = "slow-test"
+        self._history = []
+        self.started = asyncio.Event()
+        self.cleaned = asyncio.Event()
+
+    def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
+        return dict(config)
+
+    def transform_uni_message_to_model_input(self, messages: list[UniMessage]) -> list[UniMessage]:
+        return messages
+
+    def transform_model_output_to_uni_event(self, model_output: UniEvent) -> UniEvent:
+        return model_output
+
+    async def _streaming_response_internal(
+        self,
+        messages: list[UniMessage],
+        config: UniConfig,
+    ) -> AsyncIterator[UniEvent]:
+        self.started.set()
+        try:
+            await asyncio.sleep(60)
+        finally:
+            self.cleaned.set()
+
+        yield {
+            "role": "assistant",
+            "event_type": "stop",
+            "content_items": [],
+            "usage_metadata": {
+                "cached_tokens": None,
+                "prompt_tokens": None,
+                "thoughts_tokens": None,
+                "response_tokens": None,
+            },
+            "finish_reason": "stop",
+            "created_at": 0,
+        }
+
+
+def test_abort_signal_state_is_idempotent() -> None:
+    signal = AbortSignal()
+
+    assert not signal.aborted
+    assert signal.reason is None
+
+    signal.abort("first")
+    signal.abort("second")
+
+    assert signal.aborted
+    assert signal.reason == "first"
+
+
+@pytest.mark.asyncio
+async def test_abort_signal_waits_until_aborted() -> None:
+    signal = AbortSignal()
+    waiter = asyncio.create_task(signal.wait())
+
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    signal.abort("stop")
+
+    await asyncio.wait_for(waiter, timeout=1)
+    assert signal.aborted
+
+
+@pytest.mark.asyncio
+async def test_run_with_abort_returns_result_without_abort() -> None:
+    async def work() -> str:
+        await asyncio.sleep(0)
+        return "done"
+
+    assert await run_with_abort(work(), AbortSignal()) == "done"
+
+
+@pytest.mark.asyncio
+async def test_run_with_abort_cancels_coroutine_when_signal_aborts() -> None:
+    signal = AbortSignal()
+    started = asyncio.Event()
+    cleaned = asyncio.Event()
+
+    async def work() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        finally:
+            cleaned.set()
+        return "done"
+
+    task = asyncio.create_task(run_with_abort(work(), signal))
+    await started.wait()
+
+    signal.abort("stop")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleaned.is_set()
+
+
+@pytest.mark.asyncio
+async def test_run_with_abort_does_not_start_when_signal_is_already_aborted() -> None:
+    signal = AbortSignal()
+    signal.abort("stop")
+    started = False
+
+    async def work() -> str:
+        nonlocal started
+        started = True
+        return "done"
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_with_abort(work(), signal)
+
+    assert not started
+
+
+@pytest.mark.asyncio
+async def test_run_with_abort_cancels_existing_task_when_signal_is_already_aborted() -> None:
+    signal = AbortSignal()
+    signal.abort("stop")
+    started = asyncio.Event()
+
+    async def work() -> str:
+        started.set()
+        await asyncio.sleep(60)
+        return "done"
+
+    task = asyncio.create_task(work())
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_with_abort(task, signal)
+
+    assert task.cancelled()
+    assert not started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_cancels_current_iteration_when_signal_aborts() -> None:
+    client = SlowStreamingClient()
+    signal = AbortSignal()
+    messages: list[UniMessage] = [{"role": "user", "content_items": [{"type": "text", "text": "hello"}]}]
+    stream = client.streaming_response(messages=messages, config={}, signal=signal)
+
+    task = asyncio.create_task(anext(stream))
+    await client.started.wait()
+
+    signal.abort("stop")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert client.cleaned.is_set()

--- a/src_py/tests/test_playground.py
+++ b/src_py/tests/test_playground.py
@@ -14,6 +14,7 @@
 
 from flask import Flask
 
+from agenthub.abort_signal import AbortSignal
 from agenthub.integration import playground
 from agenthub.integration.playground import create_chat_app
 
@@ -52,6 +53,10 @@ def test_chat_app_index_route():
         assert b"apiKeyInput" in response.data
         assert b"apiKeyVisibilityToggle" in response.data
         assert b"toggleApiKeyVisibility()" in response.data
+        assert b'id="stopButton"' in response.data
+        assert b"stopGeneration()" in response.data
+        assert b"currentAbortController.abort()" in response.data
+        assert b"/api/abort" in response.data
         assert b'id="apiKeyVisibilityShowIcon" class="hidden"' in response.data
         assert b'id="apiKeyVisibilityHideIcon" xmlns=' in response.data
         assert b"baseUrlInput" in response.data
@@ -101,8 +106,9 @@ def test_chat_app_uses_client_connection_options(monkeypatch):
                 "base_url": base_url,
             }
 
-        async def streaming_response_stateful(self, message, config):
+        async def streaming_response_stateful(self, message, config, signal=None):
             captured["request_config"] = config
+            captured["signal"] = signal
             yield {
                 "role": "assistant",
                 "event_type": "stop",
@@ -144,6 +150,7 @@ def test_chat_app_uses_client_connection_options(monkeypatch):
         "base_url": "https://example.test/v1",
     }
     assert captured["request_config"] == {"thinking_level": "low"}
+    assert isinstance(captured["signal"], AbortSignal)
 
 
 def test_chat_app_accepts_large_image_payload(monkeypatch):
@@ -154,8 +161,9 @@ def test_chat_app_accepts_large_image_payload(monkeypatch):
         def __init__(self, model, api_key=None, base_url=None):
             pass
 
-        async def streaming_response_stateful(self, message, config):
+        async def streaming_response_stateful(self, message, config, signal=None):
             captured["message"] = message
+            captured["signal"] = signal
             yield {
                 "role": "assistant",
                 "event_type": "stop",
@@ -188,3 +196,21 @@ def test_chat_app_accepts_large_image_payload(monkeypatch):
         assert b"data:" in response.data
 
     assert captured["message"]["content_items"][0] == {"type": "image_url", "image_url": large_image}
+    assert isinstance(captured["signal"], AbortSignal)
+
+
+def test_chat_app_abort_route_interrupts_active_signal():
+    """Test that the abort route interrupts the active request signal."""
+    playground._session_abort_signals.clear()
+    signal = AbortSignal()
+    playground._session_abort_signals["abort-session"] = signal
+
+    app = create_chat_app()
+    with app.test_client() as client:
+        response = client.post("/api/abort", json={"session_id": "abort-session"})
+
+        assert response.status_code == 200
+        assert response.get_json() == {"status": "aborted"}
+
+    assert signal.aborted
+    playground._session_abort_signals.clear()

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -179,6 +179,16 @@ export class Gemini3Client extends LLMClient {
     return undefined;
   }
 
+  private _withAbortSignal<T extends { abortSignal?: AbortSignal }>(
+    config: T | undefined,
+    signal?: AbortSignal,
+  ): T | undefined {
+    if (!signal) {
+      return config;
+    }
+    return { ...(config ?? {}), abortSignal: signal } as T;
+  }
+
   /**
    * Transform universal configuration to Gemini-specific configuration.
    */
@@ -496,14 +506,14 @@ export class Gemini3Client extends LLMClient {
       options.signal,
     );
 
-    const geminiConfig: EmbedContentConfig | undefined =
-      options.config.embedding_config?.dimensions != null || options.signal
+    const geminiConfig = this._withAbortSignal<EmbedContentConfig>(
+      options.config.embedding_config?.dimensions != null
         ? {
-            outputDimensionality:
-              options.config.embedding_config?.dimensions ?? undefined,
-            abortSignal: options.signal,
+            outputDimensionality: options.config.embedding_config.dimensions,
           }
-        : undefined;
+        : undefined,
+      options.signal,
+    );
 
     const result = await this._client.models.embedContent({
       model: this._model,
@@ -557,20 +567,19 @@ export class Gemini3Client extends LLMClient {
       }
     }
 
-    const geminiConfig = this.transformUniConfigToModelConfig(options.config);
+    const geminiConfig = this._withAbortSignal<GenerateContentConfig>(
+      this.transformUniConfigToModelConfig(options.config),
+      options.signal,
+    );
     const contents = await this.transformUniMessageToModelInput(
       options.messages,
       options.signal,
     );
-    const requestConfig =
-      geminiConfig || options.signal
-        ? { ...(geminiConfig || {}), abortSignal: options.signal }
-        : undefined;
 
     const responseStream = await this._client.models.generateContentStream({
       model: this._model,
       contents: contents,
-      config: requestConfig,
+      config: geminiConfig,
     });
 
     for await (const chunk of responseStream) {

--- a/src_ts/src/index.ts
+++ b/src_ts/src/index.ts
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 export { AutoLLMClient } from "./autoClient";
-export { PromptCaching, ThinkingLevel } from "./types";
+export * from "./types";

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -27,6 +27,7 @@ import { Tracer } from "./tracer";
 
 const sessionClients: Map<string, AutoLLMClient> = new Map();
 const sessionClientOptions: Map<string, PlaygroundClientOptions> = new Map();
+const sessionAbortControllers: Map<string, AbortController> = new Map();
 
 interface PlaygroundConfig extends UniConfig {
   model?: string;
@@ -363,8 +364,9 @@ export function createChatApp(): Express {
           <div class="flex gap-3 max-w-5xl mx-auto">
               <input type="file" id="imageInput" accept="image/*" multiple class="hidden" onchange="handleImageSelect(event)">
               <button class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" onclick="document.getElementById('imageInput').click()">📎 Image</button>
-              <textarea id="messageInput" class="flex-1 px-4 py-3 border border-gray-300 rounded-md text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Type your message here..." rows="1"></textarea>
+              <textarea id="messageInput" class="flex-1 px-4 py-3 border border-gray-300 rounded-md text-sm resize-none overflow-y-hidden focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Type your message here..." rows="1"></textarea>
               <button class="bg-green-600 hover:bg-green-700 disabled:bg-green-300 disabled:cursor-not-allowed text-white px-6 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" id="sendButton" onclick="sendMessage()">Send</button>
+              <button class="hidden bg-orange-600 hover:bg-orange-700 disabled:bg-orange-300 disabled:cursor-not-allowed text-white px-6 py-3 rounded-md text-sm font-semibold whitespace-nowrap transition-colors" id="stopButton" onclick="stopGeneration()" disabled>Stop</button>
               <button class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded-md text-sm font-semibold transition-colors" onclick="clearChat()">Clear</button>
           </div>
       </div>
@@ -374,6 +376,7 @@ export function createChatApp(): Express {
           let sessionId = Math.random().toString(36).substring(7);
           let selectedImages = [];
           let lastMessageTimestamp = null;
+          let currentAbortController = null;
 
           function escapeHtml(text) {
               const div = document.createElement('div');
@@ -721,18 +724,59 @@ export function createChatApp(): Express {
               return card;
           }
 
+          function setStreamingControls(streaming) {
+              const sendButton = document.getElementById('sendButton');
+              const stopButton = document.getElementById('stopButton');
+              sendButton.disabled = streaming;
+              stopButton.disabled = !streaming;
+              stopButton.classList.toggle('hidden', !streaming);
+          }
+
+          function stopGeneration() {
+              if (!isStreaming) return;
+
+              fetch('/api/abort', {
+                  method: 'POST',
+                  headers: {
+                      'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                      session_id: sessionId
+                  }),
+                  keepalive: true
+              }).catch(error => {
+                  console.error('Error interrupting chat:', error);
+              });
+
+              if (currentAbortController) {
+                  currentAbortController.abort();
+              }
+          }
+
+          function markInterrupted(contentDiv) {
+              if (!contentDiv.textContent.trim() && contentDiv.children.length === 0) {
+                  contentDiv.textContent = 'Interrupted.';
+                  return;
+              }
+
+              const interruptedDiv = document.createElement('div');
+              interruptedDiv.className = 'mt-3 text-xs font-semibold text-orange-600';
+              interruptedDiv.textContent = 'Interrupted';
+              contentDiv.appendChild(interruptedDiv);
+          }
+
           async function sendMessage() {
               const input = document.getElementById('messageInput');
-              const sendButton = document.getElementById('sendButton');
               const container = document.getElementById('messagesContainer');
               const message = input.value.trim();
 
               if ((!message && selectedImages.length === 0) || isStreaming) return;
 
               isStreaming = true;
-              sendButton.disabled = true;
+              currentAbortController = new AbortController();
+              setStreamingControls(true);
               input.value = '';
-              input.style.height = 'auto';
+              resizeMessageInput();
 
               const currentImages = [...selectedImages];
               selectedImages = [];
@@ -769,7 +813,8 @@ export function createChatApp(): Express {
                           },
                           config: config,
                           session_id: sessionId
-                      })
+                      }),
+                      signal: currentAbortController.signal
                   });
 
                   if (!response.ok || !response.body) {
@@ -930,13 +975,18 @@ export function createChatApp(): Express {
                   }
 
               } catch (error) {
-                  contentDiv.textContent = \`Error: \${error.message}\`;
-                  console.error('Error:', error);
+                  if (error.name === 'AbortError') {
+                      markInterrupted(contentDiv);
+                  } else {
+                      contentDiv.textContent = \`Error: \${error.message}\`;
+                      console.error('Error:', error);
+                  }
                   lastMessageTimestamp = Date.now();
+              } finally {
+                  isStreaming = false;
+                  currentAbortController = null;
+                  setStreamingControls(false);
               }
-
-              isStreaming = false;
-              sendButton.disabled = false;
           }
 
           function clearChat() {
@@ -973,10 +1023,15 @@ export function createChatApp(): Express {
           });
 
           const textarea = document.getElementById('messageInput');
-          textarea.addEventListener('input', function() {
-              this.style.height = 'auto';
-              this.style.height = Math.min(this.scrollHeight, 200) + 'px';
-          });
+          function resizeMessageInput() {
+              const maxHeight = 200;
+              textarea.style.height = 'auto';
+              const nextHeight = Math.min(textarea.scrollHeight, maxHeight);
+              textarea.style.height = nextHeight + 'px';
+              textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+          }
+          textarea.addEventListener('input', resizeMessageInput);
+          resizeMessageInput();
 
       </script>
   </body>
@@ -997,57 +1052,103 @@ export function createChatApp(): Express {
     if (!message) {
       return res.status(400).json({ error: "No message provided" });
     }
+    const sessionId = session_id || "default";
 
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Connection", "keep-alive");
 
+    const abortController = new AbortController();
+    sessionAbortControllers.get(sessionId)?.abort();
+    sessionAbortControllers.set(sessionId, abortController);
+    let completed = false;
+    res.on("close", () => {
+      if (!completed) {
+        abortController.abort();
+      }
+    });
+
     try {
       const clientOptions = getClientOptions(config || {});
       if (
-        !sessionClients.has(session_id) ||
+        !sessionClients.has(sessionId) ||
         clientOptionsChanged(
-          sessionClientOptions.get(session_id),
+          sessionClientOptions.get(sessionId),
           clientOptions,
         )
       ) {
-        sessionClients.set(session_id, new AutoLLMClient(clientOptions));
-        sessionClientOptions.set(session_id, clientOptions);
+        sessionClients.set(sessionId, new AutoLLMClient(clientOptions));
+        sessionClientOptions.set(sessionId, clientOptions);
       }
 
-      const client = sessionClients.get(session_id)!;
+      const client = sessionClients.get(sessionId)!;
       const requestConfig = getRequestConfig(config || {});
 
       for await (const event of client.streamingResponseStateful({
         message,
         config: requestConfig,
+        signal: abortController.signal,
       })) {
         const serializedEvent = serializeForJson(event);
         res.write(`data: ${JSON.stringify(serializedEvent)}\n\n`);
       }
 
+      completed = true;
       res.write("data: [DONE]\n\n");
       res.end();
     } catch (error) {
+      if (abortController.signal.aborted) {
+        completed = true;
+        if (!res.writableEnded && !res.destroyed) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
+        return;
+      }
+
       const errorEvent = {
         role: "assistant",
         content_items: [{ type: "text", text: `Error: ${error}` }],
         finish_reason: "error",
       };
+      completed = true;
       res.write(`data: ${JSON.stringify(errorEvent)}\n\n`);
       res.write("data: [DONE]\n\n");
       res.end();
+    } finally {
+      if (sessionAbortControllers.get(sessionId) === abortController) {
+        sessionAbortControllers.delete(sessionId);
+      }
     }
+  });
+
+  app.post("/api/abort", (req: Request, res: Response) => {
+    const { session_id } = req.body as { session_id?: string };
+    const sessionId = session_id || "default";
+    const abortController = sessionAbortControllers.get(sessionId);
+    if (!abortController) {
+      return res.json({ status: "idle" });
+    }
+
+    abortController.abort();
+    return res.json({ status: "aborted" });
   });
 
   app.post("/api/clear", (req: Request, res: Response) => {
     const { session_id } = req.body as { session_id: string };
+    const sessionId = session_id || "default";
 
-    if (sessionClients.has(session_id)) {
-      const client = sessionClients.get(session_id)!;
+    const abortController = sessionAbortControllers.get(sessionId);
+    if (abortController) {
+      abortController.abort();
+      sessionAbortControllers.delete(sessionId);
+    }
+
+    if (sessionClients.has(sessionId)) {
+      const client = sessionClients.get(sessionId)!;
       client.clearHistory();
-      sessionClients.delete(session_id);
-      sessionClientOptions.delete(session_id);
+      sessionClients.delete(sessionId);
+      sessionClientOptions.delete(sessionId);
     }
 
     res.json({ status: "success" });

--- a/src_ts/tests/playground.test.ts
+++ b/src_ts/tests/playground.test.ts
@@ -21,6 +21,7 @@ import { UniConfig, UniEvent, UniMessage } from "../src/types";
 let mockLastStreamingOptions: {
   message: UniMessage;
   config: UniConfig;
+  signal?: AbortSignal;
 } | null = null;
 
 jest.mock("../src/autoClient", () => ({
@@ -28,6 +29,7 @@ jest.mock("../src/autoClient", () => ({
     streamingResponseStateful: async function* (options: {
       message: UniMessage;
       config: UniConfig;
+      signal?: AbortSignal;
     }): AsyncGenerator<UniEvent> {
       mockLastStreamingOptions = options;
       yield {
@@ -78,6 +80,10 @@ describe("Playground", () => {
     expect(response.text).toContain("apiKeyInput");
     expect(response.text).toContain("apiKeyVisibilityToggle");
     expect(response.text).toContain("toggleApiKeyVisibility()");
+    expect(response.text).toContain('id="stopButton"');
+    expect(response.text).toContain("stopGeneration()");
+    expect(response.text).toContain("currentAbortController.abort()");
+    expect(response.text).toContain("/api/abort");
     expect(response.text).toContain(
       'id="apiKeyVisibilityShowIcon" class="hidden"',
     );
@@ -138,6 +144,7 @@ describe("Playground", () => {
     expect(mockLastStreamingOptions?.config).toEqual({
       thinking_level: "low",
     });
+    expect(mockLastStreamingOptions?.signal).toBeInstanceOf(AbortSignal);
   });
 
   test("should accept image payloads larger than the default JSON limit", async () => {
@@ -164,5 +171,17 @@ describe("Playground", () => {
       type: "image_url",
       image_url: largeImage,
     });
+    expect(mockLastStreamingOptions?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("should expose an abort endpoint", async () => {
+    const app = createChatApp();
+
+    const response = await request(app).post("/api/abort").send({
+      session_id: "idle-session",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: "idle" });
   });
 });


### PR DESCRIPTION
## Summary
- add Python AbortSignal and wire it into Python streaming clients
- add Stop/abort controls to Python and TypeScript playgrounds
- pass abort signals through playground request handling and clear active sessions on abort/clear/disconnect

## Tests
- cd src_py && uv run pytest tests/test_playground.py tests/test_abort_signal.py
- cd src_py && uv run ruff check agenthub/integration/playground.py tests/test_playground.py agenthub/abort_signal.py agenthub/base_client.py agenthub/auto_client.py tests/test_abort_signal.py
- cd src_ts && npm run build
- cd src_ts && npm test -- playground.test.ts --runInBand
- cd src_ts && npm run lint -- --quiet