### PR TITLE
Allow empty OpenAI embedding inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions.
 
-- [2026-06-01] Release version 0.3.3.
-
-- [2026-06-01] Support OpenAI-compatible embedding input format.
+- [2026-06-01] Release version 0.3.3. Support OpenAI-compatible embedding input format.
 
 - [2026-05-30] Release version 0.3.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here, we record the addition and removal times of models, major functional updat
 
 - [2026-06-01] Release version 0.3.3.
 
+- [2026-06-01] Support OpenAI-compatible embedding input format.
+
 - [2026-05-30] Release version 0.3.2.
 
 - [2026-05-30] Support Claude 4.8 models and an OpenAI Chat Completions API-compatible client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions.
 
+- [2026-06-01] Release version 0.3.3.
+
 - [2026-05-30] Release version 0.3.2.
 
 - [2026-05-30] Support Claude 4.8 models and an OpenAI Chat Completions API-compatible client.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ https://github.com/user-attachments/assets/c49a21a1-5bf9-4768-a76d-f73c9a03ca87
 | -------------- | ----------------------------------- | ---------------------- | ---------------- | ------------------------------ |
 | Gemini 3-3.5   | Official/Google Vertex AI           | `gemini-3.5-flash`     | Text, Image      | Text, Image, Speech, Embedding |
 | Claude 4.6-4.8 | Official/Amazon Bedrock/UModelVerse | `claude-opus-4-8`      | Text, Image      | Text                           |
-| GPT-5.4/5.5    | Official/UModelVerse                | `gpt-5.5`              | Text, Image      | Text                           |
+| GPT-5.4/5.5    | Official/UModelVerse                | `gpt-5.5`              | Text, Image      | Text, Embedding                |
 | Kimi-K2.5/K2.6 | Official/OpenRouter/SiliconFlow     | `kimi-k2.6`            | Text, Image      | Text                           |
 | DeepSeek V4    | Official/OpenRouter/SiliconFlow     | `deepseek-v4-pro`      | Text             | Text                           |
 | GLM-5.1        | Official/OpenRouter/SiliconFlow     | `glm-5.1`              | Text             | Text                           |
-| Qwen3.6        | OpenRouter/SiliconFlow/vLLM         | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text                           |
+| Qwen3.6        | OpenRouter/SiliconFlow/vLLM         | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text, Embedding                |
 
 ## Installation
 
@@ -325,31 +325,62 @@ main().catch(console.error);
 ```
 </details>
 
-## Concepts: UniConfig, UniMessage and UniEvent
+### SiliconFlow Qwen3 Embedding 0.6B via OpenAI-compatible API
 
-### Text Embedding
-
-Generate embeddings using the same `streaming_response` API.
+<details><summary><strong>Python Example</strong></summary>
 
 ```python
-client = AutoLLMClient(model="gemini-embedding-2")
+import asyncio
+import os
+from agenthub import AutoLLMClient
 
-# Two messages → two embedding vectors; content_items within each message are aggregated
-embeddings = []
-async for event in client.streaming_response(
-    messages=[
-        {"role": "user", "content_items": [{"type": "text", "text": "Hello world"}]},
-        {"role": "user", "content_items": [{"type": "text", "text": "Goodbye "}, {"type": "text", "text": "world"}]},
-    ],
-    config={"embedding_config": {"dimensions": 768}},
-):
-    for item in event["content_items"]:
-        if item["type"] == "embedding":
-            embeddings.append(item["embedding"])
+os.environ["OPENAI_API_KEY"] = "your-siliconflow-api-key"
+os.environ["OPENAI_BASE_URL"] = "https://api.siliconflow.cn/v1"
 
