### PR TITLE
Preserve Claude 4.6 redacted thinking start events

### DIFF
--- a/src_py/agenthub/claude4_6/client.py
+++ b/src_py/agenthub/claude4_6/client.py
@@ -374,7 +374,9 @@ class Claude4_6Client(LLMClient):
                             "arguments": "",
                             "tool_call_id": item["tool_call_id"],
                         }
-                        yield event
+
+                if event["content_items"]:
+                    yield event
 
                 if event["usage_metadata"] is not None:
                     # initialize partial_usage

--- a/src_ts/src/claude4_6/client.ts
+++ b/src_ts/src/claude4_6/client.ts
@@ -498,8 +498,11 @@ export class Claude4_6Client extends LLMClient {
             partialToolCall.name = item.name;
             partialToolCall.arguments = "";
             partialToolCall.tool_call_id = item.tool_call_id;
-            yield uniEvent;
           }
+        }
+
+        if (uniEvent.content_items.length > 0) {
+          yield uniEvent;
         }
 
         if (uniEvent.usage_metadata !== null) {


### PR DESCRIPTION
## Summary
- preserve Claude 4.6 start events that contain redacted thinking content
- keep partial tool-call initialization behavior unchanged while yielding any non-empty start content
- mirror the fix in Python and TypeScript clients

## Verification
- cd src_py && uv run ruff check agenthub/claude4_6/client.py
- cd src_py && uv run python - <<'PY' ... fake redacted_thinking stream check ... PY
- cd src_ts && npm run build
- cd src_ts && npm run lint
- cd src_ts && node --input-type=module - <<'JS' ... fake redacted_thinking stream check ... JS