### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions. Each entry keeps one brief line; the full details of a change live in a file under [changelog/](changelog/).
 
-- [2026-07-20] Content items now carry an opaque `fidelity` payload that absorbs the former `signature`/`phase` fields (breaking), and OpenAI-compatible clients use it to replay thinking through exactly the reasoning field the upstream produced instead of always sending both spellings. ([details](changelog/2026-07-20-reasoning-field-fidelity.md))
+- [2026-07-20] Release version 0.4.0. Content items now carry an opaque `fidelity` payload that absorbs the former `signature`/`phase` fields (breaking), and OpenAI-compatible clients use it to replay thinking through exactly the reasoning field the upstream produced. ([details](changelog/2026-07-20-reasoning-field-fidelity.md))
 
 - [2026-07-17] Add the `agenthub-dev` skill that fixes the model-support development workflow, and the `changelog/` details directory. ([details](changelog/2026-07-17-agenthub-dev-skill.md))
 

--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.3.3"
+version = "0.4.0"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump the version to 0.4.0 and turn the top changelog entry into the release line.

0.4.0 ships the `fidelity` content-item payload that replaces the per-item `signature`/`phase` fields (breaking — histories recorded by 0.3.x need those fields moved under `fidelity` to replay, see [the details file](changelog/2026-07-20-reasoning-field-fidelity.md)), and OpenAI-compatible clients now replay thinking through exactly the reasoning field the upstream produced. The minor bump follows from the breaking data-model change.

- `src_py/pyproject.toml`: 0.3.3 → 0.4.0
- `src_ts/package.json` / `package-lock.json`: 0.3.3 → 0.4.0
- `CHANGELOG.md`: release line for 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8bNMvyPJ7muyDs4Fh9ZLF