### PR TITLE
Split OpenAI embedding client

### DIFF
--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -51,7 +51,7 @@ Common gateway base URLs:
 - ModelVerse: `https://api.modelverse.cn/v1` (`https://api.modelverse.cn/` for Claude)
 - vLLM: `http://127.0.0.1:8000/v1/`
 
-For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `client_type="openai"`, and set `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
+For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `client_type="openai"` (`client_type="openai-embedding"` for embedding endpoints), and set `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```python
 client = AutoLLMClient(model="Qwen/Qwen3-Embedding-0.6B", client_type="openai")

--- a/skills/agenthub-python/SKILL.md
+++ b/skills/agenthub-python/SKILL.md
@@ -54,7 +54,7 @@ Common gateway base URLs:
 For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `client_type="openai"` (`client_type="openai-embedding"` for embedding endpoints), and set `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```python
-client = AutoLLMClient(model="Qwen/Qwen3-Embedding-0.6B", client_type="openai")
+client = AutoLLMClient(model="Qwen/Qwen3-Embedding-0.6B", client_type="openai-embedding")
 ```
 
 ## Data Models

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -49,7 +49,7 @@ Common gateway base URLs:
 - ModelVerse: `https://api.modelverse.cn/v1` (`https://api.modelverse.cn/` for Claude)
 - vLLM: `http://127.0.0.1:8000/v1/`
 
-For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `clientType: "openai"`. These models use `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
+For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `clientType: "openai"` (`clientType: "openai-embedding"` for embedding endpoints). These models use `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```typescript
 const client = new AutoLLMClient({ model: "Qwen/Qwen3-Embedding-0.6B", clientType: "openai" });

--- a/skills/agenthub-typescript/SKILL.md
+++ b/skills/agenthub-typescript/SKILL.md
@@ -52,7 +52,7 @@ Common gateway base URLs:
 For models accessed through OpenAI-compatible APIs (e.g., Qwen series models via SiliconFlow or OpenRouter), pass `clientType: "openai"` (`clientType: "openai-embedding"` for embedding endpoints). These models use `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
 
 ```typescript
-const client = new AutoLLMClient({ model: "Qwen/Qwen3-Embedding-0.6B", clientType: "openai" });
+const client = new AutoLLMClient({ model: "Qwen/Qwen3-Embedding-0.6B", clientType: "openai-embedding" });
 ```
 
 ## Data Models

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -77,6 +77,10 @@ class AutoLLMClient(LLMClient):
             from .deepseek_v4 import DeepSeekV4Client
 
             return DeepSeekV4Client(model=model, api_key=api_key, base_url=base_url)
+        elif "openai" in client_type and "embedding" in client_type:
+            from .openai_embedding import OpenaiEmbeddingClient
+
+            return OpenaiEmbeddingClient(model=model, api_key=api_key, base_url=base_url)
         elif "openai" in client_type:
             from .openai import OpenaiClient
 
@@ -84,7 +88,7 @@ class AutoLLMClient(LLMClient):
         else:
             raise ValueError(
                 f"{client_type} is not supported. "
-                "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai."
+                "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai-embedding, openai."
             )
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> Any:

--- a/src_py/agenthub/openai/client.py
+++ b/src_py/agenthub/openai/client.py
@@ -284,52 +284,12 @@ class OpenaiClient(LLMClient):
             "finish_reason": finish_reason,
         }
 
