### PR TITLE
Clamp Gemini thinking levels to each model's supported set

### DIFF
--- a/changelog/0.4.2/2026-07-24-gemini-thinking-level-clamp.md
+++ b/changelog/0.4.2/2026-07-24-gemini-thinking-level-clamp.md
@@ -5,7 +5,10 @@
 - `gemini3/` clients (Python and TypeScript) no longer forward a thinking level the
   target model rejects. `_convert_thinking_level` now clamps the mapped Gemini level to
   the closest level the model supports, rounding up on ties, instead of letting the API
-  fail with `400 Thinking level MINIMAL is not supported for this model`.
+  fail with `400 Thinking level MINIMAL is not supported for this model`. This brings
+  `gemini3` into compliance with the design rule documented on
+  `UnsupportedParameterError` ("Thinking levels never raise this by design"); it was the
+  one client violating it.
 - Per-model support matrix (from the refreshed official thinking doc, verified live on
   2026-07-24 against the Gemini API):
   - `gemini-3.1-pro*`: `low`, `medium`, `high` — so NONE now degrades to `low` (it
@@ -14,9 +17,23 @@
     this model — kept for Vertex) — NONE degrades to `low`, MEDIUM rounds up to `high`.
   - `*-image` models (`gemini-3.1-flash-image`, `gemini-3-pro-image`, and their
     `-preview`/`-lite` variants): `minimal`, `high` only — LOW degrades to `minimal`,
-    MEDIUM rounds up to `high`.
+    MEDIUM rounds up to `high`. The `-image` check runs first, so `gemini-3-pro-image`
+    gets the image set, not the `gemini-3-pro` one.
+  - Any other `*-pro*` model (a generic branch, so future pro generations don't silently
+    regress to the four-level default): `low`, `medium`, `high`.
+  - `gemini-2.5*`: the vendor table claims `low`/`medium`/`high`, but the live API
+    rejects **every** `thinking_level` value for the 2.5 series ("Thinking level is not
+    supported for this model") — the capture outranks the docs, so the parameter is
+    dropped entirely and the model keeps its default dynamic thinking. Reachable only
+    via an explicit `client_type="gemini-3"` override or direct `Gemini3Client`
+    construction; name-based routing never sends 2.5 models here.
   - Flash text models keep the full `minimal`/`low`/`medium`/`high` set and are
     unchanged (NONE still maps to `minimal`).
+- Degradation is silent by design: the alternative to clamping is a hard 400, and the
+  repo-wide rule is that thinking levels never raise. Two clamps round *up*
+  (MEDIUM → `high` on `gemini-3-pro` and on image models) and NONE → `low` on
+  3.1-pro bills thinking a caller asked to avoid — accepted cost, recorded here since
+  the client has no logging infrastructure to surface it at runtime.
 - The `gemini3_6/` clients are untouched: both routed models (`gemini-3.6-flash`,
   `gemini-3.5-flash-lite`) accept all four levels.
 
@@ -26,6 +43,9 @@
   for this model. Please retry with other thinking level."; `low` and `medium` succeed.
 - `gemini-3.1-flash-image` + `low`/`medium` → the same 400, confirming the
   minimal/high-only image matrix.
+- `gemini-2.5-pro`/`gemini-2.5-flash`/`gemini-2.5-flash-lite` + any level (including
+  the officially-listed `low`) → 400 "Thinking level is not supported for this model.",
+  contradicting the vendor table's 2.5 rows.
 - `gemini-3-pro-preview` is no longer served on the official endpoint ("no longer
   available" for every request), so its `low`/`high` matrix comes from the docs table.
 - `gemini-3.1-flash-lite` (absent from the docs table) accepts `minimal`.
@@ -35,10 +55,22 @@
 
 - `llmsdk_docs/gemini3/docs/thinking.md`: replaced the outdated three-column
   supported/not-supported table with the live page's per-model table (adds
-  gemini-3.6/3.5 rows and the `gemini-3-pro-preview` low/high row).
+  gemini-3.6/3.5 rows, the `gemini-3-pro-preview` low/high row, and the 2.5 rows —
+  which the capture above shows are not actually honored by the API).
 
 ## Tests
 
-- New offline regression tests pin the clamp matrix in both languages:
+- Offline regression tests pin the clamp matrix in both languages (18 mirrored cases
+  plus two config-level assertions that the clamped/dropped value is what
+  `transform_uni_config_to_model_config` actually emits):
   `src_py/tests/test_thinking_level_mapping.py`,
   `src_ts/tests/thinking-level-mapping.test.ts`.
+
+## Drive-by fixes in the same PR
+
+- `src_py/README.md` code blocks reformatted for ruff 0.16: the Makefile lints with
+  unpinned `uvx ruff`, and 0.16.0 started format-checking markdown code blocks, which
+  broke `make lint` (and CI) on every branch. Formatting-only.
+- The flaky system-prompt e2e ("kitten … meow") prompt hardened in both languages: the
+  old prompt only implied the word and models roleplayed around it
+  (`deepseek-v4-flash`, `gemini-3.6-flash:vertex` flaked in consecutive CI runs).

