### PR TITLE
Add OpenAI-compatible client routing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check source branch
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          if [[ "${{ github.head_ref }}" != "dev" ]]; then
-            echo "Only dev branch can open PR to main"
+          if [[ "$HEAD_REPO" != "$BASE_REPO" || "$HEAD_REF" != "dev" ]]; then
+            echo "Only the dev branch from $BASE_REPO can open PRs to main"
+            echo "Current source: $HEAD_REPO:$HEAD_REF"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions.
 
+- [2026-05-30] Support Claude 4.8 models and an OpenAI Chat Completions API-compatible client.
+
 - [2026-05-28] Add abort support and agent skills.
 
 - [2026-05-27] Support Gemini 3.5, Gemini Embedding 2, Claude 4.7, Kimi-K2.6, GLM-5.1, DeepSeek V4 and Qwen3.6 models. Qwen3 models are deprecated.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ https://github.com/user-attachments/assets/c49a21a1-5bf9-4768-a76d-f73c9a03ca87
 | Kimi-K2.5/K2.6 | Official/OpenRouter/SiliconFlow     | `kimi-k2.6`            | Text, Image      | Text                           |
 | DeepSeek V4    | Official/OpenRouter/SiliconFlow     | `deepseek-v4-pro`      | Text             | Text                           |
 | GLM-5.1        | Official/OpenRouter/SiliconFlow     | `glm-5.1`              | Text             | Text                           |
-| Qwen3.6        | OpenRouter/SiliconFlow/vLLM         | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text                           |
+| Qwen3.6        | OpenAI-compatible                   | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text                           |
 
 ## Installation
 
@@ -278,7 +278,7 @@ main().catch(console.error);
 ```
 </details>
 
-### SiliconFlow Qwen3.6 35B
+### SiliconFlow Qwen3.6 35B via OpenAI-compatible API
 
 <details><summary><strong>Python Example</strong></summary>
 
@@ -287,11 +287,11 @@ import asyncio
 import os
 from agenthub import AutoLLMClient
 
-os.environ["QWEN_API_KEY"] = "your-siliconflow-api-key"
-os.environ["QWEN_BASE_URL"] = "https://api.siliconflow.cn/v1"
+os.environ["OPENAI_API_KEY"] = "your-siliconflow-api-key"
+os.environ["OPENAI_BASE_URL"] = "https://api.siliconflow.cn/v1"
 
-async def main():  
-    client = AutoLLMClient(model="Qwen/Qwen3.6-35B-A3B")
+async def main():
+    client = AutoLLMClient(model="Qwen/Qwen3.6-35B-A3B", client_type="openai")
     async for event in client.streaming_response_stateful(
         message={
             "role": "user",
@@ -310,11 +310,14 @@ asyncio.run(main())
 ```typescript
 import { AutoLLMClient } from "@prismshadow/agenthub";
 