-    async def _embed_messages_internal(
-        self,
-        messages: list[UniMessage],
-        config: UniConfig,
-    ) -> AsyncIterator[UniEvent]:
-        """Embed text messages and return embeddings."""
-        texts = []
-        for msg in messages:
-            msg_text = ""
-            for item in msg["content_items"]:
-                if item["type"] == "text":
-                    msg_text += item["text"]
-            texts.append(msg_text or " ")
-
-        embedding_config = config.get("embedding_config") or {}
-
-        params: dict[str, Any] = {"model": self._model, "input": texts}
-        if embedding_config.get("dimensions") is not None:
-            params["dimensions"] = embedding_config.get("dimensions")
-
-        result = await self._client.embeddings.create(**params)
-
-        yield {
-            "role": "assistant",
-            "event_type": "stop",
-            "content_items": [{"type": "embedding", "embedding": item.embedding} for item in result.data],
-            "usage_metadata": {
-                "cached_tokens": None,
-                "prompt_tokens": result.usage.prompt_tokens if getattr(result, "usage", None) else None,
-                "thoughts_tokens": None,
-                "response_tokens": None,
-            },
-            "finish_reason": "stop",
-        }
-
     async def _streaming_response_internal(
         self,
         messages: list[UniMessage],
         config: UniConfig,
     ) -> AsyncIterator[UniEvent]:
         """Stream generate using OpenAI Chat Completions-compatible API."""
-        if "embedding" in self._model.lower():
-            async for event in self._embed_messages_internal(messages, config):
-                yield event
-            return
-
         openai_config = self.transform_uni_config_to_model_config(config)
 
         openai_messages = await self.transform_uni_message_to_model_input(messages)

--- a/src_py/agenthub/openai_embedding/__init__.py
+++ b/src_py/agenthub/openai_embedding/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .client import OpenaiEmbeddingClient
+
+
+__all__ = ["OpenaiEmbeddingClient"]

--- a/src_py/agenthub/openai_embedding/client.py
+++ b/src_py/agenthub/openai_embedding/client.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Any, AsyncIterator
+
+from openai import AsyncOpenAI
+
+from ..base_client import LLMClient
+from ..types import UniConfig, UniEvent, UniMessage
+
+
+class OpenaiEmbeddingClient(LLMClient):
+    """OpenAI Embeddings-compatible client implementation."""
+
+    def __init__(self, model: str, api_key: str | None = None, base_url: str | None = None):
+        """Initialize OpenAI-compatible embedding client with model, API key, and base URL."""
+        self._model = model
+        api_key = api_key or os.getenv("OPENAI_API_KEY")
+        base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self._history: list[UniMessage] = []
+
+    def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
+        """Transform universal configuration to OpenAI Embeddings configuration."""
+        params: dict[str, Any] = {"model": self._model}
+        embedding_config = config.get("embedding_config") or {}
+        if embedding_config.get("dimensions") is not None:
+            params["dimensions"] = embedding_config["dimensions"]
+        return params
+
+    def transform_uni_message_to_model_input(self, messages: list[UniMessage]) -> list[str]:
+        """Transform universal messages to OpenAI Embeddings input strings."""
+        texts = []
+        for msg in messages:
+            msg_text = ""
+            for item in msg["content_items"]:
+                if item["type"] != "text":
+                    raise ValueError("OpenAI embeddings only support text content items.")
+                msg_text += item["text"]
+            texts.append(msg_text or " ")
+        return texts
+
+    def transform_model_output_to_uni_event(self, model_output: Any) -> UniEvent:
+        """Transform OpenAI Embeddings response to universal event format."""
+        usage = getattr(model_output, "usage", None)
+        return {
+            "role": "assistant",
+            "event_type": "stop",
+            "content_items": [{"type": "embedding", "embedding": item.embedding} for item in model_output.data],
+            "usage_metadata": {
+                "cached_tokens": None,
+                "prompt_tokens": usage.prompt_tokens if usage else None,
+                "thoughts_tokens": None,
+                "response_tokens": None,
+            },
+            "finish_reason": "stop",
+        }
+
+    async def _streaming_response_internal(
+        self,
+        messages: list[UniMessage],
+        config: UniConfig,
+    ) -> AsyncIterator[UniEvent]:
+        """Generate embeddings using OpenAI Embeddings-compatible API."""
+        params = self.transform_uni_config_to_model_config(config)
+        params["input"] = self.transform_uni_message_to_model_input(messages)
+        result = await self._client.embeddings.create(**params)
+        yield self.transform_model_output_to_uni_event(result)

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -90,7 +90,7 @@ if os.getenv("OPENAI_API_KEY"):
             support_temperature=False,
             support_image_understanding=False,
             support_embedding=True,
-            client_type="openai",
+            client_type="openai-embedding",
         )
     )
 