--- a/changelog/0.4.2/2026-07-24-gemini-thinking-level-clamp.md
+++ b/changelog/0.4.2/2026-07-24-gemini-thinking-level-clamp.md
@@ -1,0 +1,44 @@
+# Gemini 3 clients clamp thinking levels to what each model supports
+
+## What changed
+
+- `gemini3/` clients (Python and TypeScript) no longer forward a thinking level the
+  target model rejects. `_convert_thinking_level` now clamps the mapped Gemini level to
+  the closest level the model supports, rounding up on ties, instead of letting the API
+  fail with `400 Thinking level MINIMAL is not supported for this model`.
+- Per-model support matrix (from the refreshed official thinking doc, verified live on
+  2026-07-24 against the Gemini API):
+  - `gemini-3.1-pro*`: `low`, `medium`, `high` — so NONE now degrades to `low` (it
+    previously mapped to `minimal` and always errored).
+  - `gemini-3-pro*`: `low`, `high` (per docs; the official endpoint has decommissioned
+    this model — kept for Vertex) — NONE degrades to `low`, MEDIUM rounds up to `high`.
+  - `*-image` models (`gemini-3.1-flash-image`, `gemini-3-pro-image`, and their
+    `-preview`/`-lite` variants): `minimal`, `high` only — LOW degrades to `minimal`,
+    MEDIUM rounds up to `high`.
+  - Flash text models keep the full `minimal`/`low`/`medium`/`high` set and are
+    unchanged (NONE still maps to `minimal`).
+- The `gemini3_6/` clients are untouched: both routed models (`gemini-3.6-flash`,
+  `gemini-3.5-flash-lite`) accept all four levels.
+
+## Capture findings
+
+- `gemini-3.1-pro-preview` + `minimal` → 400 "Thinking level MINIMAL is not supported
+  for this model. Please retry with other thinking level."; `low` and `medium` succeed.
+- `gemini-3.1-flash-image` + `low`/`medium` → the same 400, confirming the
+  minimal/high-only image matrix.
+- `gemini-3-pro-preview` is no longer served on the official endpoint ("no longer
+  available" for every request), so its `low`/`high` matrix comes from the docs table.
+- `gemini-3.1-flash-lite` (absent from the docs table) accepts `minimal`.
+- Raw probes: `api_captures/gemini3/thinking_levels.probe.jsonl`.
+
+## Docs
+
+- `llmsdk_docs/gemini3/docs/thinking.md`: replaced the outdated three-column
+  supported/not-supported table with the live page's per-model table (adds
+  gemini-3.6/3.5 rows and the `gemini-3-pro-preview` low/high row).
+
+## Tests
+
+- New offline regression tests pin the clamp matrix in both languages:
+  `src_py/tests/test_thinking_level_mapping.py`,
+  `src_ts/tests/thinking-level-mapping.test.ts`.

--- a/changelog/0.4.2/README.md
+++ b/changelog/0.4.2/README.md
@@ -1,0 +1,3 @@
+# 0.4.2 (unreleased)
+
+- [2026-07-24] Gemini 3 clients clamp thinking levels to what each model actually supports — fixes `gemini-3.1-pro` rejecting `ThinkingLevel.NONE` with "Thinking level MINIMAL is not supported". ([details](2026-07-24-gemini-thinking-level-clamp.md))

--- a/llmsdk_docs/gemini3/docs/thinking.md
+++ b/llmsdk_docs/gemini3/docs/thinking.md
@@ -361,24 +361,28 @@ incremental summaries during generation:
 ## Controlling thinking
 
 Gemini models engage in dynamic thinking by default, automatically adjusting the
-amount of reasoning effort based on the complexity of the user's request.
-However, if you have specific latency constraints or require the model to engage
-in deeper reasoning than usual, you can optionally use parameters to control
-thinking behavior.
+amount of reasoning effort based on the complexity of the request. You can
+control this behavior using the `thinking_level` parameter.
 
 ### Thinking levels (Gemini 3)
 
 The `thinkingLevel` parameter, recommended for Gemini 3 models and onwards,
 lets you control reasoning behavior.
 
-The following table details the `thinkingLevel` settings for each model type:
+The following table details the `thinkingLevel` support for each model:
 
-| Thinking Level | Gemini 3.1 Pro | Gemini 3.1 Flash-Lite | Gemini 3 Flash | Description |
-|---|---|---|---|---|
-| **`minimal`** | Not supported | Supported (Default) | Supported | Matches the "no thinking" setting for most queries. The model may think very minimally for complex coding tasks. Minimizes latency for chat or high throughput applications. Note, `minimal` does not guarantee that thinking is off. |
-| **`low`** | Supported | Supported | Supported | Minimizes latency and cost. Best for simple instruction following, chat, or high-throughput applications. |
-| **`medium`** | Supported | Supported | Supported | Balanced thinking for most tasks. |
-| **`high`** | Supported (Default, Dynamic) | Supported (Dynamic) | Supported (Default, Dynamic) | Maximizes reasoning depth. The model may take significantly longer to reach a first (non thinking) output token, but the output will be more carefully reasoned. |
+| Model | Default Thinking | Levels Supported |
+|-------|------------------|------------------|
+| gemini-3.6-flash | On (medium) | minimal, low, medium, high |
+| gemini-3.5-flash-lite | On (minimal) | minimal, low, medium, high |
+| gemini-3.1-pro-preview | On (high) | low, medium, high |
+| gemini-3.1-flash-lite-image | On (minimal) | minimal, high |
+| gemini-3-flash-preview | On (high) | minimal, low, medium, high |
+| gemini-3-pro-preview | On (high) | low, high |
+| gemini-3.5-flash | On (medium) | minimal, low, medium, high |
+| gemini-2.5-pro | On | low, medium, high |
+| gemini-2.5-flash | On | low, medium, high |
+| gemini-2.5-flash-lite | Off | low, medium, high |
 
 The following example shows how to set the thinking level.
 

--- a/src_py/README.md
+++ b/src_py/README.md
@@ -44,19 +44,15 @@ Stateless method that requires passing the full message history on each call:
 import asyncio
 from agenthub import AutoLLMClient
 