-process.env.QWEN_API_KEY = "your-siliconflow-api-key";
-process.env.QWEN_BASE_URL = "https://api.siliconflow.cn/v1";
+process.env.OPENAI_API_KEY = "your-siliconflow-api-key";
+process.env.OPENAI_BASE_URL = "https://api.siliconflow.cn/v1";
 
 async function main() {
-  const client = new AutoLLMClient({ model: "Qwen/Qwen3.6-35B-A3B" });
+  const client = new AutoLLMClient({
+    model: "Qwen/Qwen3.6-35B-A3B",
+    clientType: "openai",
+  });
   for await (const event of client.streamingResponseStateful({
     message: {
       role: "user",

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ https://github.com/user-attachments/assets/c49a21a1-5bf9-4768-a76d-f73c9a03ca87
 | Model Name     | Vendor                              | Example Model ID       | Input Modalities | Output Modalities              |
 | -------------- | ----------------------------------- | ---------------------- | ---------------- | ------------------------------ |
 | Gemini 3-3.5   | Official/Google Vertex AI           | `gemini-3.5-flash`     | Text, Image      | Text, Image, Speech, Embedding |
-| Claude 4.6/4.7 | Official/Amazon Bedrock/UModelVerse | `claude-opus-4-7`      | Text, Image      | Text                           |
+| Claude 4.6-4.8 | Official/Amazon Bedrock/UModelVerse | `claude-opus-4-8`      | Text, Image      | Text                           |
 | GPT-5.4/5.5    | Official/UModelVerse                | `gpt-5.5`              | Text, Image      | Text                           |
 | Kimi-K2.5/K2.6 | Official/OpenRouter/SiliconFlow     | `kimi-k2.6`            | Text, Image      | Text                           |
 | DeepSeek V4    | Official/OpenRouter/SiliconFlow     | `deepseek-v4-pro`      | Text             | Text                           |
 | GLM-5.1        | Official/OpenRouter/SiliconFlow     | `glm-5.1`              | Text             | Text                           |
-| Qwen3.6        | OpenAI-compatible                   | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text                           |
+| Qwen3.6        | OpenRouter/SiliconFlow/vLLM         | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text                           |
 
 ## Installation
 

--- a/llmsdk_docs/README.md
+++ b/llmsdk_docs/README.md
@@ -7,7 +7,8 @@ This directory contains documentation and examples for all supported AI model SD
 To use a specific model, please refer to its dedicated README:
 
 - **[Claude 4.6](./claude4_6/README.md)** - Anthropic's Claude 4.6 API documentation and examples
-- **[Claude 4.7](./claude4_7/README.md)** - Anthropic's Claude 4.7 API documentation
+- **[Claude 4.7](./claude4_7/README.md)** - Anthropic's Claude 4.7 API documentation and examples
+- **[Claude 4.8](./claude4_8/README.md)** - Anthropic's Claude 4.8 API documentation and examples
 - **[DeepSeek V4](./deepseek_v4/README.md)** - DeepSeek V4 API documentation and OpenAI-compatible usage guides
 - **[Gemini 3](./gemini3/README.md)** - Google's Gemini 3 API documentation and examples
 - **[GLM-5.1](./glm5_1/README.md)** - Z.AI's GLM-5.1 API documentation and examples

--- a/llmsdk_docs/claude4_8/README.md
+++ b/llmsdk_docs/claude4_8/README.md
@@ -1,0 +1,9 @@
+# Claude 4.8 SDK Documentation
+
+This directory contains documentation for using Anthropic's Claude 4.8 API.
+
+## Documentation
+
+The `docs/` folder contains detailed guides on various Claude 4.8 features:
+
+- [whats-new-claude-4-8.md](./docs/whats-new-claude-4-8.md) - What's new in Claude 4.8

--- a/llmsdk_docs/claude4_8/docs/whats-new-claude-4-8.md
+++ b/llmsdk_docs/claude4_8/docs/whats-new-claude-4-8.md
@@ -1,0 +1,111 @@
+# What's new in Claude Opus 4.8
+
+Overview of new features and behavior changes in Claude Opus 4.8.
+
+---
+
+<NextOpus /> is Anthropic's most capable generally available model to date. It builds on Claude Opus 4.7. This page summarizes everything new at launch, including fast mode (research preview on the Claude API) and a lower 1,024-token minimum cacheable prompt length.
+
+## New model
+
+| Model | API model ID | Description |
+|:------|:-------------|:------------|
+| <NextOpus /> | <NextOpusId /> | Anthropic's most capable model for complex reasoning, long-horizon agentic coding, and high-autonomy work |
+
+<NextOpus /> supports the [1M token context window](/docs/en/build-with-claude/context-windows) by default on the Claude API, Amazon Bedrock, and Vertex AI (200k on Microsoft Foundry), 128k max output tokens, [adaptive thinking](/docs/en/build-with-claude/adaptive-thinking), and the same set of tools and platform features as Claude Opus 4.7.
+
+For complete pricing and specs, see the [models overview](/docs/en/about-claude/models/overview).
+
+## New features
+
+### Mid-conversation system messages
+
+<NextOpus /> accepts `role: "system"` messages immediately after a user turn in the `messages` array (subject to [placement rules](/docs/en/build-with-claude/mid-conversation-system-messages#limitations)). This lets you append updated instructions later in a long-running conversation without restating the full system prompt, which preserves [prompt cache](/docs/en/build-with-claude/prompt-caching) hits on the earlier turns and reduces input cost on agentic loops. No beta header is required. See [Mid-conversation system messages](/docs/en/build-with-claude/mid-conversation-system-messages) for usage details.
+
+### Refusal stop details
+
+The `stop_details` object on refusal responses (available since Claude Opus 4.7) is now publicly documented. When Claude declines to complete a request, this object describes the category of refusal, in addition to the existing `refusal` stop reason, making it easier for your application to tell apart different classes of declined request and to route the user to the right next step. No beta header is required. See [Handling stop reasons](/docs/en/build-with-claude/handling-stop-reasons) for the category list and handling guidance.
+
+### Effort defaults
+
+The [effort parameter](/docs/en/build-with-claude/effort) default on <NextOpus /> is `high` on all surfaces, including the Claude API and Claude Code. If you set effort explicitly today, your setting is unchanged. See [Effort](/docs/en/build-with-claude/effort) for per-level guidance.
+
+### Fast mode
+
+[Fast mode](/docs/en/build-with-claude/fast-mode) is now available for <NextOpus /> as a research preview on the Claude API. Set `speed: "fast"` to get up to 2.5x higher output tokens per second from the same model at premium pricing. See [Fast mode](/docs/en/build-with-claude/fast-mode) for access, supported models, and pricing.
+
+### Lower prompt cache minimum
+
+The minimum cacheable prompt length on <NextOpus /> is 1,024 tokens, lower than on Claude Opus 4.7. Prompts that were too short to cache on Claude Opus 4.7 can now create cache entries with no code changes. See [Prompt caching](/docs/en/build-with-claude/prompt-caching#cache-limitations) for per-model minimums.
+
+## API constraints inherited from Claude Opus 4.7
+
+<Note>
+These constraints are unchanged from Claude Opus 4.7, so code that already runs on Claude Opus 4.7 needs no changes. They apply to the Messages API only; Claude Managed Agents are unaffected.
+</Note>
+
+### Sampling parameters not supported
+
+Setting `temperature`, `top_p`, or `top_k` to a non-default value returns a 400 error on <NextOpus />, same as on Claude Opus 4.7. Omit these parameters and use prompting to guide the model's behavior.
+
+### Adaptive thinking is the only thinking mode
+
+Like Claude Opus 4.7, <NextOpus /> does not support extended thinking budgets. Setting `thinking: {"type": "enabled", "budget_tokens": N}` returns a 400 error. Use [adaptive thinking](/docs/en/build-with-claude/adaptive-thinking) and the [effort parameter](/docs/en/build-with-claude/effort) to control thinking depth.
+
+```python Python
+# Before (Opus 4.6 or earlier)
+thinking = {"type": "enabled", "budget_tokens": 32000}
+
+# After (Opus 4.7 and later)
+thinking = {"type": "adaptive"}
+output_config = {"effort": "high"}
+```
+
+## Capability improvements
+
+### Improvement areas
+
+Compared with Claude Opus 4.7, <NextOpus /> targets behavioral improvements in:
+
+- **Long-horizon agentic coding**, including better long-context handling, fewer compactions, and better [compaction](/docs/en/build-with-claude/compaction) recovery.
+- **Reasoning effort calibration**, with more reliable behavior at each effort level across a range of domains.
+- **Tool triggering**, with fewer cases of skipping a tool call that the task required.
+
+### Adaptive thinking
+
+With [adaptive thinking](/docs/en/build-with-claude/adaptive-thinking) enabled, <NextOpus /> triggers reasoning only when it judges the turn needs it. On simple lookups and short agentic steps it responds directly; on complex multi-step problems it reasons before answering. This reduces wasted thinking tokens on bimodal workloads compared to Claude Opus 4.7 at the same effort level. As on Claude Opus 4.7, thinking is off unless you explicitly set `thinking: {type: "adaptive"}` in your request.
+
+## Behavior changes
+
+These are not API breaking changes but may require prompt updates. See [Migrating to <NextOpus />](/docs/en/about-claude/models/migration-guide#migrating-from-claude-opus-47) for full guidance.
+
+- **Fewer wasted thinking tokens** at the same effort level when adaptive thinking is enabled, because the model decides per turn whether to think.
+- **Better tool triggering.** The model is less likely to skip a tool call the task required, an issue some users reported on Claude Opus 4.7.
+- **Better compaction handling and long-context quality.** Long agentic traces stay on task with fewer derailments after compaction.
+
+## Migration guide
+
+For step-by-step migration instructions and the full migration checklist, see [Migrating to <NextOpus />](/docs/en/about-claude/models/migration-guide#migrating-from-claude-opus-47). If you use Claude Code or the Agent SDK, the [Claude API skill](/docs/en/agents-and-tools/agent-skills/claude-api-skill) can apply these migration steps to your codebase automatically.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Migration guide" icon="arrow-right" href="/docs/en/about-claude/models/migration-guide#migrating-from-claude-opus-47">
+    Step-by-step upgrade instructions from Claude Opus 4.7.
+  </Card>
+  <Card title="Effort" icon="sliders" href="/docs/en/build-with-claude/effort">
+    Per-level effort guidance, including the new defaults.
+  </Card>
+  <Card title="Adaptive thinking" icon="brain" href="/docs/en/build-with-claude/adaptive-thinking">
+    The only supported thinking-on mode on <NextOpus />.
+  </Card>
+  <Card title="Prompt caching" icon="database" href="/docs/en/build-with-claude/prompt-caching">
+    How mid-conversation system messages preserve cache hits.
+  </Card>
+  <Card title="Handling stop reasons" icon="shield" href="/docs/en/build-with-claude/handling-stop-reasons">
+    Refusal stop details and how to handle them.
+  </Card>
+  <Card title="Fast mode" icon="bolt" href="/docs/en/build-with-claude/fast-mode">
+    Higher output speed at premium pricing.
+  </Card>
+</CardGroup>

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -29,6 +29,8 @@ Use exact model IDs. Create with `AutoLLMClient(model=model_id)`, or pass creden
 | Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Bedrock | `global.anthropic.claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.8 | Official / ModelVerse | `claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.8 | Bedrock | `global.anthropic.claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
@@ -40,8 +42,6 @@ Use exact model IDs. Create with `AutoLLMClient(model=model_id)`, or pass creden
 | GLM-5.1 | Official | `glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.1 | OpenRouter | `z-ai/glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.1 | SiliconFlow | `Pro/zai-org/GLM-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| Qwen3.6 | OpenRouter | `qwen/qwen3.6-35b-a3b` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
-| Qwen3.6 | SiliconFlow | `Qwen/Qwen3.6-35B-A3B` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
 
 Common gateway base URLs:
 

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -17,7 +17,7 @@ pip install agenthub-python
 
 ## Model Selection
 
-Use exact model IDs. Create with `AutoLLMClient(model=model_id)`, or pass credentials directly: `AutoLLMClient(model=model_id, api_key=key, base_url=url)`. If a model ID is not listed, ask the user to confirm the exact ID before using it.
+Use exact model IDs. If a model ID is not listed, ask the user to confirm the exact ID before using it.
 
 | Family | Provider | Model IDs | API Key | Base URL |
 | --- | --- | --- | --- | --- |
@@ -173,6 +173,23 @@ Event-only content item:
 ## APIs
 
 `AutoLLMClient` exposes five basic APIs. Prefer the stateful stream for agent loops.
+
+Initialize `AutoLLMClient` in one of three common ways:
+
+```python
+# Initialize with model name
+client = AutoLLMClient(model="gpt-5.5")
+
+# Optionally specify API key (if not using environment variables)
+client = AutoLLMClient(
+    model="gpt-5.5",
+    api_key="your-openai-api-key",
+    base_url="https://api.openai.com/v1",
+)
+
+# Use OpenAI Chat Completions-compatible routing explicitly
+client = AutoLLMClient(model="custom-model", client_type="openai")
+```
 
 ```python
 async def streaming_response(messages: list[UniMessage], config: UniConfig) -> AsyncIterator[UniEvent]:

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -15,7 +15,7 @@ npm install @prismshadow/agenthub
 
 ## Model Selection
 
-Use exact model IDs. Create with `new AutoLLMClient({ model: modelId })`, or pass credentials directly: `new AutoLLMClient({ model: modelId, apiKey: key, baseUrl: url })`. If a model ID is not listed, ask the user to confirm the exact ID before using it.
+Use exact model IDs. If a model ID is not listed, ask the user to confirm the exact ID before using it.
 
 | Family | Provider | Model IDs | API Key | Base URL |
 | --- | --- | --- | --- | --- |
@@ -171,6 +171,26 @@ Event-only content item:
 ## APIs
 
 `AutoLLMClient` exposes five basic APIs. Prefer the stateful stream for agent loops.
+
+Initialize `AutoLLMClient` in one of three common ways:
+
+```typescript
+// Initialize with model name
+const clientByModel = new AutoLLMClient({ model: "gpt-5.5" });
+
+// Optionally specify API key (if not using environment variables)
+const clientWithEndpoint = new AutoLLMClient({
+  model: "gpt-5.5",
+  apiKey: "your-openai-api-key",
+  baseUrl: "https://api.openai.com/v1",
+});
+
+// Use OpenAI Chat Completions-compatible routing explicitly
+const clientWithType = new AutoLLMClient({
+  model: "custom-model",
+  clientType: "openai",
+});
+```
 
 ```typescript
 /** Stream one stateless response from a full message list. */

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -27,6 +27,8 @@ Use exact model IDs. Create with `new AutoLLMClient({ model: modelId })`, or pas
 | Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Bedrock | `global.anthropic.claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.8 | Official / ModelVerse | `claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
+| Claude 4.8 | Bedrock | `global.anthropic.claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
@@ -38,8 +40,6 @@ Use exact model IDs. Create with `new AutoLLMClient({ model: modelId })`, or pas
 | GLM-5.1 | Official | `glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.1 | OpenRouter | `z-ai/glm-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.1 | SiliconFlow | `Pro/zai-org/GLM-5.1` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| Qwen3.6 | OpenRouter | `qwen/qwen3.6-35b-a3b` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
-| Qwen3.6 | SiliconFlow | `Qwen/Qwen3.6-35B-A3B` | `QWEN_API_KEY` | `QWEN_BASE_URL` |
 
 Common gateway base URLs:
 

--- a/src_py/README.md
+++ b/src_py/README.md
@@ -27,6 +27,9 @@ client = AutoLLMClient(model="gpt-5.5")
 
 # Optionally specify API key (if not using environment variables)
 client = AutoLLMClient(model="gpt-5.5", api_key="your-openai-api-key")
+
+# Use OpenAI Chat Completions-compatible routing explicitly
+client = AutoLLMClient(model="custom-model", client_type="openai")
 ```
 
 The client automatically selects the appropriate client based on the model name.

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -46,17 +46,17 @@ class AutoLLMClient(LLMClient):
         self, model: str, api_key: str | None = None, base_url: str | None = None, client_type: str | None = None
     ) -> LLMClient:
         """Create the appropriate client for the given model."""
-        client_type = (client_type or os.getenv("CLIENT_TYPE", model.lower())).lower()
+        client_type = (client_type or os.getenv("CLIENT_TYPE", model)).lower()
         if any(
-            prefix in client_type for prefix in ("gemini-3-", "gemini-3.1-", "gemini-3.5-", "gemini-embedding")
+            prefix in client_type for prefix in ("gemini-3", "gemini-embedding")
         ):  # e.g., gemini-3-flash-preview, gemini-embedding-2
             from .gemini3 import Gemini3Client
 
             return Gemini3Client(model=model, api_key=api_key, base_url=base_url)
-        elif "claude" in client_type and "4-7" in client_type:  # e.g., claude-opus-4-7
-            from .claude4_7 import Claude4_7Client
+        elif "claude" in client_type and ("4-7" in client_type or "4-8" in client_type):  # e.g., claude-opus-4-7
+            from .claude4_8 import Claude4_8Client
 
-            return Claude4_7Client(model=model, api_key=api_key, base_url=base_url)
+            return Claude4_8Client(model=model, api_key=api_key, base_url=base_url)
         elif "claude" in client_type and "4-6" in client_type:  # e.g., claude-sonnet-4-6
             from .claude4_6 import Claude4_6Client
 
@@ -73,18 +73,18 @@ class AutoLLMClient(LLMClient):
             from .kimi_k2_6 import KimiK2_6Client
 
             return KimiK2_6Client(model=model, api_key=api_key, base_url=base_url)
+        elif "deepseek-v4" in client_type:
+            from .deepseek_v4 import DeepSeekV4Client
+
+            return DeepSeekV4Client(model=model, api_key=api_key, base_url=base_url)
         elif "openai" in client_type:
             from .openai import OpenaiClient
 
             return OpenaiClient(model=model, api_key=api_key, base_url=base_url)
-        elif "deepseek-v4-" in client_type:
-            from .deepseek_v4 import DeepSeekV4Client
-
-            return DeepSeekV4Client(model=model, api_key=api_key, base_url=base_url)
         else:
             raise ValueError(
                 f"{client_type} is not supported. "
-                "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, openai, deepseek-v4."
+                "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai."
             )
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> Any:

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -46,7 +46,7 @@ class AutoLLMClient(LLMClient):
         self, model: str, api_key: str | None = None, base_url: str | None = None, client_type: str | None = None
     ) -> LLMClient:
         """Create the appropriate client for the given model."""
-        client_type = client_type or os.getenv("CLIENT_TYPE", model.lower())
+        client_type = (client_type or os.getenv("CLIENT_TYPE", model.lower())).lower()
         if any(
             prefix in client_type for prefix in ("gemini-3-", "gemini-3.1-", "gemini-3.5-", "gemini-embedding")
         ):  # e.g., gemini-3-flash-preview, gemini-embedding-2
@@ -73,10 +73,10 @@ class AutoLLMClient(LLMClient):
             from .kimi_k2_6 import KimiK2_6Client
 
             return KimiK2_6Client(model=model, api_key=api_key, base_url=base_url)
-        elif "qwen3.6" in client_type:
-            from .qwen3_6 import Qwen3_6Client
+        elif "openai" in client_type:
+            from .openai import OpenaiClient
 
-            return Qwen3_6Client(model=model, api_key=api_key, base_url=base_url)
+            return OpenaiClient(model=model, api_key=api_key, base_url=base_url)
         elif "deepseek-v4-" in client_type:
             from .deepseek_v4 import DeepSeekV4Client
 
@@ -84,7 +84,7 @@ class AutoLLMClient(LLMClient):
         else:
             raise ValueError(
                 f"{client_type} is not supported. "
-                "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, qwen3.6, deepseek-v4."
+                "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, openai, deepseek-v4."
             )
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> Any:

--- a/src_py/agenthub/claude4_8/__init__.py
+++ b/src_py/agenthub/claude4_8/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .client import Claude4_7Client
+from .client import Claude4_8Client
 
 
-__all__ = ["Claude4_7Client"]
+__all__ = ["Claude4_8Client"]

--- a/src_py/agenthub/claude4_8/client.py
+++ b/src_py/agenthub/claude4_8/client.py
@@ -41,11 +41,11 @@ from ..types import (
 REDACTED_THINKING = "_REDACTED_THINKING"
 
 
-class Claude4_7Client(LLMClient):
-    """Claude 4.7-specific LLM client implementation."""
+class Claude4_8Client(LLMClient):
+    """Claude 4.8-specific LLM client implementation."""
 
     def __init__(self, model: str, api_key: str | None = None, base_url: str | None = None):
-        """Initialize Claude 4.7 client with model and API key."""
+        """Initialize Claude 4.8 client with model and API key."""
         self._model = model
         api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         base_url = base_url or os.getenv("ANTHROPIC_BASE_URL")

--- a/src_py/agenthub/glm5_1/client.py
+++ b/src_py/agenthub/glm5_1/client.py
@@ -46,14 +46,14 @@ class GLM5_1Client(LLMClient):
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._history: list[UniMessage] = []
 
-    def _convert_thinking_level_to_config(self, thinking_level: ThinkingLevel) -> dict[str, str]:
+    def _convert_thinking_level_to_config(self, thinking_level: ThinkingLevel) -> dict[str, str | bool]:
         """Convert ThinkingLevel enum to GLM's thinking configuration."""
         mapping = {
             ThinkingLevel.NONE: {"type": "disabled"},
-            ThinkingLevel.LOW: {"type": "enabled"},
-            ThinkingLevel.MEDIUM: {"type": "enabled"},
-            ThinkingLevel.HIGH: {"type": "enabled"},
-            ThinkingLevel.XHIGH: {"type": "enabled"},
+            ThinkingLevel.LOW: {"type": "enabled", "clear_thinking": False},
+            ThinkingLevel.MEDIUM: {"type": "enabled", "clear_thinking": False},
+            ThinkingLevel.HIGH: {"type": "enabled", "clear_thinking": False},
+            ThinkingLevel.XHIGH: {"type": "enabled", "clear_thinking": False},
         }
         return mapping.get(thinking_level)
 

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -41,7 +41,7 @@ from .tracer import Tracer
 _event_loop: asyncio.AbstractEventLoop | None = None
 _loop_lock = threading.Lock()
 _session_clients: dict[str, AutoLLMClient] = {}
-_session_client_options: dict[str, tuple[str, str | None, str | None]] = {}
+_session_client_options: dict[str, tuple[str, str | None, str | None, str | None]] = {}
 _session_abort_signals: dict[str, AbortSignal] = {}
 
 
@@ -83,12 +83,13 @@ def _normalize_optional_string(value: Any) -> str | None:
     return None
 
 
-def _get_client_options(config: dict[str, Any]) -> tuple[str, str | None, str | None]:
+def _get_client_options(config: dict[str, Any]) -> tuple[str, str | None, str | None, str | None]:
     """Extract client construction options from playground config."""
     model = _normalize_optional_string(config.get("model")) or "gpt-5.5"
     api_key = _normalize_optional_string(config.get("api_key"))
     base_url = _normalize_optional_string(config.get("base_url"))
-    return model, api_key, base_url
+    client_type = _normalize_optional_string(config.get("client_type"))
+    return model, api_key, base_url, client_type
 
 
 def _get_request_config(config: dict[str, Any]) -> dict[str, Any]:
@@ -97,6 +98,7 @@ def _get_request_config(config: dict[str, Any]) -> dict[str, Any]:
     request_config.pop("model", None)
     request_config.pop("api_key", None)
     request_config.pop("base_url", None)
+    request_config.pop("client_type", None)
     return request_config
 
 
@@ -120,7 +122,7 @@ def create_chat_app() -> Flask:
     <!DOCTYPE html>
     <html>
     <head>
-        <title>LLM Playground</title>
+        <title>AgentHub Playground</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="https://cdn.tailwindcss.com"></script>
@@ -208,9 +210,6 @@ def create_chat_app() -> Flask:
                             <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.1" data-label="GLM 5.1" data-description="glm-5.1" onclick="selectComboboxOption('modelCombobox', this)">
                                 <span class="block truncate text-sm font-medium text-gray-900">GLM 5.1</span>
                             </button>
-                            <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="qwen/qwen3.6-35b-a3b" data-label="Qwen3.6 35B" data-description="qwen/qwen3.6-35b-a3b" onclick="selectComboboxOption('modelCombobox', this)">
-                                <span class="block truncate text-sm font-medium text-gray-900">Qwen3.6 35B</span>
-                            </button>
                             <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="gemini-3.1-flash-image-preview" data-label="Gemini 3.1 Flash Image" data-description="gemini-3.1-flash-image-preview" onclick="selectComboboxOption('modelCombobox', this)">
                                 <span class="block truncate text-sm font-medium text-gray-900">Gemini 3.1 Flash Image</span>
                             </button>
@@ -228,12 +227,19 @@ def create_chat_app() -> Flask:
                             </button>
                         </div>
                     </div>
-                    <div id="customModelWrapper" class="hidden mt-2">
+                    <div id="customModelWrapper" class="hidden mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                         <input
                             id="customModelInput"
                             type="text"
                             autocomplete="off"
                             placeholder="Custom model id"
+                            class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                        />
+                        <input
+                            id="customClientTypeInput"
+                            type="text"
+                            autocomplete="off"
+                            placeholder="Client type"
                             class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                         />
                     </div>
@@ -622,6 +628,13 @@ def create_chat_app() -> Flask:
                 const apiKey = document.getElementById('apiKeyInput').value.trim();
                 if (apiKey) {
                     config.api_key = apiKey;
+                }
+
+                if (document.getElementById('modelSelect').value === '__custom__') {
+                    const clientType = document.getElementById('customClientTypeInput').value.trim();
+                    if (clientType) {
+                        config.client_type = clientType;
+                    }
                 }
 
                 const baseUrl = document.getElementById('baseUrlInput').value.trim();
@@ -1059,8 +1072,13 @@ def create_chat_app() -> Flask:
                 # Get or create client for this session
                 client_options = _get_client_options(config)
                 if session_id not in _session_clients or _session_client_options.get(session_id) != client_options:
-                    model, api_key, base_url = client_options
-                    _session_clients[session_id] = AutoLLMClient(model=model, api_key=api_key, base_url=base_url)
+                    model, api_key, base_url, client_type = client_options
+                    _session_clients[session_id] = AutoLLMClient(
+                        model=model,
+                        api_key=api_key,
+                        base_url=base_url,
+                        client_type=client_type,
+                    )
                     _session_client_options[session_id] = client_options
 
                 client = _session_clients[session_id]

--- a/src_py/agenthub/integration/tracer.py
+++ b/src_py/agenthub/integration/tracer.py
@@ -692,7 +692,7 @@ class Tracer:
             items = []
             try:
                 with os.scandir(full_path) as scanner:
-                    raw_entries = list(scanner)
+                    raw_entries = [entry for entry in scanner if entry.name != ".DS_Store"]
 
                 # Filter entries that pass the security check first
                 safe_entries: list[tuple[os.DirEntry, Path]] = []

--- a/src_py/agenthub/kimi_k2_6/client.py
+++ b/src_py/agenthub/kimi_k2_6/client.py
@@ -102,7 +102,7 @@ class KimiK2_6Client(LLMClient):
         kimi_config = {"model": self._model, "stream": True, "stream_options": {"include_usage": True}}
 
         if config.get("max_tokens") is not None:
-            kimi_config["max_tokens"] = config["max_tokens"]
+            kimi_config["max_completion_tokens"] = config["max_tokens"]
 
         if config.get("temperature") is not None and config["temperature"] != 1.0:
             raise ValueError("Kimi does not support setting temperature.")

--- a/src_py/agenthub/openai/__init__.py
+++ b/src_py/agenthub/openai/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .client import Qwen3_6Client
+from .client import OpenaiClient
 
 
-__all__ = ["Qwen3_6Client"]
+__all__ = ["OpenaiClient"]

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -79,10 +79,7 @@ class OpenaiClient(LLMClient):
                 },
             }
 
-        if tool_choice in ("none", "auto", "required"):
-            return tool_choice
-
-        raise ValueError("OpenAI Chat Completions only supports 'none', 'auto', 'required', or named tools.")
+        return tool_choice
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """
@@ -109,7 +106,7 @@ class OpenaiClient(LLMClient):
             openai_config["tool_choice"] = self._convert_tool_choice(config["tool_choice"])
 
         if config.get("prompt_caching") is not None and config["prompt_caching"] != PromptCaching.ENABLE:
-            raise ValueError("prompt_caching must be ENABLE for OpenAI Chat Compatible.")
+            raise ValueError("prompt_caching must be ENABLE for OpenAI.")
 
         return openai_config
 
@@ -344,9 +341,6 @@ class OpenaiClient(LLMClient):
                         else:
                             # update partial tool call for tool call object
                             partial_tool_call["arguments"] += item["arguments"]
-                            partial_tool_call["tool_call_id"] = (
-                                item["tool_call_id"] or partial_tool_call["tool_call_id"]
-                            )
 
                 yield event
             elif event["event_type"] == "stop":

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -37,14 +37,14 @@ from ..types import (
 from ..utils import fix_openrouter_usage_metadata
 
 
-class Qwen3_6Client(LLMClient):
-    """Qwen3.6 client-specific LLM client implementation using OpenAI-compatible API."""
+class OpenaiClient(LLMClient):
+    """OpenAI Chat Completions-compatible client implementation."""
 
     def __init__(self, model: str, api_key: str | None = None, base_url: str | None = None):
-        """Initialize Qwen3.6 client with model and API key."""
+        """Initialize OpenAI-compatible chat client with model, API key, and base URL."""
         self._model = model
-        api_key = api_key or os.getenv("QWEN_API_KEY")
-        base_url = base_url or os.getenv("QWEN_BASE_URL", "http://127.0.0.1:8000/v1/")
+        api_key = api_key or os.getenv("OPENAI_API_KEY")
+        base_url = base_url or os.getenv("OPENAI_BASE_URL")
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self._history: list[UniMessage] = []
 
@@ -68,55 +68,64 @@ class Qwen3_6Client(LLMClient):
             base64_string = base64.b64encode(image_bytes).decode("utf-8")
             return f"data:{mime_type};base64,{base64_string}"
 
-    def _convert_tool_choice(self, tool_choice: ToolChoice) -> str:
-        """Convert ToolChoice to OpenAI's tool_choice format."""
-        if tool_choice == "auto":
-            return "auto"
-        else:
-            raise ValueError("Qwen3 only supports 'auto' for tool_choice.")
+    def _convert_tool_choice(self, tool_choice: ToolChoice) -> str | dict[str, Any]:
+        """Convert ToolChoice to OpenAI Chat Completions tool_choice format."""
+        if isinstance(tool_choice, list):
+            return {
+                "type": "allowed_tools",
+                "allowed_tools": {
+                    "mode": "auto",
+                    "tools": [{"type": "function", "function": {"name": name}} for name in tool_choice],
+                },
+            }
+
+        if tool_choice in ("none", "auto", "required"):
+            return tool_choice
+
+        raise ValueError("OpenAI Chat Completions only supports 'none', 'auto', 'required', or named tools.")
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """
-        Transform universal configuration to Qwen3-specific configuration.
+        Transform universal configuration to OpenAI Chat Completions configuration.
 
         Args:
             config: Universal configuration dict
 
         Returns:
-            Qwen3 configuration dictionary
+            OpenAI Chat Completions configuration dictionary
         """
-        qwen_config = {"model": self._model, "stream": True}
+        openai_config = {"model": self._model, "stream": True, "stream_options": {"include_usage": True}}
 
         if config.get("max_tokens") is not None:
-            qwen_config["max_tokens"] = config["max_tokens"]
+            openai_config["max_completion_tokens"] = config["max_tokens"]
 
         if config.get("temperature") is not None:
-            qwen_config["temperature"] = config["temperature"]
+            openai_config["temperature"] = config["temperature"]
 
         if config.get("tools") is not None:
-            qwen_config["tools"] = [{"type": "function", "function": tool} for tool in config["tools"]]
+            openai_config["tools"] = [{"type": "function", "function": tool} for tool in config["tools"]]
 
         if config.get("tool_choice") is not None:
-            qwen_config["tool_choice"] = self._convert_tool_choice(config["tool_choice"])
+            openai_config["tool_choice"] = self._convert_tool_choice(config["tool_choice"])
 
         if config.get("prompt_caching") is not None and config["prompt_caching"] != PromptCaching.ENABLE:
-            raise ValueError("prompt_caching must be ENABLE for Qwen.")
+            raise ValueError("prompt_caching must be ENABLE for OpenAI Chat Compatible.")
 
-        return qwen_config
+        return openai_config
 
     async def transform_uni_message_to_model_input(
         self, messages: list[UniMessage]
     ) -> list[ChatCompletionMessageParam]:
         """
-        Transform universal message format to Qwen-specific message format.
+        Transform universal message format to OpenAI Chat Completions message format.
 
         Args:
             messages: List of universal message dictionaries
 
         Returns:
-            List of Qwen message dictionaries
+            List of OpenAI Chat Completions message dictionaries
         """
-        qwen_messages = []
+        openai_messages = []
 
         for msg in messages:
             content_parts = []  # may be empty for tool results
@@ -157,7 +166,7 @@ class Qwen3_6Client(LLMClient):
                                 content.append({"type": "image_url", "image_url": {"url": base64_image}})
 
                     # Tool results are sent as separate messages
-                    qwen_messages.append(
+                    openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
@@ -180,13 +189,13 @@ class Qwen3_6Client(LLMClient):
 
             # message may be empty for tool results
             if len(message.keys()) > 1:
-                qwen_messages.append(message)
+                openai_messages.append(message)
 
-        return qwen_messages
+        return openai_messages
 
     def transform_model_output_to_uni_event(self, model_output: ChatCompletionChunk) -> UniEvent:
         """
-        Transform Qwen model output to universal event format.
+        Transform OpenAI Chat Completions streaming chunk to universal event format.
 
         Args:
             model_output: OpenAI streaming chunk
@@ -204,14 +213,8 @@ class Qwen3_6Client(LLMClient):
             delta = choice.delta
 
             if delta.content:
-                # manually check for content since tool parser of vLLM is not stable
-                if delta.content == "<tool_call>":
-                    event_type = "start"
-                elif delta.content == "</tool_call>":
-                    event_type = "stop"
-                else:
-                    event_type = "delta"
-                    content_items.append({"type": "text", "text": delta.content})
+                event_type = "delta"
+                content_items.append({"type": "text", "text": delta.content})
 
             # vLLM & siliconflow compatibility
             if getattr(delta, "reasoning_content", None):
@@ -231,7 +234,7 @@ class Qwen3_6Client(LLMClient):
                             "type": "partial_tool_call",
                             "name": tool_call.function.name or "",
                             "arguments": tool_call.function.arguments or "",
-                            "tool_call_id": tool_call.function.name or "",
+                            "tool_call_id": tool_call.id or tool_call.function.name or "",
                         }
                     )
 
@@ -289,19 +292,15 @@ class Qwen3_6Client(LLMClient):
         messages: list[UniMessage],
         config: UniConfig,
     ) -> AsyncIterator[UniEvent]:
-        """Stream generate using Qwen3 SDK with unified conversion methods."""
-        # Use unified config conversion
-        qwen_config = self.transform_uni_config_to_model_config(config)
+        """Stream generate using OpenAI Chat Completions-compatible API."""
+        openai_config = self.transform_uni_config_to_model_config(config)
 
-        # Use unified message conversion
-        qwen_messages = await self.transform_uni_message_to_model_input(messages)
+        openai_messages = await self.transform_uni_message_to_model_input(messages)
 
-        # Extract system prompt if present
         if config.get("system_prompt"):
-            qwen_messages.insert(0, {"role": "system", "content": config["system_prompt"]})
+            openai_messages.insert(0, {"role": "system", "content": config["system_prompt"]})
 
-        # Stream generate
-        stream = await self._client.chat.completions.create(**qwen_config, messages=qwen_messages)
+        stream = await self._client.chat.completions.create(**openai_config, messages=openai_messages)
 
         partial_tool_call = {}
         partial_usage = {}
@@ -310,20 +309,16 @@ class Qwen3_6Client(LLMClient):
             # the finish reason and usage metadata should be accumulated
             partial_usage["finish_reason"] = event["finish_reason"] or partial_usage.get("finish_reason")
             partial_usage["usage_metadata"] = event["usage_metadata"] or partial_usage.get("usage_metadata")
-            if event["event_type"] == "start":
-                # start new partial tool call for <tool_call>
-                partial_tool_call = {"data": ""}
-            elif event["event_type"] == "delta":
-                if "data" in partial_tool_call:
-                    # update partial tool call for <tool_call>
-                    partial_tool_call["data"] += event["content_items"][0]["text"]
-                    continue
-
+            if event["event_type"] == "delta":
                 for item in event["content_items"]:
                     if item["type"] == "partial_tool_call":
                         if not partial_tool_call:
                             # start new partial tool call for tool call object
-                            partial_tool_call = {"name": item["name"], "arguments": item["arguments"]}
+                            partial_tool_call = {
+                                "name": item["name"],
+                                "arguments": item["arguments"],
+                                "tool_call_id": item["tool_call_id"],
+                            }
                         elif item["name"]:
                             # finish previous partial tool call for tool call object
                             yield {
@@ -334,53 +329,27 @@ class Qwen3_6Client(LLMClient):
                                         "type": "tool_call",
                                         "name": partial_tool_call["name"],
                                         "arguments": json.loads(partial_tool_call["arguments"] or "{}"),
-                                        "tool_call_id": partial_tool_call["name"],
+                                        "tool_call_id": partial_tool_call["tool_call_id"],
                                     }
                                 ],
                                 "usage_metadata": None,
                                 "finish_reason": None,
                             }
                             # start new partial tool call for tool call object
-                            partial_tool_call = {"name": item["name"], "arguments": item["arguments"]}
+                            partial_tool_call = {
+                                "name": item["name"],
+                                "arguments": item["arguments"],
+                                "tool_call_id": item["tool_call_id"],
+                            }
                         else:
                             # update partial tool call for tool call object
                             partial_tool_call["arguments"] += item["arguments"]
+                            partial_tool_call["tool_call_id"] = (
+                                item["tool_call_id"] or partial_tool_call["tool_call_id"]
+                            )
 
                 yield event
             elif event["event_type"] == "stop":
-                if "data" in partial_tool_call:
-                    # finish partial tool call for <tool_call>
-                    tool_call = json.loads(partial_tool_call["data"].strip())
-                    yield {
-                        "role": "assistant",
-                        "event_type": "delta",
-                        "content_items": [
-                            {
-                                "type": "partial_tool_call",
-                                "name": tool_call["name"],
-                                "arguments": json.dumps(tool_call["arguments"], ensure_ascii=False),
-                                "tool_call_id": tool_call["name"],
-                            }
-                        ],
-                        "usage_metadata": None,
-                        "finish_reason": None,
-                    }
-                    yield {
-                        "role": "assistant",
-                        "event_type": "delta",
-                        "content_items": [
-                            {
-                                "type": "tool_call",
-                                "name": tool_call["name"],
-                                "arguments": tool_call["arguments"],
-                                "tool_call_id": tool_call["name"],
-                            }
-                        ],
-                        "usage_metadata": None,
-                        "finish_reason": None,
-                    }
-                    partial_tool_call = {}
-
                 if partial_tool_call:
                     # finish partial tool call for tool call object
                     yield {
@@ -391,7 +360,7 @@ class Qwen3_6Client(LLMClient):
                                 "type": "tool_call",
                                 "name": partial_tool_call["name"],
                                 "arguments": json.loads(partial_tool_call["arguments"] or "{}"),
-                                "tool_call_id": partial_tool_call["name"],
+                                "tool_call_id": partial_tool_call["tool_call_id"],
                             }
                         ],
                         "usage_metadata": None,

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -40,6 +40,7 @@ class Model:
     support_tts: bool = False
     support_embedding: bool = False
     provider: Literal["official", "bedrock", "vertex", "siliconflow", "openrouter", "modelverse"] = "official"
+    client_type: str | None = None
 
     def __repr__(self) -> str:
         return f"{self.name}:{self.provider}"
@@ -124,14 +125,14 @@ RUN_SLOW_TEST = os.getenv("RUN_SLOW_TEST", "0") == "1"
 
 if os.getenv("OPENROUTER_API_KEY") and RUN_SLOW_TEST:
     AVAILABLE_MODELS.append(Model(name="z-ai/glm-5.1", provider="openrouter", support_image_understanding=False))
-    AVAILABLE_MODELS.append(Model(name="qwen/qwen3.6-35b-a3b", provider="openrouter"))
+    AVAILABLE_MODELS.append(Model(name="qwen/qwen3.6-35b-a3b", provider="openrouter", client_type="openai"))
     AVAILABLE_MODELS.append(Model(name="moonshotai/kimi-k2.6", provider="openrouter", support_temperature=False))
 
 if os.getenv("SILICONFLOW_API_KEY") and RUN_SLOW_TEST:
     AVAILABLE_MODELS.append(
         Model(name="Pro/zai-org/GLM-5.1", provider="siliconflow", support_image_understanding=False)
     )
-    AVAILABLE_MODELS.append(Model(name="Qwen/Qwen3.6-35B-A3B", provider="siliconflow"))
+    AVAILABLE_MODELS.append(Model(name="Qwen/Qwen3.6-35B-A3B", provider="siliconflow", client_type="openai"))
     AVAILABLE_MODELS.append(Model(name="Pro/moonshotai/Kimi-K2.6", provider="siliconflow", support_temperature=False))
 
 if os.getenv("MODELVERSE_API_KEY") and RUN_SLOW_TEST:
@@ -162,7 +163,7 @@ async def _create_client(model: Model) -> AutoLLMClient:
     else:
         api_key, base_url = None, None
 
-    return AutoLLMClient(model=model.name, api_key=api_key, base_url=base_url)
+    return AutoLLMClient(model=model.name, api_key=api_key, base_url=base_url, client_type=model.client_type)
 
 
 async def _check_event_integrity(event: dict) -> None:
@@ -361,6 +362,14 @@ async def test_unknown_model():
     """Test that unknown models raise ValueError."""
     with pytest.raises(ValueError, match="not support"):
         AutoLLMClient(model="unknown-model")
+
+
+@pytest.mark.asyncio
+async def test_openai_client_type_routes_to_openai_client():
+    """Test client_type override for OpenAI-compatible models."""
+    client = AutoLLMClient(model="unknown-model", api_key="test-key", client_type="openai-compatible")
+
+    assert client._client.__class__.__name__ == "OpenaiClient"
 
 
 @pytest.mark.asyncio

--- a/src_py/tests/test_playground.py
+++ b/src_py/tests/test_playground.py
@@ -33,7 +33,7 @@ def test_chat_app_index_route():
     with app.test_client() as client:
         response = client.get("/")
         assert response.status_code == 200
-        assert b"LLM Playground" in response.data
+        assert b"AgentHub Playground" in response.data
         assert b'<h1 class="text-xl font-semibold">AgentHub</h1>' in response.data
         assert b"messagesContainer" in response.data
         assert b"messageInput" in response.data
@@ -99,11 +99,12 @@ def test_chat_app_uses_client_connection_options(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, model, api_key=None, base_url=None):
+        def __init__(self, model, api_key=None, base_url=None, client_type=None):
             captured["client_options"] = {
                 "model": model,
                 "api_key": api_key,
                 "base_url": base_url,
+                "client_type": client_type,
             }
 
         async def streaming_response_stateful(self, message, config, signal=None):
@@ -136,6 +137,7 @@ def test_chat_app_uses_client_connection_options(monkeypatch):
                     "model": "gpt-5.5",
                     "api_key": "test-key",
                     "base_url": "https://example.test/v1",
+                    "client_type": "gpt-5.5",
                     "thinking_level": "low",
                 },
             },
@@ -148,6 +150,7 @@ def test_chat_app_uses_client_connection_options(monkeypatch):
         "model": "gpt-5.5",
         "api_key": "test-key",
         "base_url": "https://example.test/v1",
+        "client_type": "gpt-5.5",
     }
     assert captured["request_config"] == {"thinking_level": "low"}
     assert isinstance(captured["signal"], AbortSignal)
@@ -158,7 +161,7 @@ def test_chat_app_accepts_large_image_payload(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, model, api_key=None, base_url=None):
+        def __init__(self, model, api_key=None, base_url=None, client_type=None):
             pass
 
         async def streaming_response_stateful(self, message, config, signal=None):

--- a/src_py/tests/test_tracer.py
+++ b/src_py/tests/test_tracer.py
@@ -372,6 +372,29 @@ def test_web_app_sort_by_name(temp_cache_dir):
         assert "sort=mtime" in html
 
 
+def test_web_app_filters_ds_store(temp_cache_dir):
+    """Test that macOS metadata files are hidden from directory listings."""
+    tracer = Tracer(cache_dir=temp_cache_dir)
+
+    model = "fake-model"
+    history = [{"role": "user", "content_items": [{"type": "text", "text": "Test"}]}]
+    config = {}
+    tracer.save_history(model, history, "agent/conv", config)
+    (Path(temp_cache_dir) / ".DS_Store").write_text("metadata")
+    (Path(temp_cache_dir) / "agent" / ".DS_Store").write_text("metadata")
+
+    app = tracer.create_web_app()
+
+    with app.test_client() as client:
+        root_response = client.get("/")
+        assert root_response.status_code == 200
+        assert ".DS_Store" not in root_response.data.decode()
+
+        nested_response = client.get("/agent")
+        assert nested_response.status_code == 200
+        assert ".DS_Store" not in nested_response.data.decode()
+
+
 def test_web_app_sort_by_mtime(temp_cache_dir):
     """Test directory listing sorted by modification time (most recent first)."""
     tracer = Tracer(cache_dir=temp_cache_dir)

--- a/src_ts/README.md
+++ b/src_ts/README.md
@@ -22,6 +22,8 @@ process.env.OPENAI_API_KEY = "your-openai-api-key";
 
 async function main() {
   const client = new AutoLLMClient({ model: "gpt-5.5" });
+  // For OpenAI Chat Completions-compatible endpoints:
+  // const client = new AutoLLMClient({ model: "custom-model", clientType: "openai" });
 
   for await (const event of client.streamingResponseStateful({
     message: {

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -15,7 +15,7 @@
 import { LLMClient } from "./baseClient";
 import { Gemini3Client } from "./gemini3";
 import { Claude4_6Client } from "./claude4_6";
-import { Claude4_7Client } from "./claude4_7";
+import { Claude4_8Client } from "./claude4_8";
 import { GPT5_5Client } from "./gpt5_5";
 import { GLM5_1Client } from "./glm5_1";
 import { KimiK2_6Client } from "./kimi_k2_6";
@@ -75,14 +75,15 @@ export class AutoLLMClient extends LLMClient {
     ).toLowerCase();
 
     if (
-      clientType.includes("gemini-3-") ||
-      clientType.includes("gemini-3.1-") ||
-      clientType.includes("gemini-3.5-") ||
+      clientType.includes("gemini-3") ||
       clientType.includes("gemini-embedding")
     ) {
       return new Gemini3Client({ model, apiKey, baseUrl });
-    } else if (clientType.includes("claude") && clientType.includes("4-7")) {
-      return new Claude4_7Client({ model, apiKey, baseUrl });
+    } else if (
+      clientType.includes("claude") &&
+      (clientType.includes("4-7") || clientType.includes("4-8"))
+    ) {
+      return new Claude4_8Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("claude") && clientType.includes("4-6")) {
       return new Claude4_6Client({ model, apiKey, baseUrl });
     } else if (
@@ -97,14 +98,14 @@ export class AutoLLMClient extends LLMClient {
       clientType.includes("kimi-k2.6")
     ) {
       return new KimiK2_6Client({ model, apiKey, baseUrl });
+    } else if (clientType.includes("deepseek-v4")) {
+      return new DeepSeekV4Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("openai")) {
       return new OpenaiClient({ model, apiKey, baseUrl });
-    } else if (clientType.includes("deepseek-v4-")) {
-      return new DeepSeekV4Client({ model, apiKey, baseUrl });
     } else {
       throw new Error(
         `${clientType} is not supported. ` +
-          "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, openai, deepseek-v4.",
+          "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai.",
       );
     }
   }

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -19,7 +19,7 @@ import { Claude4_7Client } from "./claude4_7";
 import { GPT5_5Client } from "./gpt5_5";
 import { GLM5_1Client } from "./glm5_1";
 import { KimiK2_6Client } from "./kimi_k2_6";
-import { Qwen3_6Client } from "./qwen3_6";
+import { OpenaiClient } from "./openai";
 import { DeepSeekV4Client } from "./deepseek_v4";
 import { UniConfig, UniEvent, UniMessage } from "./types";
 
@@ -68,7 +68,11 @@ export class AutoLLMClient extends LLMClient {
     baseUrl?: string | null,
     clientType?: string | null,
   ): LLMClient {
-    clientType = clientType || process.env.CLIENT_TYPE || model.toLowerCase();
+    clientType = (
+      clientType ||
+      process.env.CLIENT_TYPE ||
+      model.toLowerCase()
+    ).toLowerCase();
 
     if (
       clientType.includes("gemini-3-") ||
@@ -93,14 +97,14 @@ export class AutoLLMClient extends LLMClient {
       clientType.includes("kimi-k2.6")
     ) {
       return new KimiK2_6Client({ model, apiKey, baseUrl });
-    } else if (clientType.includes("qwen3.6")) {
-      return new Qwen3_6Client({ model, apiKey, baseUrl });
+    } else if (clientType.includes("openai")) {
+      return new OpenaiClient({ model, apiKey, baseUrl });
     } else if (clientType.includes("deepseek-v4-")) {
       return new DeepSeekV4Client({ model, apiKey, baseUrl });
     } else {
       throw new Error(
         `${clientType} is not supported. ` +
-          "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, qwen3.6, deepseek-v4.",
+          "Supported client types: gemini-3, claude-4-7, claude-4-6, gpt-5.4, gpt-5.5, glm-5.1, kimi-k2.5, kimi-k2.6, openai, deepseek-v4.",
       );
     }
   }

--- a/src_ts/src/claude4_8/client.ts
+++ b/src_ts/src/claude4_8/client.ts
@@ -36,15 +36,15 @@ import {
 const REDACTED_THINKING = "_REDACTED_THINKING";
 
 /**
- * Claude 4.7-specific LLM client implementation.
+ * Claude 4.8-specific LLM client implementation.
  */
-export class Claude4_7Client extends LLMClient {
+export class Claude4_8Client extends LLMClient {
   protected _model: string;
   private _client: Anthropic | AnthropicBedrock;
   private _use_bedrock: boolean;
 
   /**
-   * Initialize Claude 4.7 client with model and API key.
+   * Initialize Claude 4.8 client with model and API key.
    */
   constructor(options: {
     model: string;

--- a/src_ts/src/claude4_8/index.ts
+++ b/src_ts/src/claude4_8/index.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { Claude4_7Client } from "./client";
+export { Claude4_8Client } from "./client";

--- a/src_ts/src/glm5_1/client.ts
+++ b/src_ts/src/glm5_1/client.ts
@@ -66,7 +66,9 @@ export class GLM5_1Client extends LLMClient {
     type: string;
     clear_thinking?: boolean;
   } {
-    const mapping: { [key: string]: { type: string; clear_thinking?: boolean } } = {
+    const mapping: {
+      [key: string]: { type: string; clear_thinking?: boolean };
+    } = {
       [ThinkingLevel.NONE]: { type: "disabled" },
       [ThinkingLevel.LOW]: { type: "enabled", clear_thinking: false },
       [ThinkingLevel.MEDIUM]: { type: "enabled", clear_thinking: false },

--- a/src_ts/src/glm5_1/client.ts
+++ b/src_ts/src/glm5_1/client.ts
@@ -64,13 +64,14 @@ export class GLM5_1Client extends LLMClient {
    */
   private _convertThinkingLevelToConfig(thinkingLevel: ThinkingLevel): {
     type: string;
+    clear_thinking?: boolean;
   } {
-    const mapping: { [key: string]: { type: string } } = {
+    const mapping: { [key: string]: { type: string; clear_thinking?: boolean } } = {
       [ThinkingLevel.NONE]: { type: "disabled" },
-      [ThinkingLevel.LOW]: { type: "enabled" },
-      [ThinkingLevel.MEDIUM]: { type: "enabled" },
-      [ThinkingLevel.HIGH]: { type: "enabled" },
-      [ThinkingLevel.XHIGH]: { type: "enabled" },
+      [ThinkingLevel.LOW]: { type: "enabled", clear_thinking: false },
+      [ThinkingLevel.MEDIUM]: { type: "enabled", clear_thinking: false },
+      [ThinkingLevel.HIGH]: { type: "enabled", clear_thinking: false },
+      [ThinkingLevel.XHIGH]: { type: "enabled", clear_thinking: false },
     };
     return mapping[thinkingLevel];
   }

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -33,12 +33,14 @@ interface PlaygroundConfig extends UniConfig {
   model?: string;
   api_key?: string;
   base_url?: string;
+  client_type?: string;
 }
 
 interface PlaygroundClientOptions {
   model: string;
   apiKey?: string;
   baseUrl?: string;
+  clientType?: string;
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -50,6 +52,7 @@ function getClientOptions(config: PlaygroundConfig): PlaygroundClientOptions {
     model: normalizeOptionalString(config.model) || "gpt-5.5",
     apiKey: normalizeOptionalString(config.api_key),
     baseUrl: normalizeOptionalString(config.base_url),
+    clientType: normalizeOptionalString(config.client_type),
   };
 }
 
@@ -58,6 +61,7 @@ function getRequestConfig(config: PlaygroundConfig): UniConfig {
   delete requestConfig.model;
   delete requestConfig.api_key;
   delete requestConfig.base_url;
+  delete requestConfig.client_type;
   return requestConfig;
 }
 
@@ -69,7 +73,8 @@ function clientOptionsChanged(
     !previous ||
     previous.model !== next.model ||
     previous.apiKey !== next.apiKey ||
-    previous.baseUrl !== next.baseUrl
+    previous.baseUrl !== next.baseUrl ||
+    previous.clientType !== next.clientType
   );
 }
 
@@ -128,7 +133,7 @@ export function createChatApp(): Express {
   <!DOCTYPE html>
   <html>
   <head>
-      <title>LLM Playground</title>
+      <title>AgentHub Playground</title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <script src="https://cdn.tailwindcss.com"></script>
@@ -216,9 +221,6 @@ export function createChatApp(): Express {
                           <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.1" data-label="GLM 5.1" data-description="glm-5.1" onclick="selectComboboxOption('modelCombobox', this)">
                               <span class="block truncate text-sm font-medium text-gray-900">GLM 5.1</span>
                           </button>
-                          <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="qwen/qwen3.6-35b-a3b" data-label="Qwen3.6 35B" data-description="qwen/qwen3.6-35b-a3b" onclick="selectComboboxOption('modelCombobox', this)">
-                              <span class="block truncate text-sm font-medium text-gray-900">Qwen3.6 35B</span>
-                          </button>
                           <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="gemini-3.1-flash-image-preview" data-label="Gemini 3.1 Flash Image" data-description="gemini-3.1-flash-image-preview" onclick="selectComboboxOption('modelCombobox', this)">
                               <span class="block truncate text-sm font-medium text-gray-900">Gemini 3.1 Flash Image</span>
                           </button>
@@ -236,12 +238,19 @@ export function createChatApp(): Express {
                           </button>
                       </div>
                   </div>
-                  <div id="customModelWrapper" class="hidden mt-2">
+                  <div id="customModelWrapper" class="hidden mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                       <input
                           id="customModelInput"
                           type="text"
                           autocomplete="off"
                           placeholder="Custom model id"
+                          class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                      <input
+                          id="customClientTypeInput"
+                          type="text"
+                          autocomplete="off"
+                          placeholder="Client type"
                           class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       />
                   </div>
@@ -630,6 +639,13 @@ export function createChatApp(): Express {
               const apiKey = document.getElementById('apiKeyInput').value.trim();
               if (apiKey) {
                   config.api_key = apiKey;
+              }
+
+              if (document.getElementById('modelSelect').value === '__custom__') {
+                  const clientType = document.getElementById('customClientTypeInput').value.trim();
+                  if (clientType) {
+                      config.client_type = clientType;
+                  }
               }
 
               const baseUrl = document.getElementById('baseUrlInput').value.trim();

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -1088,10 +1088,7 @@ export function createChatApp(): Express {
       const clientOptions = getClientOptions(config || {});
       if (
         !sessionClients.has(sessionId) ||
-        clientOptionsChanged(
-          sessionClientOptions.get(sessionId),
-          clientOptions,
-        )
+        clientOptionsChanged(sessionClientOptions.get(sessionId), clientOptions)
       ) {
         sessionClients.set(sessionId, new AutoLLMClient(clientOptions));
         sessionClientOptions.set(sessionId, clientOptions);

--- a/src_ts/src/integration/tracer.ts
+++ b/src_ts/src/integration/tracer.ts
@@ -766,7 +766,9 @@ export class Tracer {
       try {
         const sortBy = req.query["sort"] === "mtime" ? "mtime" : "name";
 
-        const entries = fs.readdirSync(fullPath, { withFileTypes: true });
+        const entries = fs
+          .readdirSync(fullPath, { withFileTypes: true })
+          .filter((entry) => entry.name !== ".DS_Store");
         const entryStats = new Map<string, fs.Stats>();
         for (const entry of entries) {
           entryStats.set(

--- a/src_ts/src/kimi_k2_6/client.ts
+++ b/src_ts/src/kimi_k2_6/client.ts
@@ -145,7 +145,7 @@ export class KimiK2_6Client extends LLMClient {
     };
 
     if (config.max_tokens !== undefined) {
-      kimiConfig.max_tokens = config.max_tokens;
+      kimiConfig.max_completion_tokens = config.max_tokens;
     }
 
     if (config.temperature !== undefined && config.temperature !== 1.0) {

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -116,13 +116,7 @@ export class OpenaiClient extends LLMClient {
       };
     }
 
-    if (["none", "auto", "required"].includes(toolChoice)) {
-      return toolChoice;
-    }
-
-    throw new Error(
-      'OpenAI Chat Completions only supports "none", "auto", "required", or named tools.',
-    );
+    return toolChoice;
   }
 
   /**
@@ -160,9 +154,7 @@ export class OpenaiClient extends LLMClient {
       config.prompt_caching !== undefined &&
       config.prompt_caching !== PromptCaching.ENABLE
     ) {
-      throw new Error(
-        "prompt_caching must be ENABLE for OpenAI Chat Compatible.",
-      );
+      throw new Error("prompt_caching must be ENABLE for OpenAI.");
     }
 
     return openaiConfig;
@@ -454,8 +446,6 @@ export class OpenaiClient extends LLMClient {
               // update partial tool call for tool call object
               partialToolCall.arguments =
                 (partialToolCall.arguments || "") + item.arguments;
-              partialToolCall.tool_call_id =
-                item.tool_call_id || partialToolCall.tool_call_id;
             }
           }
         }

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -34,14 +34,14 @@ import {
 import { fixOpenrouterUsageMetadata } from "../utils";
 
 /**
- * Qwen3.6 client-specific LLM client implementation using OpenAI-compatible API.
+ * OpenAI Chat Completions-compatible client implementation.
  */
-export class Qwen3_6Client extends LLMClient {
+export class OpenaiClient extends LLMClient {
   protected _model: string;
   private _client: OpenAI;
 
   /**
-   * Initialize Qwen3.6 client with model and API key.
+   * Initialize OpenAI-compatible chat client with model, API key, and base URL.
    */
   constructor(options: {
     model: string;
@@ -51,11 +51,8 @@ export class Qwen3_6Client extends LLMClient {
   }) {
     super();
     this._model = options.model;
-    const key = options.apiKey || process.env.QWEN_API_KEY || undefined;
-    const url =
-      options.baseUrl ||
-      process.env.QWEN_BASE_URL ||
-      "http://127.0.0.1:8000/v1/";
+    const key = options.apiKey || process.env.OPENAI_API_KEY || undefined;
+    const url = options.baseUrl || process.env.OPENAI_BASE_URL || undefined;
     this._client = new OpenAI({ apiKey: key, baseURL: url });
   }
 
@@ -102,65 +99,83 @@ export class Qwen3_6Client extends LLMClient {
   }
 
   /**
-   * Convert ToolChoice to OpenAI's tool_choice format.
+   * Convert ToolChoice to OpenAI Chat Completions tool_choice format.
    */
-  private _convertToolChoice(toolChoice: ToolChoice): string {
-    if (toolChoice === "auto") {
-      return "auto";
-    } else {
-      throw new Error('Qwen3 only supports "auto" for tool_choice.');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _convertToolChoice(toolChoice: ToolChoice): any {
+    if (Array.isArray(toolChoice)) {
+      return {
+        type: "allowed_tools",
+        allowed_tools: {
+          mode: "auto",
+          tools: toolChoice.map((name) => ({
+            type: "function",
+            function: { name },
+          })),
+        },
+      };
     }
+
+    if (["none", "auto", "required"].includes(toolChoice)) {
+      return toolChoice;
+    }
+
+    throw new Error(
+      'OpenAI Chat Completions only supports "none", "auto", "required", or named tools.',
+    );
   }
 
   /**
-   * Transform universal configuration to Qwen-specific configuration.
+   * Transform universal configuration to OpenAI Chat Completions configuration.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   transformUniConfigToModelConfig(config: UniConfig): any {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const qwenConfig: any = {
+    const openaiConfig: any = {
       model: this._model,
       stream: true,
       stream_options: { include_usage: true },
     };
 
     if (config.max_tokens !== undefined) {
-      qwenConfig.max_tokens = config.max_tokens;
+      openaiConfig.max_completion_tokens = config.max_tokens;
     }
 
     if (config.temperature !== undefined) {
-      qwenConfig.temperature = config.temperature;
+      openaiConfig.temperature = config.temperature;
     }
 
     if (config.tools !== undefined) {
-      qwenConfig.tools = config.tools.map((tool) => ({
+      openaiConfig.tools = config.tools.map((tool) => ({
         type: "function",
         function: tool,
       }));
     }
 
     if (config.tool_choice !== undefined) {
-      qwenConfig.tool_choice = this._convertToolChoice(config.tool_choice);
+      openaiConfig.tool_choice = this._convertToolChoice(config.tool_choice);
     }
 
     if (
       config.prompt_caching !== undefined &&
       config.prompt_caching !== PromptCaching.ENABLE
     ) {
-      throw new Error("prompt_caching must be ENABLE for Qwen.");
+      throw new Error(
+        "prompt_caching must be ENABLE for OpenAI Chat Compatible.",
+      );
     }
 
-    return qwenConfig;
+    return openaiConfig;
   }
 
   /**
-   * Transform universal message format to Qwen-specific message format.
+   * Transform universal message format to OpenAI Chat Completions message format.
    */
   async transformUniMessageToModelInput(
     messages: UniMessage[],
     signal?: AbortSignal,
   ): Promise<ChatCompletionMessageParam[]> {
-    const qwenMessages: ChatCompletionMessageParam[] = [];
+    const openaiMessages: ChatCompletionMessageParam[] = [];
 
     for (const msg of messages) {
       const contentParts: Array<{
@@ -223,7 +238,7 @@ export class Qwen3_6Client extends LLMClient {
             }
           }
 
-          qwenMessages.push({
+          openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
             content,
@@ -251,15 +266,15 @@ export class Qwen3_6Client extends LLMClient {
       }
 
       if (Object.keys(message).length > 1) {
-        qwenMessages.push(message);
+        openaiMessages.push(message);
       }
     }
 
-    return qwenMessages;
+    return openaiMessages;
   }
 
   /**
-   * Transform Qwen model output to universal event format.
+   * Transform OpenAI Chat Completions streaming chunk to universal event format.
    */
   transformModelOutputToUniEvent(modelOutput: ChatCompletionChunk): UniEvent {
     let eventType: EventType | null = null;
@@ -272,14 +287,8 @@ export class Qwen3_6Client extends LLMClient {
       const delta = choice?.delta;
 
       if (delta?.content) {
-        if (delta.content === "<tool_call>") {
-          eventType = "start";
-        } else if (delta.content === "</tool_call>") {
-          eventType = "stop";
-        } else {
-          eventType = "delta";
-          contentItems.push({ type: "text", text: delta.content });
-        }
+        eventType = "delta";
+        contentItems.push({ type: "text", text: delta.content });
       }
 
       // vLLM & siliconflow compatibility
@@ -310,7 +319,7 @@ export class Qwen3_6Client extends LLMClient {
             type: "partial_tool_call",
             name: toolCall.function?.name || "",
             arguments: toolCall.function?.arguments || "",
-            tool_call_id: toolCall.function?.name || "",
+            tool_call_id: toolCall.id || toolCall.function?.name || "",
           });
         }
       }
@@ -366,29 +375,29 @@ export class Qwen3_6Client extends LLMClient {
   }
 
   /**
-   * Stream generate using Qwen3 SDK with unified conversion methods.
+   * Stream generate using OpenAI Chat Completions-compatible API.
    */
   async *_streamingResponseInternal(options: {
     messages: UniMessage[];
     config: UniConfig;
     signal?: AbortSignal;
   }): AsyncGenerator<UniEvent> {
-    const qwenConfig = this.transformUniConfigToModelConfig(options.config);
-    const qwenMessages = await this.transformUniMessageToModelInput(
+    const openaiConfig = this.transformUniConfigToModelConfig(options.config);
+    const openaiMessages = await this.transformUniMessageToModelInput(
       options.messages,
       options.signal,
     );
 
     if (options.config.system_prompt) {
-      qwenMessages.unshift({
+      openaiMessages.unshift({
         role: "system",
         content: options.config.system_prompt,
       });
     }
 
     const params: ChatCompletionCreateParamsStreaming = {
-      ...qwenConfig,
-      messages: qwenMessages,
+      ...openaiConfig,
+      messages: openaiMessages,
       stream: true,
     };
 
@@ -400,7 +409,6 @@ export class Qwen3_6Client extends LLMClient {
       name?: string;
       arguments?: string;
       tool_call_id?: string;
-      data?: string;
     } = {};
     let partialUsage: {
       finish_reason?: FinishReason | null;
@@ -414,25 +422,14 @@ export class Qwen3_6Client extends LLMClient {
         event.finish_reason || partialUsage.finish_reason;
       partialUsage.usage_metadata =
         event.usage_metadata || partialUsage.usage_metadata;
-      if (event.event_type === "start") {
-        // start new partial tool call for <tool_call>
-        partialToolCall.data = "";
-      } else if (event.event_type === "delta") {
-        if (partialToolCall.data !== undefined) {
-          // update partial tool call for <tool_call>
-          partialToolCall.data +=
-            event.content_items[0]?.type === "text"
-              ? (event.content_items[0] as { text: string }).text
-              : "";
-          continue;
-        }
-
+      if (event.event_type === "delta") {
         for (const item of event.content_items) {
           if (item.type === "partial_tool_call") {
             if (!partialToolCall.name) {
               // start new partial tool call for tool call object
               partialToolCall.name = item.name;
               partialToolCall.arguments = item.arguments;
+              partialToolCall.tool_call_id = item.tool_call_id;
             } else if (item.name) {
               // finish previous partial tool call for tool call object
               yield {
@@ -443,7 +440,7 @@ export class Qwen3_6Client extends LLMClient {
                     type: "tool_call",
                     name: partialToolCall.name,
                     arguments: JSON.parse(partialToolCall.arguments || "{}"),
-                    tool_call_id: partialToolCall.name,
+                    tool_call_id: partialToolCall.tool_call_id as string,
                   },
                 ],
                 usage_metadata: null,
@@ -452,50 +449,19 @@ export class Qwen3_6Client extends LLMClient {
               // start new partial tool call for tool call object
               partialToolCall.name = item.name;
               partialToolCall.arguments = item.arguments;
+              partialToolCall.tool_call_id = item.tool_call_id;
             } else {
               // update partial tool call for tool call object
               partialToolCall.arguments =
-                partialToolCall.arguments + item.arguments;
+                (partialToolCall.arguments || "") + item.arguments;
+              partialToolCall.tool_call_id =
+                item.tool_call_id || partialToolCall.tool_call_id;
             }
           }
         }
 
         yield event;
       } else if (event.event_type === "stop") {
-        if (partialToolCall.data !== undefined) {
-          // finish partial tool call for <tool_call>
-          const toolCall = JSON.parse(partialToolCall.data.trim());
-          yield {
-            role: "assistant",
-            event_type: "delta",
-            content_items: [
-              {
-                type: "partial_tool_call",
-                name: toolCall.name,
-                arguments: JSON.stringify(toolCall.arguments, null, 0),
-                tool_call_id: toolCall.name,
-              },
-            ],
-            usage_metadata: null,
-            finish_reason: null,
-          };
-          yield {
-            role: "assistant",
-            event_type: "delta",
-            content_items: [
-              {
-                type: "tool_call",
-                name: toolCall.name,
-                arguments: toolCall.arguments,
-                tool_call_id: toolCall.name,
-              },
-            ],
-            usage_metadata: null,
-            finish_reason: null,
-          };
-          partialToolCall.data = undefined;
-        }
-
         if (partialToolCall.name) {
           // finish partial tool call for tool call object
           yield {
@@ -506,7 +472,7 @@ export class Qwen3_6Client extends LLMClient {
                 type: "tool_call",
                 name: partialToolCall.name,
                 arguments: JSON.parse(partialToolCall.arguments || "{}"),
-                tool_call_id: partialToolCall.name,
+                tool_call_id: partialToolCall.tool_call_id as string,
               },
             ],
             usage_metadata: null,

--- a/src_ts/src/openai/index.ts
+++ b/src_ts/src/openai/index.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { Qwen3_6Client } from "./client";
+export { OpenaiClient } from "./client";

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -28,6 +28,7 @@ interface Model {
   supportImageGeneration: boolean;
   supportAudioGeneration: boolean;
   supportEmbedding: boolean;
+  clientType?: string;
   provider:
     | "official"
     | "bedrock"
@@ -219,6 +220,7 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: false,
+    clientType: "openai",
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -252,6 +254,7 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: false,
+    clientType: "openai",
     provider: "siliconflow",
   });
   AVAILABLE_MODELS.push({
@@ -317,7 +320,12 @@ function createClient(model: Model): AutoLLMClient {
     baseUrl = undefined;
   }
 
-  return new AutoLLMClient({ model: model.name, apiKey, baseUrl });
+  return new AutoLLMClient({
+    model: model.name,
+    apiKey,
+    baseUrl,
+    clientType: model.clientType,
+  });
 }
 
 function checkEventIntegrity(event: UniEvent): void {
@@ -1000,6 +1008,16 @@ test("should reject unknown model", () => {
   expect(() => new AutoLLMClient({ model: "unknown-model" })).toThrow(
     "not supported",
   );
+});
+
+test("should route openai clientType to OpenaiClient", () => {
+  const client = new AutoLLMClient({
+    model: "unknown-model",
+    apiKey: "test-key",
+    clientType: "openai-compatible",
+  });
+
+  expect((client as any)._client.constructor.name).toBe("OpenaiClient");
 });
 
 test("should validate last event has usage_metadata and finish_reason", () => {

--- a/src_ts/tests/tracer.test.ts
+++ b/src_ts/tests/tracer.test.ts
@@ -333,6 +333,30 @@ describe("Tracer", () => {
     expect(html).toContain("sort=mtime");
   });
 
+  test("should filter .DS_Store from directory listings", async () => {
+    const tracer = new Tracer(tempCacheDir);
+    const model = "fake-model";
+    const history: UniMessage[] = [
+      { role: "user", content_items: [{ type: "text", text: "Test" }] },
+    ];
+    const config = {};
+
+    tracer.saveHistory(model, history, "agent/conv", config);
+    fs.writeFileSync(path.join(tempCacheDir, ".DS_Store"), "metadata");
+    fs.writeFileSync(path.join(tempCacheDir, "agent", ".DS_Store"), "metadata");
+
+    const app = tracer.createWebApp();
+    const supertest = await import("supertest");
+
+    const rootResponse = await supertest.default(app).get("/");
+    expect(rootResponse.status).toBe(200);
+    expect(rootResponse.text).not.toContain(".DS_Store");
+
+    const nestedResponse = await supertest.default(app).get("/agent");
+    expect(nestedResponse.status).toBe(200);
+    expect(nestedResponse.text).not.toContain(".DS_Store");
+  });
+
   test("should sort directory listing by mtime", async () => {
     const tracer = new Tracer(tempCacheDir);
     const model = "fake-model";


### PR DESCRIPTION
## Summary
- Add Claude 4.8 support and OpenAI Chat Completions-compatible client routing
- Update AgentHub skill docs with AutoLLMClient initialization examples
- Filter .DS_Store from tracer directory listings in Python and TypeScript

## Tests
- uvx ruff check .
- uv run pytest tests/test_client.py -k "openai_client_type"
- uv run pytest tests/test_tracer.py -k "ds_store or sort"
- npm run build
- npm run lint
- npm test -- tests/client.test.ts -t "openai clientType"
- npm test -- tests/tracer.test.ts -t "DS_Store|sort"