-# len(embeddings) == 2
-# len(embeddings[0]) == 768
+async def main():
+    client = AutoLLMClient(model="Qwen/Qwen3-Embedding-0.6B", client_type="openai")
+
+    async for event in client.streaming_response_stateful(
+        message={
+            "role": "user",
+            "content_items": [{"type": "text", "text": "Hello world"}]
+        },
+        config={},
+    ):
+        print(event)
 ```
+</details>
+
+<details><summary><strong>TypeScript Example</strong></summary>
+
+```typescript
+import { AutoLLMClient } from "@prismshadow/agenthub";
+
+process.env.OPENAI_API_KEY = "your-siliconflow-api-key";
+process.env.OPENAI_BASE_URL = "https://api.siliconflow.cn/v1";
+
+async function main() {
+  const client = new AutoLLMClient({
+    model: "Qwen/Qwen3-Embedding-0.6B",
+    clientType: "openai",
+  });
+  for await (const event of client.streamingResponseStateful({
+    message: {
+      role: "user",
+      content_items: [{ type: "text", text: "Hello world" }],
+    },
+    config: {}
+  })) {
+    console.log(event);
+  }
+}
+
+main().catch(console.error);
+```
+</details>
+
+
+## Concepts: UniConfig, UniMessage and UniEvent
 
 ### UniConfig
 

--- a/README.md
+++ b/README.md
@@ -343,11 +343,13 @@ async def main():
     async for event in client.streaming_response_stateful(
         message={
             "role": "user",
-            "content_items": [{"type": "text", "text": "Hello world"}]
+            "content_items": [{"type": "text", "text": "Hello world"}],
         },
         config={},
     ):
         print(event)
+
+asyncio.run(main())
 ```
 </details>
 
@@ -369,7 +371,7 @@ async function main() {
       role: "user",
       content_items: [{ type: "text", text: "Hello world" }],
     },
-    config: {}
+    config: {},
   })) {
     console.log(event);
   }
