### PR TITLE
Update package metadata links

### DIFF
--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -11,6 +11,11 @@ authors = [
   {name = "PrismShadow"},
 ]
 
+[project.urls]
+Homepage = "https://github.com/Prism-Shadow/agenthub"
+Repository = "https://github.com/Prism-Shadow/agenthub"
+Issues = "https://github.com/Prism-Shadow/agenthub/issues"
+
 [project.optional-dependencies]
 dev = ["httpx[socks]", "pytest>=8.4.2", "pytest-asyncio>=0.23.0", "ruff>=0.14.3", "pillow>=10.0.0"]
 

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Prism-Shadow/AgentHub.git"
+    "url": "git+https://github.com/Prism-Shadow/agenthub.git"
   },
   "keywords": [
     "agent",
@@ -60,7 +60,7 @@
   "author": "PrismShadow",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Prism-Shadow/AgentHub/issues"
+    "url": "https://github.com/Prism-Shadow/agenthub/issues"
   },
-  "homepage": "https://github.com/Prism-Shadow/AgentHub#readme"
+  "homepage": "https://github.com/Prism-Shadow/agenthub#readme"
 }


### PR DESCRIPTION
## Summary
- add Python package project URLs for the repository
- update TypeScript package repository, bugs, and homepage links to Prism-Shadow/agenthub

## Verification
- python3 -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("src_py/pyproject.toml").read_text()); print("pyproject OK")'
- node -e 'JSON.parse(require("fs").readFileSync("src_ts/package.json", "utf8")); console.log("package.json OK")'