### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions.
 
+- [2026-05-30] Release version 0.3.2.
+
 - [2026-05-30] Support Claude 4.8 models and an OpenAI Chat Completions API-compatible client.
 
 - [2026-05-28] Add abort support and agent skills.

--- a/src_py/agenthub/claude4_6/client.py
+++ b/src_py/agenthub/claude4_6/client.py
@@ -146,7 +146,7 @@ class Claude4_6Client(LLMClient):
         if config.get("max_tokens") is not None:
             claude_config["max_tokens"] = config["max_tokens"]
         else:
-            claude_config["max_tokens"] = 32768  # Claude requires max_tokens to be specified
+            claude_config["max_tokens"] = 64000  # Claude requires max_tokens to be specified
 
         if config.get("temperature") is not None:
             claude_config["temperature"] = config["temperature"]

--- a/src_py/agenthub/claude4_8/client.py
+++ b/src_py/agenthub/claude4_8/client.py
@@ -146,10 +146,10 @@ class Claude4_8Client(LLMClient):
         if config.get("max_tokens") is not None:
             claude_config["max_tokens"] = config["max_tokens"]
         else:
-            claude_config["max_tokens"] = 32768  # Claude requires max_tokens to be specified
+            claude_config["max_tokens"] = 64000  # Claude requires max_tokens to be specified
 
         if config.get("temperature") is not None and config["temperature"] != 1.0:
-            raise ValueError("Claude 4.7 does not support setting temperature.")
+            raise ValueError("Claude 4.8 does not support setting temperature.")
 
         if config.get("thinking_level") is not None:
             claude_config.update(self._convert_thinking_level_to_thinking_config(config["thinking_level"]))

--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.3.2.dev0"
+version = "0.3.2"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.2-dev.0",
+  "version": "0.3.2",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src_ts/src/claude4_6/client.ts
+++ b/src_ts/src/claude4_6/client.ts
@@ -198,7 +198,7 @@ export class Claude4_6Client extends LLMClient {
     if (config.max_tokens !== undefined) {
       claudeConfig.max_tokens = config.max_tokens;
     } else {
-      claudeConfig.max_tokens = 32768;
+      claudeConfig.max_tokens = 64000;
     }
 
     if (config.temperature !== undefined) {

--- a/src_ts/src/claude4_8/client.ts
+++ b/src_ts/src/claude4_8/client.ts
@@ -198,11 +198,11 @@ export class Claude4_8Client extends LLMClient {
     if (config.max_tokens !== undefined) {
       claudeConfig.max_tokens = config.max_tokens;
     } else {
-      claudeConfig.max_tokens = 32768;
+      claudeConfig.max_tokens = 64000;
     }
 
     if (config.temperature !== undefined && config.temperature !== 1.0) {
-      throw new Error("Claude 4.7 does not support setting temperature.");
+      throw new Error("Claude 4.8 does not support setting temperature.");
     }
 
     if (config.thinking_level !== undefined) {


### PR DESCRIPTION
## Summary
- Set Python package version to 0.3.2
- Set TypeScript package and lockfile versions to 0.3.2
- Add the 0.3.2 release entry to the changelog

## Tests
- uvx ruff check .
- npm run build
- npm run lint
- node package version consistency check