### PR TITLE
Reuse abort waiter during streaming

### DIFF
--- a/src_py/agenthub/base_client.py
+++ b/src_py/agenthub/base_client.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import time
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from typing import Any, AsyncIterator
 
-from .abort_signal import AbortSignal, run_with_abort
+from .abort_signal import AbortSignal
 from .types import (
     ContentItem,
     FinishReason,
@@ -188,19 +190,57 @@ class LLMClient(ABC):
 
         last_event: UniEvent | None = None
         events = []
+        if signal is not None:
+            signal.throw_if_aborted()
+
         stream = self._streaming_response_internal(messages, config)
+        abort_task: asyncio.Task[None] | None = None
+        waiting_for_stream = False
+        if signal is not None:
+            streaming_task = asyncio.current_task()
+            abort_task = asyncio.create_task(signal.wait())
+
+            def cancel_streaming_task(task: asyncio.Task[None]) -> None:
+                if (
+                    task.cancelled()
+                    or not signal.aborted
+                    or not waiting_for_stream
+                    or streaming_task is None
+                    or streaming_task.done()
+                ):
+                    return
+
+                streaming_task.cancel(signal.reason)
+
+            abort_task.add_done_callback(cancel_streaming_task)
+
         try:
             while True:
                 try:
-                    event = await anext(stream) if signal is None else await run_with_abort(anext(stream), signal)
+                    if signal is not None:
+                        signal.throw_if_aborted()
+                        waiting_for_stream = True
+                        signal.throw_if_aborted()
+
+                    event = await anext(stream)
                 except StopAsyncIteration:
                     break
+                except asyncio.CancelledError:
+                    if signal is not None and signal.aborted:
+                        signal.throw_if_aborted()
+                    raise
+                finally:
+                    waiting_for_stream = False
 
                 event["created_at"] = int(time.time() * 1000)
                 last_event = event
                 events.append(event)
                 yield event
         finally:
+            if abort_task is not None and not abort_task.done():
+                abort_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await abort_task
             await stream.aclose()
 
         self._validate_last_event(last_event)

--- a/src_py/tests/test_abort_signal.py
+++ b/src_py/tests/test_abort_signal.py
@@ -65,6 +65,76 @@ class SlowStreamingClient(LLMClient):
         }
 
 
+class MultiEventStreamingClient(LLMClient):
+    def __init__(self) -> None:
+        self._model = "multi-event-test"
+        self._history = []
+
+    def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
+        return dict(config)
+
+    def transform_uni_message_to_model_input(self, messages: list[UniMessage]) -> list[UniMessage]:
+        return messages
+
+    def transform_model_output_to_uni_event(self, model_output: UniEvent) -> UniEvent:
+        return model_output
+
+    async def _streaming_response_internal(
+        self,
+        messages: list[UniMessage],
+        config: UniConfig,
+    ) -> AsyncIterator[UniEvent]:
+        for text in ("hello", " world"):
+            await asyncio.sleep(0)
+            yield {
+                "role": "assistant",
+                "event_type": "delta",
+                "content_items": [{"type": "text", "text": text}],
+                "usage_metadata": None,
+                "finish_reason": None,
+                "created_at": 0,
+            }
+
+        await asyncio.sleep(0)
+        yield {
+            "role": "assistant",
+            "event_type": "stop",
+            "content_items": [],
+            "usage_metadata": {
+                "cached_tokens": None,
+                "prompt_tokens": 1,
+                "thoughts_tokens": None,
+                "response_tokens": 2,
+            },
+            "finish_reason": "stop",
+            "created_at": 0,
+        }
+
+
+class CountingAbortSignal(AbortSignal):
+    def __init__(self) -> None:
+        super().__init__()
+        self.wait_count = 0
+
+    async def wait(self) -> None:
+        self.wait_count += 1
+        await super().wait()
+
+
+class StreamCreationTrackingClient(MultiEventStreamingClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream_created = False
+
+    def _streaming_response_internal(
+        self,
+        messages: list[UniMessage],
+        config: UniConfig,
+    ) -> AsyncIterator[UniEvent]:
+        self.stream_created = True
+        return super()._streaming_response_internal(messages, config)
+
+
 def test_abort_signal_state_is_idempotent() -> None:
     signal = AbortSignal()
 
@@ -195,3 +265,29 @@ async def test_streaming_response_cancels_current_iteration_when_signal_aborts()
         await task
 
     assert client.cleaned.is_set()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_reuses_one_abort_waiter_for_whole_stream() -> None:
+    client = MultiEventStreamingClient()
+    signal = CountingAbortSignal()
+    messages: list[UniMessage] = [{"role": "user", "content_items": [{"type": "text", "text": "hello"}]}]
+
+    events = [event async for event in client.streaming_response(messages=messages, config={}, signal=signal)]
+
+    assert len(events) == 3
+    assert signal.wait_count == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_does_not_create_stream_when_signal_is_already_aborted() -> None:
+    client = StreamCreationTrackingClient()
+    signal = AbortSignal()
+    signal.abort("stop")
+    messages: list[UniMessage] = [{"role": "user", "content_items": [{"type": "text", "text": "hello"}]}]
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in client.streaming_response(messages=messages, config={}, signal=signal):
+            pass
+
+    assert not client.stream_created


### PR DESCRIPTION
## Summary
- avoid creating a fresh signal.wait task for every streamed event
- keep one abort waiter alive for the full streaming response
- add regression coverage that a multi-event stream registers only one abort waiter

## Tests
- cd src_py && uv run pytest tests/test_abort_signal.py tests/test_playground.py
- cd src_py && uv run ruff check agenthub/base_client.py tests/test_abort_signal.py agenthub/abort_signal.py
- cd src_py && uv run pytest tests/test_client.py -q