### PR TITLE
chore: bump version to 0.3.3 dev

### DIFF
--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.3.2"
+version = "0.3.3.dev0"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.2",
+  "version": "0.3.3-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.3.2",
+      "version": "0.3.3-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.2",
+  "version": "0.3.3-dev.0",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- bump Python package version to 0.3.3.dev0
- bump TypeScript package and lockfile versions to 0.3.3-dev.0

## Tests
- make lint (src_py)
- make test (src_py)
- make lint (src_ts)
- make test (src_ts)