@@ -378,7 +380,6 @@ async function main() {
 main().catch(console.error);
 ```
 </details>
-
 
 ## Concepts: UniConfig, UniMessage and UniEvent
 

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -25,7 +25,6 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | Gemini 3 Image | Official / Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Gemini 3 TTS | Official / Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Gemini Embedding | Official / Vertex AI | `gemini-embedding-2` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| OpenAI Embedding | Official | `text-embedding-3-small`, `text-embedding-3-large` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Claude 4.6 | Official / ModelVerse | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
@@ -34,6 +33,7 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | Claude 4.8 | Bedrock | `global.anthropic.claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| OpenAI Embedding | Official | `text-embedding-3-small`, `text-embedding-3-large` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Kimi-K2.6 | OpenRouter | `moonshotai/kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Kimi-K2.6 | SiliconFlow | `Pro/moonshotai/Kimi-K2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
@@ -54,7 +54,7 @@ Common gateway base URLs:
 For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `client_type="openai"`, and set `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```python
-client = AutoLLMClient(model="Qwen/Qwen3-Embedding-8B", client_type="openai")
+client = AutoLLMClient(model="Qwen/Qwen3-Embedding-0.6B", client_type="openai")
 ```
 
 ## Data Models
@@ -287,37 +287,6 @@ async def main():
 
 
 asyncio.run(main())
-```
-
-
-## Text Embedding
-
-Use `streaming_response` with an embedding model (e.g., `gemini-embedding-2`, `text-embedding-3-large`) to generate vector embeddings. 
-
-Each `UniMessage` in the `messages` list produces **one embedding vector**. Within a single message, all items in `content_items` are aggregated into a single embedding. Set `embedding_config.dimensions` in the config to control vector size.
-
-```python
-from agenthub import AutoLLMClient
-
-client = AutoLLMClient(model="gemini-embedding-2")
-
-embeddings = []
-async for event in client.streaming_response(
-    messages=[
-        {"role": "user", "content_items": [{"type": "text", "text": "Hello world"}]},
-        {"role": "user", "content_items": [
-            {"type": "text", "text": "Goodbye "},
-            {"type": "text", "text": "world"},
-        ]},
-    ],
-    config={"embedding_config": {"dimensions": 768}},
-):
-    for item in event["content_items"]:
-        if item["type"] == "embedding":
-            embeddings.append(item["embedding"])
-
-# len(embeddings) == 2
-# len(embeddings[0]) == 768
 ```
 
 ## Tracer

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -350,3 +350,4 @@ Agent loop rules:
 
 - Send every tool result with the exact `tool_call_id` from its originating `tool_call`. Do not invent, normalize, or reuse IDs across unrelated tool calls.
 - Preserve `thinking` and `inline_thinking` items. Do not strip `phase` or `signature` fields.
+- For embedding models, each `UniMessage` in the `messages` array produces **one embedding vector**. Within a single message, all items in `content_items` are aggregated into a single embedding. Set `embedding_config.dimensions` in the config to control vector size.

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -23,7 +23,6 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | Gemini 3 Image | Official / Vertex AI | `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Gemini 3 TTS | Official / Vertex AI | `gemini-3.1-flash-tts-preview` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
 | Gemini Embedding | Official / Vertex AI | `gemini-embedding-2` | `GEMINI_API_KEY` | `GEMINI_BASE_URL` |
-| OpenAI Embedding | Official | `text-embedding-3-small`, `text-embedding-3-large` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Claude 4.6 | Official / ModelVerse | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.6 | Bedrock | `global.anthropic.claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | Claude 4.7 | Official / ModelVerse | `claude-opus-4-7` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
@@ -32,6 +31,7 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | Claude 4.8 | Bedrock | `global.anthropic.claude-opus-4-8` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` |
 | GPT 5.4 | Official / ModelVerse | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | GPT 5.5 | Official / ModelVerse | `gpt-5.5` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
+| OpenAI Embedding | Official | `text-embedding-3-small`, `text-embedding-3-large` | `OPENAI_API_KEY` | `OPENAI_BASE_URL` |
 | Kimi-K2.6 | Official | `kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Kimi-K2.6 | OpenRouter | `moonshotai/kimi-k2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
 | Kimi-K2.6 | SiliconFlow | `Pro/moonshotai/Kimi-K2.6` | `MOONSHOT_API_KEY` | `MOONSHOT_BASE_URL` |
@@ -52,7 +52,7 @@ Common gateway base URLs:
 For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `clientType: "openai"`. These models use `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```typescript
-const client = new AutoLLMClient({ model: "Qwen/Qwen3-Embedding-8B", clientType: "openai" });
+const client = new AutoLLMClient({ model: "Qwen/Qwen3-Embedding-0.6B", clientType: "openai" });
 ```
 
 ## Data Models
@@ -290,43 +290,6 @@ async function main(): Promise<void> {
 }
 
 void main();
-```
-
-
-## Text Embedding
-
-Use `streamingResponse` with an embedding model (e.g., `gemini-embedding-2`, `text-embedding-3-large`) to generate vector embeddings. 
-
-Each `UniMessage` in the `messages` array produces **one embedding vector**. Within a single message, all items in `content_items` are aggregated into a single embedding. Set `embedding_config.dimensions` in the config to control vector size.
-
-```typescript
-import { AutoLLMClient } from "@prismshadow/agenthub";
-
-const client = new AutoLLMClient({ model: "gemini-embedding-2" });
-
-const embeddings: number[][] = [];
-for await (const event of client.streamingResponse({
-  messages: [
-    { role: "user", content_items: [{ type: "text", text: "Hello world" }] },
-    {
-      role: "user",
-      content_items: [
-        { type: "text", text: "Goodbye " },
-        { type: "text", text: "world" },
-      ],
-    },
-  ],
-  config: { embedding_config: { dimensions: 768 } },
-})) {
-  for (const item of event.content_items) {
-    if (item.type === "embedding") {
-      embeddings.push(item.embedding);
-    }
-  }
-}
-
-// len(embeddings) == 2
-// len(embeddings[0]) == 768
 ```
 
 ## Tracer

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -352,3 +352,4 @@ Keep these points in mind for agent loops:
 
 - Send every tool result with the exact `tool_call_id` from its originating `tool_call`. Do not invent, normalize, or reuse IDs across unrelated tool calls.
 - Preserve `thinking` and `inline_thinking` items. Do not strip `phase` or `signature` fields.
+- For embedding models, each `UniMessage` in the `messages` array produces **one embedding vector**. Within a single message, all items in `content_items` are aggregated into a single embedding. Set `embedding_config.dimensions` in the config to control vector size.

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -296,7 +296,7 @@ class OpenaiClient(LLMClient):
             for item in msg["content_items"]:
                 if item["type"] == "text":
                     msg_text += item["text"]
-            texts.append(msg_text)
+            texts.append(msg_text if msg_text else " ")
 
         embedding_config = config.get("embedding_config") or {}
 

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -296,7 +296,7 @@ class OpenaiClient(LLMClient):
             for item in msg["content_items"]:
                 if item["type"] == "text":
                     msg_text += item["text"]
-            texts.append(msg_text if msg_text else " ")
+            texts.append(msg_text or " ")
 
         embedding_config = config.get("embedding_config") or {}
 

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -296,11 +296,7 @@ class OpenaiClient(LLMClient):
             for item in msg["content_items"]:
                 if item["type"] == "text":
                     msg_text += item["text"]
-            if msg_text:
-                texts.append(msg_text)
-
-        if not texts:
-            raise ValueError("No text content found for embedding.")
+            texts.append(msg_text)
 
         embedding_config = config.get("embedding_config") or {}
 

--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.3.3.dev0"
+version = "0.3.3"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -136,6 +136,17 @@ RUN_SLOW_TEST = os.getenv("RUN_SLOW_TEST", "0") == "1"
 if os.getenv("OPENROUTER_API_KEY") and RUN_SLOW_TEST:
     AVAILABLE_MODELS.append(Model(name="z-ai/glm-5.1", provider="openrouter", support_image_understanding=False))
     AVAILABLE_MODELS.append(Model(name="qwen/qwen3.6-35b-a3b", provider="openrouter", client_type="openai"))
+    AVAILABLE_MODELS.append(
+        Model(
+            name="qwen/qwen3-embedding-4b",
+            support_text=False,
+            support_temperature=False,
+            support_image_understanding=False,
+            support_embedding=True,
+            provider="openrouter",
+            client_type="openai",
+        )
+    )
     AVAILABLE_MODELS.append(Model(name="moonshotai/kimi-k2.6", provider="openrouter", support_temperature=False))
 
 if os.getenv("SILICONFLOW_API_KEY") and RUN_SLOW_TEST:

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.3-dev.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.3.3-dev.0",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.3-dev.0",
+  "version": "0.3.3",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -382,7 +382,7 @@ export class OpenaiClient extends LLMClient {
           msgText += item.text;
         }
       }
-      texts.push(msgText ? msgText : " ");
+      texts.push(msgText || " ");
     }
 
     const dimensions = options.config.embedding_config?.dimensions;

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -382,13 +382,7 @@ export class OpenaiClient extends LLMClient {
           msgText += item.text;
         }
       }
-      if (msgText) {
-        texts.push(msgText);
-      }
-    }
-
-    if (texts.length === 0) {
-      throw new Error("No text content found for embedding.");
+      texts.push(msgText);
     }
 
     const dimensions = options.config.embedding_config?.dimensions;

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -382,7 +382,7 @@ export class OpenaiClient extends LLMClient {
           msgText += item.text;
         }
       }
-      texts.push(msgText);
+      texts.push(msgText ? msgText : " ");
     }
 
     const dimensions = options.config.embedding_config?.dimensions;

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -236,6 +236,17 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
+    name: "qwen/qwen3-embedding-4b",
+    supportTextGeneration: false,
+    supportTemperature: false,
+    supportImageUnderstanding: false,
+    supportImageGeneration: false,
+    supportAudioGeneration: false,
+    supportEmbedding: true,
+    clientType: "openai",
+    provider: "openrouter",
+  });
+  AVAILABLE_MODELS.push({
     name: "moonshotai/kimi-k2.6",
     supportTextGeneration: true,
     supportTemperature: false,


### PR DESCRIPTION
## Summary
- allow OpenAI embedding requests to preserve one input per `UniMessage`, including empty aggregated text
- document embedding aggregation behavior in Python and TypeScript skills
- bump Python and TypeScript package versions to 0.3.3

## Tests
- `make lint` in `src_py/`
- `npm run lint` in `src_ts/`
- `npm run build` in `src_ts/`
- `make test` in `src_py/`
- `make test` in `src_ts/`