@@ -144,7 +144,7 @@ if os.getenv("OPENROUTER_API_KEY") and RUN_SLOW_TEST:
             support_image_understanding=False,
             support_embedding=True,
             provider="openrouter",
-            client_type="openai",
+            client_type="openai-embedding",
         )
     )
     AVAILABLE_MODELS.append(Model(name="moonshotai/kimi-k2.6", provider="openrouter", support_temperature=False))
@@ -163,7 +163,7 @@ if os.getenv("SILICONFLOW_API_KEY") and RUN_SLOW_TEST:
             support_image_understanding=False,
             support_embedding=True,
             provider="siliconflow",
-            client_type="openai",
+            client_type="openai-embedding",
         )
     )
 
@@ -397,11 +397,18 @@ async def test_unknown_model():
 
 
 @pytest.mark.asyncio
-async def test_openai_client_type_routes_to_openai_client():
+@pytest.mark.parametrize(
+    ("client_type", "client_name"),
+    [
+        ("openai-compatible", "OpenaiClient"),
+        ("openai-embedding-compatible", "OpenaiEmbeddingClient"),
+    ],
+)
+async def test_openai_client_type_routes(client_type: str, client_name: str):
     """Test client_type override for OpenAI-compatible models."""
-    client = AutoLLMClient(model="unknown-model", api_key="test-key", client_type="openai-compatible")
+    client = AutoLLMClient(model="unknown-model", api_key="test-key", client_type=client_type)
 
-    assert client._client.__class__.__name__ == "OpenaiClient"
+    assert client._client.__class__.__name__ == client_name
 
 
 @pytest.mark.asyncio

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -20,6 +20,7 @@ import { GPT5_5Client } from "./gpt5_5";
 import { GLM5_1Client } from "./glm5_1";
 import { KimiK2_6Client } from "./kimi_k2_6";
 import { OpenaiClient } from "./openai";
+import { OpenaiEmbeddingClient } from "./openai_embedding";
 import { DeepSeekV4Client } from "./deepseek_v4";
 import { UniConfig, UniEvent, UniMessage } from "./types";
 
@@ -100,12 +101,17 @@ export class AutoLLMClient extends LLMClient {
       return new KimiK2_6Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("deepseek-v4")) {
       return new DeepSeekV4Client({ model, apiKey, baseUrl });
+    } else if (
+      clientType.includes("openai") &&
+      clientType.includes("embedding")
+    ) {
+      return new OpenaiEmbeddingClient({ model, apiKey, baseUrl });
     } else if (clientType.includes("openai")) {
       return new OpenaiClient({ model, apiKey, baseUrl });
     } else {
       throw new Error(
         `${clientType} is not supported. ` +
-          "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai.",
+          "Supported client types: gemini-3, claude-4-8, claude-4-7, claude-4-6, gpt-5.5, gpt-5.4, glm-5.1, kimi-k2.6, kimi-k2.5, deepseek-v4, openai-embedding, openai.",
       );
     }
   }