+
 async def main():
     client = AutoLLMClient(model="gpt-5.5")
 
     async for event in client.streaming_response(
-        messages=[
-            {
-                "role": "user",
-                "content_items": [{"type": "text", "text": "Hello!"}]
-            }
-        ],
-        config={}
+        messages=[{"role": "user", "content_items": [{"type": "text", "text": "Hello!"}]}], config={}
     ):
         print(event)
+
 
 asyncio.run(main())
 ```
@@ -69,28 +65,22 @@ Stateful method that maintains conversation history internally:
 import asyncio
 from agenthub import AutoLLMClient
 
+
 async def main():
     client = AutoLLMClient(model="gpt-5.5")
 
     # First message
     async for event in client.streaming_response_stateful(
-        message={
-            "role": "user",
-            "content_items": [{"type": "text", "text": "My name is Alice"}]
-        },
-        config={}
+        message={"role": "user", "content_items": [{"type": "text", "text": "My name is Alice"}]}, config={}
     ):
         print(event)
 
     # Second message - history is maintained automatically
     async for event in client.streaming_response_stateful(
-        message={
-            "role": "user",
-            "content_items": [{"type": "text", "text": "What's my name?"}]
-        },
-        config={}
+        message={"role": "user", "content_items": [{"type": "text", "text": "What's my name?"}]}, config={}
     ):
         print(event)
+
 
 asyncio.run(main())
 ```
@@ -145,9 +135,11 @@ import asyncio
 import json
 from agenthub import AutoLLMClient
 
+
 def get_weather(location: str) -> str:
     """Mock function to get weather."""
     return f"Temperature in {location}: 22°C"
+
 
 async def main():
     # Define tool
@@ -156,14 +148,9 @@ async def main():
         "description": "Gets the current weather for a given location.",
         "parameters": {
             "type": "object",
-            "properties": {
-                "location": {
-                    "type": "string",
-                    "description": "The city name"
-                }
-            },
-            "required": ["location"]
-        }
+            "properties": {"location": {"type": "string", "description": "The city name"}},
+            "required": ["location"],
+        },
     }
 
     client = AutoLLMClient(model="gpt-5.5")
@@ -172,11 +159,8 @@ async def main():
     # User asks about weather
     events = []
     async for event in client.streaming_response_stateful(
-        message={
-            "role": "user",
-            "content_items": [{"type": "text", "text": "What's the weather in London?"}]
-        },
-        config=config
+        message={"role": "user", "content_items": [{"type": "text", "text": "What's the weather in London?"}]},
+        config=config,
     ):
         events.append(event)
 
@@ -203,13 +187,14 @@ async def main():
                     {
                         "type": "tool_result",
                         "text": result,
-                        "tool_call_id": tool_call["tool_call_id"]  # Required for tool responses
+                        "tool_call_id": tool_call["tool_call_id"],  # Required for tool responses
                     }
-                ]
+                ],
             },
-            config=config
+            config=config,
         ):
             print(event)
+
 
 asyncio.run(main())
 ```
@@ -224,8 +209,13 @@ asyncio.run(main())
     "content_items": [
         {"type": "text", "text": "Hello"},
         {"type": "image_url", "image_url": "https://..."},
-        {"type": "tool_call", "name": "get_weather", "arguments": {"location": "London"}, "tool_call_id": "call_abc123"}
-    ]
+        {
+            "type": "tool_call",
+            "name": "get_weather",
+            "arguments": {"location": "London"},
+            "tool_call_id": "call_abc123",
+        },
+    ],
 }
 ```
 
@@ -240,9 +230,9 @@ When responding to a tool call, include the `tool_call_id` in the result content
         {
             "type": "tool_result",
             "text": "London is 22°C today.",
-            "tool_call_id": "call_abc123"  # From tool_call event
+            "tool_call_id": "call_abc123",  # From tool_call event
         }
-    ]
+    ],
 }
 ```
 
@@ -260,7 +250,7 @@ config = {
     "tool_choice": "auto",  # "auto", "required", "none", or ["tool_name"]
     "system_prompt": "You are a helpful assistant",
     "prompt_caching": PromptCaching.ENABLE,
-    "trace_id": "agent1/conversation_001"  # Optional: save conversation trace
+    "trace_id": "agent1/conversation_001",  # Optional: save conversation trace
 }
 ```
 
