### PR TITLE
Preserve Claude redacted thinking start events

### DIFF
--- a/src_py/agenthub/claude4_7/client.py
+++ b/src_py/agenthub/claude4_7/client.py
@@ -374,7 +374,9 @@ class Claude4_7Client(LLMClient):
                             "arguments": "",
                             "tool_call_id": item["tool_call_id"],
                         }
-                        yield event
+
+                if event["content_items"]:
+                    yield event
 
                 if event["usage_metadata"] is not None:
                     # initialize partial_usage

--- a/src_ts/src/claude4_7/client.ts
+++ b/src_ts/src/claude4_7/client.ts
@@ -500,8 +500,11 @@ export class Claude4_7Client extends LLMClient {
             partialToolCall.name = item.name;
             partialToolCall.arguments = "";
             partialToolCall.tool_call_id = item.tool_call_id;
-            yield uniEvent;
           }
+        }
+
+        if (uniEvent.content_items.length > 0) {
+          yield uniEvent;
         }
 
         if (uniEvent.usage_metadata !== null) {


### PR DESCRIPTION
## Summary
- yield Claude 4.7 start events whenever they contain content items
- preserve redacted_thinking signatures needed for multi-turn conversations
- keep partial tool call initialization behavior unchanged

## Tests
- cd src_py && uv run ruff check agenthub/claude4_7/client.py
- cd src_py && uv run pytest tests/test_client.py -q
- cd src_ts && npm run build
- cd src_ts && npm run lint -- --quiet