--- a/src_ts/src/openai/client.ts
+++ b/src_ts/src/openai/client.ts
@@ -367,56 +367,6 @@ export class OpenaiClient extends LLMClient {
   }
 
   /**
-   * Embed text messages and return embeddings.
-   */
-  private async *_embedMessagesInternal(options: {
-    messages: UniMessage[];
-    config: UniConfig;
-    signal?: AbortSignal;
-  }): AsyncGenerator<UniEvent> {
-    const texts: string[] = [];
-    for (const msg of options.messages) {
-      let msgText = "";
-      for (const item of msg.content_items) {
-        if (item.type === "text") {
-          msgText += item.text;
-        }
-      }
-      texts.push(msgText || " ");
-    }
-
-    const dimensions = options.config.embedding_config?.dimensions;
-
-    const params: OpenAI.EmbeddingCreateParams = {
-      model: this._model as OpenAI.EmbeddingModel,
-      input: texts,
-    };
-    if (dimensions !== undefined) {
-      params.dimensions = dimensions;
-    }
-
-    const result = await this._client.embeddings.create(params, {
-      signal: options.signal,
-    });
-
-    yield {
-      role: "assistant",
-      event_type: "stop",
-      content_items: result.data.map((item) => ({
-        type: "embedding" as const,
-        embedding: item.embedding,
-      })),
-      usage_metadata: {
-        cached_tokens: null,
-        prompt_tokens: result.usage?.prompt_tokens ?? null,
-        thoughts_tokens: null,
-        response_tokens: null,
-      },
-      finish_reason: "stop",
-    };
-  }
-
-  /**
    * Stream generate using OpenAI Chat Completions-compatible API.
    */
   async *_streamingResponseInternal(options: {
@@ -424,13 +374,6 @@ export class OpenaiClient extends LLMClient {
     config: UniConfig;
     signal?: AbortSignal;
   }): AsyncGenerator<UniEvent> {
-    if (this._model.toLowerCase().includes("embedding")) {
-      for await (const event of this._embedMessagesInternal(options)) {
-        yield event;
-      }
-      return;
-    }
-
     const openaiConfig = this.transformUniConfigToModelConfig(options.config);
     const openaiMessages = await this.transformUniMessageToModelInput(
       options.messages,

--- a/src_ts/src/openai_embedding/client.ts
+++ b/src_ts/src/openai_embedding/client.ts
@@ -1,0 +1,120 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import OpenAI from "openai";
+import type {
+  CreateEmbeddingResponse,
+  EmbeddingCreateParams,
+} from "openai/resources/embeddings";
+import { LLMClient } from "../baseClient";
+import { UniConfig, UniEvent, UniMessage } from "../types";
+
+/**
+ * OpenAI Embeddings-compatible client implementation.
+ */
+export class OpenaiEmbeddingClient extends LLMClient {
+  protected _model: string;
+  private _client: OpenAI;
+
+  /**
+   * Initialize OpenAI-compatible embedding client with model, API key, and base URL.
+   */
+  constructor(options: {
+    model: string;
+    apiKey?: string;
+    baseUrl?: string | null;
+    clientType?: string | null;
+  }) {
+    super();
+    this._model = options.model;
+    const key = options.apiKey || process.env.OPENAI_API_KEY || undefined;
+    const url = options.baseUrl || process.env.OPENAI_BASE_URL || undefined;
+    this._client = new OpenAI({ apiKey: key, baseURL: url });
+  }
+
+  /**
+   * Transform universal configuration to OpenAI Embeddings configuration.
+   */
+  transformUniConfigToModelConfig(
+    config: UniConfig,
+  ): Omit<EmbeddingCreateParams, "input"> {
+    const params: Omit<EmbeddingCreateParams, "input"> = {
+      model: this._model as OpenAI.EmbeddingModel,
+    };
+    const dimensions = config.embedding_config?.dimensions;
+    if (dimensions !== undefined) {
+      params.dimensions = dimensions;
+    }
+    return params;
+  }
+
+  /**
+   * Transform universal messages to OpenAI Embeddings input strings.
+   */
+  transformUniMessageToModelInput(messages: UniMessage[]): string[] {
+    const texts: string[] = [];
+    for (const msg of messages) {
+      let msgText = "";
+      for (const item of msg.content_items) {
+        if (item.type !== "text") {
+          throw new Error("OpenAI embeddings only support text content items.");
+        }
+        msgText += item.text;
+      }
+      texts.push(msgText || " ");
+    }
+    return texts;
+  }
+
+  /**
+   * Transform OpenAI Embeddings response to universal event format.
+   */
+  transformModelOutputToUniEvent(
+    modelOutput: CreateEmbeddingResponse,
+  ): UniEvent {
+    return {
+      role: "assistant",
+      event_type: "stop",
+      content_items: modelOutput.data.map((item) => ({
+        type: "embedding" as const,
+        embedding: item.embedding,
+      })),
+      usage_metadata: {
+        cached_tokens: null,
+        prompt_tokens: modelOutput.usage?.prompt_tokens ?? null,
+        thoughts_tokens: null,
+        response_tokens: null,
+      },
+      finish_reason: "stop",
+    };
+  }
+
+  /**
+   * Generate embeddings using OpenAI Embeddings-compatible API.
+   */
+  async *_streamingResponseInternal(options: {
+    messages: UniMessage[];
+    config: UniConfig;
+    signal?: AbortSignal;
+  }): AsyncGenerator<UniEvent> {
+    const params: EmbeddingCreateParams = {
+      ...this.transformUniConfigToModelConfig(options.config),
+      input: this.transformUniMessageToModelInput(options.messages),
+    };
+    const result = await this._client.embeddings.create(params, {
+      signal: options.signal,
+    });
+    yield this.transformModelOutputToUniEvent(result);
+  }
+}

--- a/src_ts/src/openai_embedding/index.ts
+++ b/src_ts/src/openai_embedding/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { OpenaiEmbeddingClient } from "./client";

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -119,7 +119,7 @@ if (process.env.OPENAI_API_KEY) {
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: true,
-    clientType: "openai",
+    clientType: "openai-embedding",
     provider: "official",
   });
 }
@@ -243,7 +243,7 @@ if (process.env.OPENROUTER_API_KEY && RUN_SLOW_TEST) {
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: true,
-    clientType: "openai",
+    clientType: "openai-embedding",
     provider: "openrouter",
   });
   AVAILABLE_MODELS.push({
@@ -298,7 +298,7 @@ if (process.env.SILICONFLOW_API_KEY && RUN_SLOW_TEST) {
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: true,
-    clientType: "openai",
+    clientType: "openai-embedding",
     provider: "siliconflow",
   });
 }