@@ -279,8 +269,7 @@ client = AutoLLMClient(model="gpt-5.5")
 config = {"trace_id": "agent1/conversation_001"}
 
 async for event in client.streaming_response_stateful(
-    message={"role": "user", "content_items": [{"type": "text", "text": "Hello"}]},
-    config=config
+    message={"role": "user", "content_items": [{"type": "text", "text": "Hello"}]}, config=config
 ):
     pass  # Conversation is automatically saved
 ```

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -92,8 +92,27 @@ class Gemini3Client(LLMClient):
 
         return {"data": image_bytes, "mime_type": mime_type}
 
+    # Gemini thinking levels from weakest to strongest, used to pick the
+    # closest supported level when a model rejects the requested one.
+    _GEMINI_LEVEL_ORDER = (
+        types.ThinkingLevel.MINIMAL,
+        types.ThinkingLevel.LOW,
+        types.ThinkingLevel.MEDIUM,
+        types.ThinkingLevel.HIGH,
+    )
+
+    def _supported_thinking_levels(self) -> tuple[types.ThinkingLevel, ...]:
+        """Thinking levels the target model accepts (llmsdk_docs/gemini3/docs/thinking.md)."""
+        if "-image" in self._model:
+            return (types.ThinkingLevel.MINIMAL, types.ThinkingLevel.HIGH)
+        if "gemini-3.1-pro" in self._model:
+            return (types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH)
+        if "gemini-3-pro" in self._model:
+            return (types.ThinkingLevel.LOW, types.ThinkingLevel.HIGH)
+        return self._GEMINI_LEVEL_ORDER
+
     def _convert_thinking_level(self, thinking_level: ThinkingLevel | None) -> types.ThinkingLevel | None:
-        """Convert ThinkingLevel enum to Gemini's ThinkingLevel."""
+        """Convert ThinkingLevel enum to the closest Gemini ThinkingLevel the model supports."""
         mapping = {
             ThinkingLevel.NONE: types.ThinkingLevel.MINIMAL,
             ThinkingLevel.LOW: types.ThinkingLevel.LOW,
@@ -101,7 +120,20 @@ class Gemini3Client(LLMClient):
             ThinkingLevel.HIGH: types.ThinkingLevel.HIGH,
             ThinkingLevel.XHIGH: types.ThinkingLevel.HIGH,
         }
-        return mapping.get(thinking_level)
+        level = mapping.get(thinking_level)
+        supported = self._supported_thinking_levels()
+        if level is None or level in supported:
+            return level
+        # Degrade silently to the nearest supported level; ties round up,
+        # e.g. MEDIUM becomes HIGH on gemini-3-pro.
+        index = self._GEMINI_LEVEL_ORDER.index(level)
+        return min(
+            supported,
+            key=lambda candidate: (
+                abs(self._GEMINI_LEVEL_ORDER.index(candidate) - index),
+                -self._GEMINI_LEVEL_ORDER.index(candidate),
+            ),
+        )
 
     def _convert_tool_choice(self, tool_choice: ToolChoice) -> types.FunctionCallingConfig:
         """Convert ToolChoice to Gemini's tool config."""

--- a/src_py/agenthub/gemini3/client.py
+++ b/src_py/agenthub/gemini3/client.py
@@ -102,13 +102,26 @@ class Gemini3Client(LLMClient):
     )
 
     def _supported_thinking_levels(self) -> tuple[types.ThinkingLevel, ...]:
-        """Thinking levels the target model accepts (llmsdk_docs/gemini3/docs/thinking.md)."""
+        """Thinking levels the target model accepts (llmsdk_docs/gemini3/docs/thinking.md).
+
+        An empty tuple means the model rejects the thinking_level parameter
+        entirely, so it must be omitted from the request.
+        """
+        if "gemini-2.5" in self._model:
+            # The vendor table claims low/medium/high, but the live API rejects
+            # every thinking_level value for the 2.5 series (verified 2026-07-24).
+            return ()
         if "-image" in self._model:
             return (types.ThinkingLevel.MINIMAL, types.ThinkingLevel.HIGH)
-        if "gemini-3.1-pro" in self._model:
-            return (types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH)
         if "gemini-3-pro" in self._model:
+            # The only pro generation without "medium".
             return (types.ThinkingLevel.LOW, types.ThinkingLevel.HIGH)
+        if "-pro" in self._model:
+            # Every pro generation rejects "minimal"; matching broadly keeps
+            # future pro models on the safe side (clamping a level the model
+            # would have accepted costs a little accuracy, forwarding an
+            # unsupported one is a 400).
+            return (types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH)
         return self._GEMINI_LEVEL_ORDER
 
     def _convert_thinking_level(self, thinking_level: ThinkingLevel | None) -> types.ThinkingLevel | None:
@@ -121,8 +134,14 @@ class Gemini3Client(LLMClient):
             ThinkingLevel.XHIGH: types.ThinkingLevel.HIGH,
         }
         level = mapping.get(thinking_level)
+        if level is None:
+            return None
         supported = self._supported_thinking_levels()
-        if level is None or level in supported:
+        if not supported:
+            # The model takes no thinking_level at all; drop the parameter and
+            # let the model use its default instead of forwarding a 400.
+            return None
+        if level in supported:
             return level
         # Degrade silently to the nearest supported level; ties round up,
         # e.g. MEDIUM becomes HIGH on gemini-3-pro.

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -549,7 +549,10 @@ async def test_system_prompt(model: Model):
 
     client = await _create_client(model)
     messages = [{"role": "user", "content_items": [{"type": "text", "text": "Hello"}]}]
-    config = {"system_prompt": "You are a kitten that must end with the word 'meow'."}
+    config = {
+        "system_prompt": "You are a kitten. Every reply MUST contain the exact word 'meow' — "
+        "never a variant like 'mreow' or a *purrs* action instead."
+    }
 
     text = ""
     async for event in client.streaming_response(messages=messages, config=config):

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from google.genai import types
+
+from agenthub import AutoLLMClient, ThinkingLevel
+
+
+# Not every Gemini model accepts every thinking level (verified live 2026-07-24;
+# see llmsdk_docs/gemini3/docs/thinking.md): pro models reject "minimal"
+# (gemini-3-pro also "medium"), image models accept only "minimal" and "high".
+# Unsupported levels must clamp to the closest supported one, never error.
+GEMINI3_THINKING_LEVEL_CASES = [
+    ("gemini-3.1-pro-preview", ThinkingLevel.NONE, types.ThinkingLevel.LOW),
+    ("gemini-3.1-pro-preview", ThinkingLevel.LOW, types.ThinkingLevel.LOW),
+    ("gemini-3.1-pro-preview", ThinkingLevel.MEDIUM, types.ThinkingLevel.MEDIUM),
+    ("gemini-3.1-pro-preview", ThinkingLevel.HIGH, types.ThinkingLevel.HIGH),
+    ("gemini-3.1-pro-preview", ThinkingLevel.XHIGH, types.ThinkingLevel.HIGH),
+    ("gemini-3-pro-preview", ThinkingLevel.NONE, types.ThinkingLevel.LOW),
+    ("gemini-3-pro-preview", ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH),
+    ("gemini-3.1-flash-image", ThinkingLevel.NONE, types.ThinkingLevel.MINIMAL),
+    ("gemini-3.1-flash-image", ThinkingLevel.LOW, types.ThinkingLevel.MINIMAL),
+    ("gemini-3.1-flash-image", ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH),
+    ("gemini-3-flash-preview", ThinkingLevel.NONE, types.ThinkingLevel.MINIMAL),
+    ("gemini-3.5-flash", ThinkingLevel.MEDIUM, types.ThinkingLevel.MEDIUM),
+]
+
+
+@pytest.mark.parametrize(("model", "level", "expected"), GEMINI3_THINKING_LEVEL_CASES)
+def test_gemini3_thinking_level_clamps_to_model_support(
+    model: str, level: ThinkingLevel, expected: types.ThinkingLevel
+):
+    client = AutoLLMClient(model=model, api_key="test-key")
+    assert client._client._convert_thinking_level(level) == expected  # noqa: SLF001

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -20,8 +20,10 @@ from agenthub import AutoLLMClient, ThinkingLevel
 
 # Not every Gemini model accepts every thinking level (verified live 2026-07-24;
 # see llmsdk_docs/gemini3/docs/thinking.md): pro models reject "minimal"
-# (gemini-3-pro also "medium"), image models accept only "minimal" and "high".
-# Unsupported levels must clamp to the closest supported one, never error.
+# (gemini-3-pro also "medium"), image models accept only "minimal" and "high",
+# and the 2.5 series rejects the thinking_level parameter outright. Unsupported
+# levels must clamp to the closest supported one — or be dropped entirely for
+# models that take none — never error.
 GEMINI3_THINKING_LEVEL_CASES = [
     ("gemini-3.1-pro-preview", ThinkingLevel.NONE, types.ThinkingLevel.LOW),
     ("gemini-3.1-pro-preview", ThinkingLevel.LOW, types.ThinkingLevel.LOW),
@@ -33,14 +35,46 @@ GEMINI3_THINKING_LEVEL_CASES = [
     ("gemini-3.1-flash-image", ThinkingLevel.NONE, types.ThinkingLevel.MINIMAL),
     ("gemini-3.1-flash-image", ThinkingLevel.LOW, types.ThinkingLevel.MINIMAL),
     ("gemini-3.1-flash-image", ThinkingLevel.MEDIUM, types.ThinkingLevel.HIGH),
+    # "-image" wins over "gemini-3-pro" (LOW would stay LOW under the pro set).
+    ("gemini-3-pro-image", ThinkingLevel.LOW, types.ThinkingLevel.MINIMAL),
     ("gemini-3-flash-preview", ThinkingLevel.NONE, types.ThinkingLevel.MINIMAL),
     ("gemini-3.5-flash", ThinkingLevel.MEDIUM, types.ThinkingLevel.MEDIUM),
+    # The 2.5 series rejects thinking_level for every value: drop the parameter.
+    ("gemini-2.5-pro", ThinkingLevel.NONE, None),
+    ("gemini-2.5-flash", ThinkingLevel.HIGH, None),
+    ("gemini-2.5-flash-lite", ThinkingLevel.LOW, None),
+    # A future pro generation falls into the generic "-pro" branch.
+    ("gemini-4-pro", ThinkingLevel.NONE, types.ThinkingLevel.LOW),
+    # An unrecognized model inherits the full four-level default.
+    ("gemini-9-flash", ThinkingLevel.NONE, types.ThinkingLevel.MINIMAL),
 ]
+
+
+def _create_gemini3_auto_client(model: str) -> AutoLLMClient:
+    # client_type pins routing so pre-3 and hypothetical model names reach
+    # Gemini3Client the same way an explicit override would in user code.
+    return AutoLLMClient(model=model, api_key="test-key", client_type="gemini-3")
 
 
 @pytest.mark.parametrize(("model", "level", "expected"), GEMINI3_THINKING_LEVEL_CASES)
 def test_gemini3_thinking_level_clamps_to_model_support(
-    model: str, level: ThinkingLevel, expected: types.ThinkingLevel
+    model: str, level: ThinkingLevel, expected: types.ThinkingLevel | None
 ):
-    client = AutoLLMClient(model=model, api_key="test-key")
+    client = _create_gemini3_auto_client(model)
     assert client._client._convert_thinking_level(level) == expected  # noqa: SLF001
+
+
+def test_gemini3_thinking_config_carries_clamped_level():
+    client = _create_gemini3_auto_client("gemini-3.1-pro-preview")
+    config = client._client.transform_uni_config_to_model_config(  # noqa: SLF001
+        {"thinking_level": ThinkingLevel.NONE}
+    )
+    assert config.thinking_config.thinking_level == types.ThinkingLevel.LOW
+
+
+def test_gemini3_thinking_config_omits_level_for_pre_3_models():
+    client = _create_gemini3_auto_client("gemini-2.5-flash")
+    config = client._client.transform_uni_config_to_model_config(  # noqa: SLF001
+        {"thinking_level": ThinkingLevel.HIGH}
+    )
+    assert config.thinking_config.thinking_level is None

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -162,7 +162,38 @@ export class Gemini3Client extends LLMClient {
   }
 
   /**
-   * Convert ThinkingLevel enum to Gemini's ThinkingLevel.
+   * Gemini thinking levels from weakest to strongest, used to pick the
+   * closest supported level when a model rejects the requested one.
+   */
+  private static readonly GEMINI_LEVEL_ORDER: GeminiThinkingLevel[] = [
+    GeminiThinkingLevel.MINIMAL,
+    GeminiThinkingLevel.LOW,
+    GeminiThinkingLevel.MEDIUM,
+    GeminiThinkingLevel.HIGH,
+  ];
+
+  /**
+   * Thinking levels the target model accepts (llmsdk_docs/gemini3/docs/thinking.md).
+   */
+  private _supportedThinkingLevels(): GeminiThinkingLevel[] {
+    if (this._model.includes("-image")) {
+      return [GeminiThinkingLevel.MINIMAL, GeminiThinkingLevel.HIGH];
+    }
+    if (this._model.includes("gemini-3.1-pro")) {
+      return [
+        GeminiThinkingLevel.LOW,
+        GeminiThinkingLevel.MEDIUM,
+        GeminiThinkingLevel.HIGH,
+      ];
+    }
+    if (this._model.includes("gemini-3-pro")) {
+      return [GeminiThinkingLevel.LOW, GeminiThinkingLevel.HIGH];
+    }
+    return Gemini3Client.GEMINI_LEVEL_ORDER;
+  }
+
+  /**
+   * Convert ThinkingLevel enum to the closest Gemini ThinkingLevel the model supports.
    */
   private _convertThinkingLevel(
     thinkingLevel: ThinkingLevel | undefined,
@@ -176,7 +207,23 @@ export class Gemini3Client extends LLMClient {
       [ThinkingLevel.HIGH]: GeminiThinkingLevel.HIGH,
       [ThinkingLevel.XHIGH]: GeminiThinkingLevel.HIGH,
     };
-    return mapping[thinkingLevel];
+    const level = mapping[thinkingLevel];
+    const supported = this._supportedThinkingLevels();
+    if (level === undefined || supported.includes(level)) {
+      return level;
+    }
+    // Degrade silently to the nearest supported level; ties round up,
+    // e.g. MEDIUM becomes HIGH on gemini-3-pro.
+    const order = Gemini3Client.GEMINI_LEVEL_ORDER;
+    const index = order.indexOf(level);
+    return supported.reduce((best, candidate) => {
+      const bestDistance = Math.abs(order.indexOf(best) - index);
+      const candidateDistance = Math.abs(order.indexOf(candidate) - index);
+      if (candidateDistance !== bestDistance) {
+        return candidateDistance < bestDistance ? candidate : best;
+      }
+      return order.indexOf(candidate) > order.indexOf(best) ? candidate : best;
+    });
   }
 
   /**

--- a/src_ts/src/gemini3/client.ts
+++ b/src_ts/src/gemini3/client.ts
@@ -174,20 +174,33 @@ export class Gemini3Client extends LLMClient {
 
   /**
    * Thinking levels the target model accepts (llmsdk_docs/gemini3/docs/thinking.md).
+   *
+   * An empty array means the model rejects the thinking_level parameter
+   * entirely, so it must be omitted from the request.
    */
   private _supportedThinkingLevels(): GeminiThinkingLevel[] {
+    if (this._model.includes("gemini-2.5")) {
+      // The vendor table claims low/medium/high, but the live API rejects
+      // every thinking_level value for the 2.5 series (verified 2026-07-24).
+      return [];
+    }
     if (this._model.includes("-image")) {
       return [GeminiThinkingLevel.MINIMAL, GeminiThinkingLevel.HIGH];
     }
-    if (this._model.includes("gemini-3.1-pro")) {
+    if (this._model.includes("gemini-3-pro")) {
+      // The only pro generation without "medium".
+      return [GeminiThinkingLevel.LOW, GeminiThinkingLevel.HIGH];
+    }
+    if (this._model.includes("-pro")) {
+      // Every pro generation rejects "minimal"; matching broadly keeps
+      // future pro models on the safe side (clamping a level the model
+      // would have accepted costs a little accuracy, forwarding an
+      // unsupported one is a 400).
       return [
         GeminiThinkingLevel.LOW,
         GeminiThinkingLevel.MEDIUM,
         GeminiThinkingLevel.HIGH,
       ];
-    }
-    if (this._model.includes("gemini-3-pro")) {
-      return [GeminiThinkingLevel.LOW, GeminiThinkingLevel.HIGH];
     }
     return Gemini3Client.GEMINI_LEVEL_ORDER;
   }
@@ -208,12 +221,21 @@ export class Gemini3Client extends LLMClient {
       [ThinkingLevel.XHIGH]: GeminiThinkingLevel.HIGH,
     };
     const level = mapping[thinkingLevel];
+    if (level === undefined) {
+      return undefined;
+    }
     const supported = this._supportedThinkingLevels();
-    if (level === undefined || supported.includes(level)) {
+    if (supported.length === 0) {
+      // The model takes no thinking_level at all; drop the parameter and
+      // let the model use its default instead of forwarding a 400.
+      return undefined;
+    }
+    if (supported.includes(level)) {
       return level;
     }
     // Degrade silently to the nearest supported level; ties round up,
-    // e.g. MEDIUM becomes HIGH on gemini-3-pro.
+    // e.g. MEDIUM becomes HIGH on gemini-3-pro. `supported` is non-empty
+    // here, so the initial-value-less reduce cannot throw.
     const order = Gemini3Client.GEMINI_LEVEL_ORDER;
     const index = order.indexOf(level);
     return supported.reduce((best, candidate) => {

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -736,7 +736,9 @@ if (AVAILABLE_MODELS.length > 0) {
         },
       ];
       const config: UniConfig = {
-        system_prompt: "You are a kitten that must end with the word 'meow'.",
+        system_prompt:
+          "You are a kitten. Every reply MUST contain the exact word 'meow' — " +
+          "never a variant like 'mreow' or a *purrs* action instead.",
       };
 
       let text = "";

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, describe, test } from "@jest/globals";
+import { ThinkingLevel as GeminiThinkingLevel } from "@google/genai";
+import { AutoLLMClient, ThinkingLevel } from "../src";
+
+// Not every Gemini model accepts every thinking level (verified live 2026-07-24;
+// see llmsdk_docs/gemini3/docs/thinking.md): pro models reject "minimal"
+// (gemini-3-pro also "medium"), image models accept only "minimal" and "high".
+// Unsupported levels must clamp to the closest supported one, never error.
+const GEMINI3_THINKING_LEVEL_CASES: Array<
+  [string, ThinkingLevel, GeminiThinkingLevel]
+> = [
+  ["gemini-3.1-pro-preview", ThinkingLevel.NONE, GeminiThinkingLevel.LOW],
+  ["gemini-3.1-pro-preview", ThinkingLevel.LOW, GeminiThinkingLevel.LOW],
+  ["gemini-3.1-pro-preview", ThinkingLevel.MEDIUM, GeminiThinkingLevel.MEDIUM],
+  ["gemini-3.1-pro-preview", ThinkingLevel.HIGH, GeminiThinkingLevel.HIGH],
+  ["gemini-3.1-pro-preview", ThinkingLevel.XHIGH, GeminiThinkingLevel.HIGH],
+  ["gemini-3-pro-preview", ThinkingLevel.NONE, GeminiThinkingLevel.LOW],
+  ["gemini-3-pro-preview", ThinkingLevel.MEDIUM, GeminiThinkingLevel.HIGH],
+  ["gemini-3.1-flash-image", ThinkingLevel.NONE, GeminiThinkingLevel.MINIMAL],
+  ["gemini-3.1-flash-image", ThinkingLevel.LOW, GeminiThinkingLevel.MINIMAL],
+  ["gemini-3.1-flash-image", ThinkingLevel.MEDIUM, GeminiThinkingLevel.HIGH],
+  ["gemini-3-flash-preview", ThinkingLevel.NONE, GeminiThinkingLevel.MINIMAL],
+  ["gemini-3.5-flash", ThinkingLevel.MEDIUM, GeminiThinkingLevel.MEDIUM],
+];
+
+describe("gemini3 thinking level clamping", () => {
+  test.each(GEMINI3_THINKING_LEVEL_CASES)(
+    "%s clamps %s to %s",
+    (model, level, expected) => {
+      const client = new AutoLLMClient({ model, apiKey: "test-key" });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((client as any)._client._convertThinkingLevel(level)).toBe(
+        expected,
+      );
+    },
+  );
+});

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -18,10 +18,12 @@ import { AutoLLMClient, ThinkingLevel } from "../src";
 
 // Not every Gemini model accepts every thinking level (verified live 2026-07-24;
 // see llmsdk_docs/gemini3/docs/thinking.md): pro models reject "minimal"
-// (gemini-3-pro also "medium"), image models accept only "minimal" and "high".
-// Unsupported levels must clamp to the closest supported one, never error.
+// (gemini-3-pro also "medium"), image models accept only "minimal" and "high",
+// and the 2.5 series rejects the thinking_level parameter outright. Unsupported
+// levels must clamp to the closest supported one — or be dropped entirely for
+// models that take none — never error.
 const GEMINI3_THINKING_LEVEL_CASES: Array<
-  [string, ThinkingLevel, GeminiThinkingLevel]
+  [string, ThinkingLevel, GeminiThinkingLevel | undefined]
 > = [
   ["gemini-3.1-pro-preview", ThinkingLevel.NONE, GeminiThinkingLevel.LOW],
   ["gemini-3.1-pro-preview", ThinkingLevel.LOW, GeminiThinkingLevel.LOW],
@@ -33,19 +35,57 @@ const GEMINI3_THINKING_LEVEL_CASES: Array<
   ["gemini-3.1-flash-image", ThinkingLevel.NONE, GeminiThinkingLevel.MINIMAL],
   ["gemini-3.1-flash-image", ThinkingLevel.LOW, GeminiThinkingLevel.MINIMAL],
   ["gemini-3.1-flash-image", ThinkingLevel.MEDIUM, GeminiThinkingLevel.HIGH],
+  // "-image" wins over "gemini-3-pro" (LOW would stay LOW under the pro set).
+  ["gemini-3-pro-image", ThinkingLevel.LOW, GeminiThinkingLevel.MINIMAL],
   ["gemini-3-flash-preview", ThinkingLevel.NONE, GeminiThinkingLevel.MINIMAL],
   ["gemini-3.5-flash", ThinkingLevel.MEDIUM, GeminiThinkingLevel.MEDIUM],
+  // The 2.5 series rejects thinking_level for every value: drop the parameter.
+  ["gemini-2.5-pro", ThinkingLevel.NONE, undefined],
+  ["gemini-2.5-flash", ThinkingLevel.HIGH, undefined],
+  ["gemini-2.5-flash-lite", ThinkingLevel.LOW, undefined],
+  // A future pro generation falls into the generic "-pro" branch.
+  ["gemini-4-pro", ThinkingLevel.NONE, GeminiThinkingLevel.LOW],
+  // An unrecognized model inherits the full four-level default.
+  ["gemini-9-flash", ThinkingLevel.NONE, GeminiThinkingLevel.MINIMAL],
 ];
+
+// clientType pins routing so pre-3 and hypothetical model names reach
+// Gemini3Client the same way an explicit override would in user code.
+function createGemini3AutoClient(model: string): AutoLLMClient {
+  return new AutoLLMClient({
+    model,
+    apiKey: "test-key",
+    clientType: "gemini-3",
+  });
+}
 
 describe("gemini3 thinking level clamping", () => {
   test.each(GEMINI3_THINKING_LEVEL_CASES)(
     "%s clamps %s to %s",
     (model, level, expected) => {
-      const client = new AutoLLMClient({ model, apiKey: "test-key" });
+      const client = createGemini3AutoClient(model);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((client as any)._client._convertThinkingLevel(level)).toBe(
         expected,
       );
     },
   );
+
+  test("thinking config carries the clamped level", () => {
+    const client = createGemini3AutoClient("gemini-3.1-pro-preview");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (client as any)._client.transformUniConfigToModelConfig({
+      thinking_level: ThinkingLevel.NONE,
+    });
+    expect(config.thinkingConfig.thinkingLevel).toBe(GeminiThinkingLevel.LOW);
+  });
+
+  test("thinking config omits the level for pre-3 models", () => {
+    const client = createGemini3AutoClient("gemini-2.5-flash");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = (client as any)._client.transformUniConfigToModelConfig({
+      thinking_level: ThinkingLevel.HIGH,
+    });
+    expect(config.thinkingConfig.thinkingLevel).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

`gemini-3.1-pro` fails with `400 Thinking level MINIMAL is not supported for this model` whenever `thinking_level=NONE` is used: the `gemini3` clients mapped `NONE → MINIMAL` unconditionally, but pro models don't accept `minimal`. This violated the design rule already documented on `UnsupportedParameterError` in `errors.py`/`errors.ts` — "Thinking levels never raise this by design: every client maps each ThinkingLevel onto the closest level the model supports" — `gemini3` was the one client not honoring it.

## Fix

`_convert_thinking_level` (Python + TypeScript, identical behavior) clamps the mapped Gemini level to the closest level the target model supports, rounding up on ties — or omits the parameter entirely for models that reject it outright — instead of forwarding a level the API will 400 on:

| Model family | Accepts | Behavior |
|---|---|---|
| `gemini-3.1-pro*` | low, medium, high | NONE → low |
| `gemini-3-pro*` | low, high | NONE → low, MEDIUM → high |
| `*-image` (checked first, so `gemini-3-pro-image` lands here) | minimal, high | LOW → minimal, MEDIUM → high |
| any other `*-pro*` (generic branch: future pro generations degrade safely) | low, medium, high | NONE → low |
| `gemini-2.5*` | **none** — live API rejects every `thinking_level` value, contradicting the vendor table | parameter dropped; model keeps default dynamic thinking |
| flash text models | minimal, low, medium, high | unchanged |

The 2.5 series is reachable only via explicit `client_type="gemini-3"` or direct `Gemini3Client` construction (name routing never sends it here), but both are public API. Degradation is deliberately silent (repo-wide rule: thinking levels never raise; no logging infrastructure exists in the clients) — the cost trade, including the two round-*up* clamps, is recorded in the changelog. An empty supported-set is a defined state ("omit the parameter") and is guarded before `min()`/`reduce`, so neither can see an empty input. `gemini3_6` clients are untouched — both routed models accept all four levels.

## Verification

- Live probes against the Gemini API (2026-07-24, raw exchanges in git-ignored `api_captures/gemini3/`): `gemini-3.1-pro-preview` rejects `minimal`, accepts `low`/`medium`; `gemini-3.1-flash-image` rejects `low`/`medium`; `gemini-2.5-pro`/`-flash`/`-flash-lite` reject **every** level including the officially-listed `low`; `gemini-3.1-flash-lite` accepts `minimal`. `gemini-3-pro-preview` is decommissioned on the official endpoint, so its low/high set comes from the docs table (kept for Vertex).
- End-to-end through `AutoLLMClient`: `gemini-3.1-pro-preview` with `NONE` and `XHIGH` streams successfully (the `NONE` case previously 400'd); `gemini-2.5-flash` via `client_type="gemini-3"` with `thinking_level=HIGH` streams successfully with the parameter dropped.
- Offline regression tests pin the matrix in both languages — 18 mirrored clamp cases (including the `-image`-over-`-pro` branch-order pin, 2.5 drops, a future `-pro` model, and the fall-through default) plus 2 config-level assertions on `transform_uni_config_to_model_config` output.
- `make lint` passes on this branch (see drive-bys), `npm run lint` + `npm run build` clean; gemini-scoped e2e: 22 passed (py), 68 passed (ts).
- Synced `llmsdk_docs/gemini3/docs/thinking.md` with the live official page; the capture findings above document where the live API contradicts that table (2.5 rows).

## Drive-by commits

- `635addd` formats `src_py/README.md` code blocks for ruff 0.16: the Makefile lints with unpinned `uvx ruff`, and 0.16.0 started format-checking markdown code blocks, breaking `make lint`/CI on every branch — including `origin/dev`. This branch's `make lint` passes because of this commit.
- `7b911cf` hardens the flaky system-prompt e2e prompt (models roleplayed "mreow"/"*purrs*" without the literal word; flaked on `deepseek-v4-flash` and `gemini-3.6-flash:vertex` in consecutive CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)