@@ -1008,8 +1008,17 @@ if (AVAILABLE_MODELS.length > 0) {
 
       const client = createClient(model);
       const messages = [
-        { role: "user" as const, content_items: [{ type: "text" as const, text: "Hello world" }] },
-        { role: "user" as const, content_items: [{ type: "text" as const, text: "Goodbye " }, { type: "text" as const, text: "world" }] },
+        {
+          role: "user" as const,
+          content_items: [{ type: "text" as const, text: "Hello world" }],
+        },
+        {
+          role: "user" as const,
+          content_items: [
+            { type: "text" as const, text: "Goodbye " },
+            { type: "text" as const, text: "world" },
+          ],
+        },
       ];
 
       const events: UniEvent[] = [];
@@ -1039,14 +1048,35 @@ test("should reject unknown model", () => {
   );
 });
 
-test("should route openai clientType to OpenaiClient", () => {
+test.each([
+  ["openai-compatible", "OpenaiClient"],
+  ["openai-embedding-compatible", "OpenaiEmbeddingClient"],
+])("should route %s clientType to %s", (clientType, clientName) => {
   const client = new AutoLLMClient({
     model: "unknown-model",
     apiKey: "test-key",
-    clientType: "openai-compatible",
+    clientType,
   });
 
-  expect((client as any)._client.constructor.name).toBe("OpenaiClient");
+  expect((client as any)._client.constructor.name).toBe(clientName);
+});
+
+test("should reject non-text content items for OpenAI embeddings", () => {
+  const client = new AutoLLMClient({
+    model: "unknown-model",
+    apiKey: "test-key",
+    clientType: "openai-embedding",
+  });
+  const messages: UniMessage[] = [
+    {
+      role: "user",
+      content_items: [{ type: "image_url", image_url: IMAGE }],
+    },
+  ];
+
+  expect(() => client.transformUniMessageToModelInput(messages)).toThrow(
+    "only support text",
+  );
 });
 
 test("should validate last event has usage_metadata and finish_reason", () => {


### PR DESCRIPTION
## Summary
- split OpenAI embeddings into dedicated Python and TypeScript clients
- route OpenAI embedding client types separately from OpenAI chat clients
- update AgentHub skills and route coverage for OpenAI embedding clients

## Validation
- make lint in src_py
- make lint in src_ts
- uv run pytest -vvv tests/test_client.py -k "openai_client_type_routes"
- npm run test -- --runTestsByPath tests/client.test.ts -t "route openai|reject non-text"