### PR TITLE
Release 0.4.3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run tests
         working-directory: ./src_py
         run: |
-          uv run pytest -vvv tests
+          uv run pytest -vvv -n 16 --dist loadgroup tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions. Each release keeps one brief line here; the per-entry summaries live in `changelog/<version>/README.md`, and every entry links its detail file.
 
+- [2026-08-18] [Version 0.4.3](changelog/0.4.3/README.md): every streaming client skips the heartbeat events gateways inject on long generations, across the OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, and Gemini protocols.
+
 - [2026-08-18] [Version 0.4.2](changelog/0.4.2/README.md): generic OpenAI Responses and Anthropic Messages protocol clients covering OpenAI, OpenRouter, DeepSeek, Z.AI, and MiniMax (the generic chat client renames to `openai-chat`), GPT-5.6 support, `UniConfig.fast_mode`, and the Claude and Kimi series clients unified with family-wide `temperature` rejection.
 
 - [2026-07-22] [Version 0.4.1](changelog/0.4.1/README.md): Kimi K3, the Gemini 3.6 generation (gemini-3.6-flash, gemini-3.5-flash-lite), and GLM-5.2 support, a supported-model registry with USD/CNY pricing, context windows, and modalities, and the `UnsupportedParameterError` parameter error class.

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -4,6 +4,8 @@
 
 在这里，我们记录模型的新增与移除时间、主要功能更新、缺陷修复，以及关键版本的发布时间。每个发布版本在此保留一行简述；逐条目的摘要位于 `changelog/<version>/README.md`，且每个条目都会链接到自己的详情文件。
 
+- [2026-08-18] [版本 0.4.3](changelog/0.4.3/README.zh.md)：所有流式 client 跳过网关在长生成期间注入的心跳事件，覆盖 OpenAI Responses、OpenAI Chat Completions、Anthropic Messages 与 Gemini 四种协议。
+
 - [2026-08-18] [版本 0.4.2](changelog/0.4.2/README.zh.md)：通用 OpenAI Responses 与 Anthropic Messages 协议 client，覆盖 OpenAI、OpenRouter、DeepSeek、Z.AI 与 MiniMax（通用 chat client 重命名为 `openai-chat`），支持 GPT-5.6，新增 `UniConfig.fast_mode`，并统一 Claude 与 Kimi 系列 client、对全家族拒绝 `temperature`。
 
 - [2026-07-22] [版本 0.4.1](changelog/0.4.1/README.zh.md)：支持 Kimi K3、Gemini 3.6 代（gemini-3.6-flash、gemini-3.5-flash-lite）与 GLM-5.2，新增包含美元/人民币定价、上下文窗口与模态信息的受支持模型注册表，以及 `UnsupportedParameterError` 参数错误类。

--- a/changelog/0.4.3/2026-08-18-gateway-heartbeats.md
+++ b/changelog/0.4.3/2026-08-18-gateway-heartbeats.md
@@ -1,0 +1,46 @@
+# Every streaming client skips gateway heartbeat events
+
+- **Date:** 2026-08-18
+- **Type:** fix
+- **Scope:** `openai_responses`, `openai_chat`, `ant_messages`, `gemini3_7`, `tests`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+- **Issue:** [Prism-Shadow/penguin-harness#286](https://github.com/Prism-Shadow/penguin-harness/issues/286)
+
+[中文版](2026-08-18-gateway-heartbeats.zh.md)
+
+## What changed
+
+- `gpt5_6`, `openai_responses`, and `minimax_m3` clients (Python and TypeScript) recognize
+  the `keepalive` stream event as a known no-op and skip it silently. Gateways in front of
+  Responses-compatible servers (one-api-style proxies, OpenRouter) inject
+  `{"type": "keepalive", "sequence_number": N}` heartbeats into the SSE stream on long
+  generations; these previously fell through to the unknown-event guard and killed the
+  stream with `ValueError`/`Error`: `Unknown output: {"type":"keepalive","sequence_number":3}`.
+- `openai_chat`, `deepseek_v4`, `glm5_3`, and `kimi_k3` clients read a chunk's `choices`
+  only when the field is populated. A heartbeat is not a Chat Completions chunk, so
+  `choices` arrives as `None`/`undefined` rather than an empty list, and the previous
+  length check killed the stream with `TypeError: object of type 'NoneType' has no len()` /
+  `TypeError: Cannot read properties of undefined (reading 'length')`.
+- `claude5` and `ant_messages` clients treat the Messages API `ping` event as a known no-op
+  alongside `text`, `thinking`, `signature`, and `input_json`. Both Anthropic SDKs drop
+  `ping` at the SSE layer, so it reaches the transform only from a gateway that relabels it
+  onto another event, where it previously raised `Unknown output: {"type":"ping"}`.
+- `gemini3_7` clients mark a chunk carrying neither candidates nor usage as `unused`, and
+  the stream loop skips it instead of emitting an empty `delta` event. A heartbeat arriving
+  after the final chunk previously became the last event of the stream and failed the
+  `Last event must carry usage_metadata` check in `base_client`.
+- The unknown-event guards themselves are unchanged: genuinely unknown event types,
+  including provider error events, still raise.
+- Offline regression tests in both languages stream heartbeats through every streaming
+  client — interleaved between normal events and after the final event — and pin the guards
+  for unknown events: `src_py/tests/test_keepalive_events.py`,
+  `src_ts/tests/keepalive-events.test.ts`.
+
+## Heartbeat handling by protocol
+
+| Protocol | Clients | Heartbeat shape | Handling |
+| --- | --- | --- | --- |
+| OpenAI Responses | `gpt5_6`, `openai_responses`, `minimax_m3` | `{"type": "keepalive", "sequence_number": N}` | known no-op event type |
+| OpenAI Chat Completions | `openai_chat`, `deepseek_v4`, `glm5_3`, `kimi_k3` | a chunk carrying no `choices` | no choices and no usage yields no event |
+| Anthropic Messages | `claude5`, `ant_messages` | `{"type": "ping"}` | known no-op event type |
+| Gemini generateContent | `gemini3_7` | a chunk carrying no candidates and no usage | `unused` event, skipped by the stream loop |

--- a/changelog/0.4.3/2026-08-18-gateway-heartbeats.zh.md
+++ b/changelog/0.4.3/2026-08-18-gateway-heartbeats.zh.md
@@ -1,0 +1,41 @@
+# 所有流式 client 跳过网关的心跳事件
+
+- **Date:** 2026-08-18
+- **Type:** fix
+- **Scope:** `openai_responses`, `openai_chat`, `ant_messages`, `gemini3_7`, `tests`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+- **Issue:** [Prism-Shadow/penguin-harness#286](https://github.com/Prism-Shadow/penguin-harness/issues/286)
+
+[English](2026-08-18-gateway-heartbeats.md)
+
+## 变更内容
+
+- `gpt5_6`、`openai_responses` 与 `minimax_m3` client（Python 与 TypeScript）把 `keepalive`
+  流事件识别为已知的无操作事件并静默跳过。位于 Responses 兼容服务前面的网关（one-api 风格代理、
+  OpenRouter）会在长生成期间向 SSE 流注入 `{"type": "keepalive", "sequence_number": N}` 心跳；
+  此前这些事件会落入未知事件守卫，以 `ValueError`/`Error` 中断整个流：
+  `Unknown output: {"type":"keepalive","sequence_number":3}`。
+- `openai_chat`、`deepseek_v4`、`glm5_3` 与 `kimi_k3` client 仅在 `choices` 字段有值时才读取它。
+  心跳并不是一个 Chat Completions chunk，因此 `choices` 会以 `None`/`undefined` 而非空列表到达，
+  此前的长度判断会以 `TypeError: object of type 'NoneType' has no len()` /
+  `TypeError: Cannot read properties of undefined (reading 'length')` 中断整个流。
+- `claude5` 与 `ant_messages` client 把 Messages API 的 `ping` 事件与 `text`、`thinking`、
+  `signature`、`input_json` 一同视为已知的无操作事件。两种语言的 Anthropic SDK 都会在 SSE 层丢弃
+  `ping`，因此它只有在网关把它改挂到其他事件上时才会到达转换函数，此前会抛出
+  `Unknown output: {"type":"ping"}`。
+- `gemini3_7` client 把既无 candidates 又无 usage 的 chunk 标记为 `unused`，流循环直接跳过，
+  而不再产生一个空的 `delta` 事件。此前若心跳出现在最后一个 chunk 之后，它会成为流的最后一个事件，
+  并触发 `base_client` 的 `Last event must carry usage_metadata` 校验失败。
+- 未知事件守卫本身未变：真正未知的事件类型（包括服务方的错误事件）仍会抛出。
+- 两种语言的离线回归测试让心跳穿插在正常事件之间、并出现在最后一个事件之后，流过全部流式 client，
+  同时钉住未知事件的守卫：`src_py/tests/test_keepalive_events.py`、
+  `src_ts/tests/keepalive-events.test.ts`。
+
+## 各协议的心跳处理
+
+| 协议 | Client | 心跳形态 | 处理方式 |
+| --- | --- | --- | --- |
+| OpenAI Responses | `gpt5_6`, `openai_responses`, `minimax_m3` | `{"type": "keepalive", "sequence_number": N}` | 已知的无操作事件类型 |
+| OpenAI Chat Completions | `openai_chat`, `deepseek_v4`, `glm5_3`, `kimi_k3` | 不带 `choices` 的 chunk | 既无 choices 又无 usage 则不产生事件 |
+| Anthropic Messages | `claude5`, `ant_messages` | `{"type": "ping"}` | 已知的无操作事件类型 |
+| Gemini generateContent | `gemini3_7` | 既无 candidates 又无 usage 的 chunk | 标记为 `unused`，由流循环跳过 |

--- a/changelog/0.4.3/2026-08-19-minimax-routing-order.md
+++ b/changelog/0.4.3/2026-08-19-minimax-routing-order.md
@@ -1,0 +1,15 @@
+# MiniMax routing moved into the client-type chain
+
+- **Date:** 2026-08-19
+- **Type:** refactor
+- **Scope:** `auto_client`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+
+[中文版](2026-08-19-minimax-routing-order.zh.md)
+
+## What changed
+
+- `auto_client.py` and `autoClient.ts` test `client_type == "minimax-m3"` after the Kimi
+  branch instead of ahead of the whole chain, so the MiniMax branch sits with the other
+  model-family branches. The test itself is untouched, and no other branch matches
+  `minimax-m3`, so every client type routes to the same client as before.

--- a/changelog/0.4.3/2026-08-19-minimax-routing-order.zh.md
+++ b/changelog/0.4.3/2026-08-19-minimax-routing-order.zh.md
@@ -1,0 +1,14 @@
+# MiniMax 的路由分支移入 client type 判断链
+
+- **Date:** 2026-08-19
+- **Type:** refactor
+- **Scope:** `auto_client`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+
+[English](2026-08-19-minimax-routing-order.md)
+
+## 变更内容
+
+- `auto_client.py` 与 `autoClient.ts` 把 `client_type == "minimax-m3"` 的判断从整条判断链之前
+  移到 Kimi 分支之后，使 MiniMax 分支与其他模型家族的分支排在一起。判断条件本身未变，且没有其他
+  分支会匹配 `minimax-m3`，因此所有 client type 的路由结果与此前一致。

--- a/changelog/0.4.3/2026-08-19-parallel-e2e-suites.md
+++ b/changelog/0.4.3/2026-08-19-parallel-e2e-suites.md
@@ -1,0 +1,41 @@
+# The e2e suites run one client per worker
+
+- **Date:** 2026-08-19
+- **Type:** process
+- **Scope:** `tests`, `workflows`, `pyproject`, `jest.config`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+
+[中文版](2026-08-19-parallel-e2e-suites.zh.md)
+
+## What changed
+
+- `src_py/tests/conftest.py` marks every test carrying a `model` parameter with an
+  `xdist_group` keyed on that model's id, and the Python suite runs under
+  `pytest -n 16 --dist loadgroup` (`src_py/Makefile` and `.github/workflows/pytest.yml`).
+  Distinct models run on separate workers; the tests of one model stay serial on the
+  worker that owns its group, because providers rate-limit per client. `pytest-xdist>=3.6.0`
+  joins the `dev` extra in `src_py/pyproject.toml`.
+- `src_ts/tests/client.test.ts` declares each check through a `modelTest` helper that opens
+  a describe block per check holding one `test.concurrent` per model. jest-circus runs
+  describe blocks one after another and the tests inside one block concurrently, so the
+  models of a check run in parallel while a single model never has two checks in flight.
+  The helper takes its timeout ahead of the body.
+- `src_ts/tests/client.test.ts` primes gaxios' lazily imported fetch from a `beforeAll`
+  hook, and `gaxios` joins `devDependencies`. Jest keeps a single `isInsideTestCode` flag
+  per runtime and clears it as soon as any concurrent sibling finishes, so the dynamic
+  `import()` gaxios runs on its first request — the transport behind Vertex
+  service-account auth — otherwise fails the in-flight tests with
+  `ReferenceError: You are trying to import a file outside of the scope of the test code`.
+- `src_ts/jest.config.js` raises `maxConcurrency` to 64 so the concurrency cap clears the
+  model count instead of the default 5.
+
+## Test names
+
+The TypeScript e2e names regrouped from model-then-check to check-then-model:
+
+| Before | After |
+| --- | --- |
+| `Client tests for <model> > <check>` | `Client tests > <check> > <model>` |
+
+`npm run test -- -t "<model>"` still selects one model's tests, and
+`uv run pytest -k "<model>"` is unaffected.

--- a/changelog/0.4.3/2026-08-19-parallel-e2e-suites.zh.md
+++ b/changelog/0.4.3/2026-08-19-parallel-e2e-suites.zh.md
@@ -1,0 +1,36 @@
+# e2e 测试套件按 client 分配到各自的 worker
+
+- **Date:** 2026-08-19
+- **Type:** process
+- **Scope:** `tests`, `workflows`, `pyproject`, `jest.config`
+- **PR:** [#174](https://github.com/Prism-Shadow/agenthub/pull/174)
+
+[English](2026-08-19-parallel-e2e-suites.md)
+
+## 变更内容
+
+- `src_py/tests/conftest.py` 为每个带 `model` 参数的测试打上以该模型 id 为键的 `xdist_group`
+  标记，Python 套件改为在 `pytest -n 16 --dist loadgroup` 下运行（`src_py/Makefile` 与
+  `.github/workflows/pytest.yml`）。不同模型分散到不同 worker；同一模型的测试则串行留在拥有
+  该分组的 worker 上，因为服务方按 client 限流。`pytest-xdist>=3.6.0` 加入
+  `src_py/pyproject.toml` 的 `dev` 附加依赖。
+- `src_ts/tests/client.test.ts` 通过 `modelTest` 辅助函数声明每一项检查：每项检查是一个
+  describe 块，其中每个模型对应一个 `test.concurrent`。jest-circus 逐个执行 describe 块、
+  并发执行块内的测试，因此一项检查的各模型并行运行，而同一模型不会同时进行两项检查。该辅助函数
+  把超时参数放在测试体之前。
+- `src_ts/tests/client.test.ts` 在 `beforeAll` 钩子中预热 gaxios 延迟导入的 fetch，并把 `gaxios`
+  加入 `devDependencies`。Jest 对整个 runtime 只维护一个 `isInsideTestCode` 标志，且在任意并发
+  兄弟测试结束时就会清除它；gaxios（Vertex 服务账号鉴权所用的传输层）在首次请求时执行的动态
+  `import()` 因此会让正在进行的测试以
+  `ReferenceError: You are trying to import a file outside of the scope of the test code` 失败。
+- `src_ts/jest.config.js` 把 `maxConcurrency` 提高到 64，使并发上限超过模型数量，而不是默认的 5。
+
+## 测试名称
+
+TypeScript e2e 的名称从「模型在前、检查在后」改为「检查在前、模型在后」：
+
+| 变更前 | 变更后 |
+| --- | --- |
+| `Client tests for <model> > <check>` | `Client tests > <check> > <model>` |
+
+`npm run test -- -t "<model>"` 仍可筛选出单个模型的测试，`uv run pytest -k "<model>"` 不受影响。

--- a/changelog/0.4.3/README.md
+++ b/changelog/0.4.3/README.md
@@ -1,0 +1,7 @@
+# 0.4.3
+
+[中文版](README.zh.md)
+
+- [2026-08-19] The e2e suites run one client per worker, so distinct models are tested in parallel. ([details](2026-08-19-parallel-e2e-suites.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))
+- [2026-08-19] The MiniMax routing branch moved into the client-type chain, after the Kimi branch. ([details](2026-08-19-minimax-routing-order.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))
+- [2026-08-18] Every streaming client skips the heartbeat events gateways inject on long generations instead of failing the stream. ([details](2026-08-18-gateway-heartbeats.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))

--- a/changelog/0.4.3/README.zh.md
+++ b/changelog/0.4.3/README.zh.md
@@ -1,0 +1,7 @@
+# 0.4.3
+
+[English](README.md)
+
+- [2026-08-19] e2e 测试套件按 client 分配到各自的 worker，不同模型并行测试。([详情](2026-08-19-parallel-e2e-suites.zh.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))
+- [2026-08-19] MiniMax 的路由分支移入 client type 判断链，排在 Kimi 分支之后。([详情](2026-08-19-minimax-routing-order.zh.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))
+- [2026-08-18] 所有流式 client 跳过网关在长生成期间注入的心跳事件，不再因此中断流。([详情](2026-08-18-gateway-heartbeats.zh.md), [#174](https://github.com/Prism-Shadow/agenthub/pull/174))

--- a/src_py/Makefile
+++ b/src_py/Makefile
@@ -14,4 +14,4 @@ build:
 
 test:
 	uv pip install -e .[dev]
-	uv run pytest -vvv tests
+	uv run pytest -vvv -n 16 --dist loadgroup tests

--- a/src_py/agenthub/ant_messages/client.py
+++ b/src_py/agenthub/ant_messages/client.py
@@ -300,7 +300,9 @@ class AntMessagesClient(LLMClient):
         elif ant_event_type == "message_stop":
             event_type = "stop"
 
-        elif ant_event_type in ["text", "thinking", "signature", "input_json"]:
+        elif ant_event_type in ["text", "thinking", "signature", "input_json", "ping"]:
+            # the SDK drops the "ping" heartbeat at the SSE layer; it reaches here only from
+            # gateways that relabel it onto another event
             event_type = "unused"
 
         else:

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -47,10 +47,6 @@ class AutoLLMClient(LLMClient):
     ) -> LLMClient:
         """Create the appropriate client for the given model."""
         client_type = (client_type or os.getenv("CLIENT_TYPE") or model).lower()
-        if client_type == "minimax-m3":
-            from .minimax_m3 import MiniMaxM3Client
-
-            return MiniMaxM3Client(model=model, api_key=api_key, base_url=base_url)
         # every Gemini generation shares the unified client ("gemini-3" also matches the
         # gemini-3.7/gemini-3.6/gemini-3.5-flash-lite client types)
         if any(
@@ -78,6 +74,10 @@ class AutoLLMClient(LLMClient):
             from .kimi_k3 import KimiK3Client
 
             return KimiK3Client(model=model, api_key=api_key, base_url=base_url)
+        elif client_type == "minimax-m3":
+            from .minimax_m3 import MiniMaxM3Client
+
+            return MiniMaxM3Client(model=model, api_key=api_key, base_url=base_url)
         elif "deepseek-v4" in client_type:
             from .deepseek_v4 import DeepSeekV4Client
 

--- a/src_py/agenthub/claude5/client.py
+++ b/src_py/agenthub/claude5/client.py
@@ -349,7 +349,9 @@ class Claude5Client(LLMClient):
         elif claude_event_type == "message_stop":
             event_type = "stop"
 
-        elif claude_event_type in ["text", "thinking", "signature", "input_json"]:
+        elif claude_event_type in ["text", "thinking", "signature", "input_json", "ping"]:
+            # the SDK drops the "ping" heartbeat at the SSE layer; it reaches here only from
+            # gateways that relabel it onto another event
             event_type = "unused"
 
         else:

--- a/src_py/agenthub/deepseek_v4/client.py
+++ b/src_py/agenthub/deepseek_v4/client.py
@@ -206,7 +206,9 @@ class DeepSeekV4Client(LLMClient):
         usage_metadata: UsageMetadata | None = None
         finish_reason: FinishReason | None = None
 
-        if len(model_output.choices) > 0:
+        # gateways inject content-free heartbeat chunks on long generations, whose choices
+        # the SDK leaves as None rather than an empty list
+        if model_output.choices:
             choice = model_output.choices[0]
             delta = choice.delta
 

--- a/src_py/agenthub/gemini3_7/client.py
+++ b/src_py/agenthub/gemini3_7/client.py
@@ -376,6 +376,11 @@ class Gemini3_7Client(LLMClient):
         usage_metadata: UsageMetadata | None = None
         finish_reason: FinishReason | None = None
 
+        if not model_output.candidates and not model_output.usage_metadata:
+            # gateways inject heartbeat chunks on long generations; they map to a chunk with
+            # neither candidates nor usage, so there is nothing to emit
+            event_type = "unused"
+
         if model_output.candidates:
             candidate = model_output.candidates[0]
             content = getattr(candidate, "content", None)
@@ -511,6 +516,9 @@ class Gemini3_7Client(LLMClient):
         )
         async for chunk in response_stream:
             event = self.transform_model_output_to_uni_event(chunk)
+            if event["event_type"] == "unused":
+                continue
+
             for item in event["content_items"]:
                 if item["type"] == "tool_call":
                     # gemini 3.7 does not support partial tool call, mock a partial tool call event

--- a/src_py/agenthub/glm5_3/client.py
+++ b/src_py/agenthub/glm5_3/client.py
@@ -239,7 +239,9 @@ class GLM5_3Client(LLMClient):
         usage_metadata: UsageMetadata | None = None
         finish_reason: FinishReason | None = None
 
-        if len(model_output.choices) > 0:
+        # gateways inject content-free heartbeat chunks on long generations, whose choices
+        # the SDK leaves as None rather than an empty list
+        if model_output.choices:
             choice = model_output.choices[0]
             delta = choice.delta
 

--- a/src_py/agenthub/gpt5_6/client.py
+++ b/src_py/agenthub/gpt5_6/client.py
@@ -301,6 +301,7 @@ class GPT5_6Client(LLMClient):
             "response.reasoning_text.done",
             "response.content_part.added",
             "response.content_part.done",
+            "keepalive",  # gateway heartbeat on long generations; carries no content
         ]:
             event_type = "unused"
 

--- a/src_py/agenthub/kimi_k3/client.py
+++ b/src_py/agenthub/kimi_k3/client.py
@@ -267,7 +267,9 @@ class KimiK3Client(LLMClient):
         usage_metadata: UsageMetadata | None = None
         finish_reason: FinishReason | None = None
 
-        if len(model_output.choices) > 0:
+        # gateways inject content-free heartbeat chunks on long generations, whose choices
+        # the SDK leaves as None rather than an empty list
+        if model_output.choices:
             choice = model_output.choices[0]
             delta = choice.delta
 

--- a/src_py/agenthub/minimax_m3/client.py
+++ b/src_py/agenthub/minimax_m3/client.py
@@ -248,6 +248,7 @@ class MiniMaxM3Client(LLMClient):
             "response.output_item.done",
             "response.content_part.added",
             "response.content_part.done",
+            "keepalive",  # gateway heartbeat on long generations; carries no content
         ):
             raise ValueError(f"Unknown output: {model_output}")
 

--- a/src_py/agenthub/openai_chat/client.py
+++ b/src_py/agenthub/openai_chat/client.py
@@ -220,7 +220,9 @@ class OpenaiChatClient(LLMClient):
         usage_metadata: UsageMetadata | None = None
         finish_reason: FinishReason | None = None
 
-        if len(model_output.choices) > 0:
+        # gateways inject content-free heartbeat chunks on long generations, whose choices
+        # the SDK leaves as None rather than an empty list
+        if model_output.choices:
             choice = model_output.choices[0]
             delta = choice.delta
 

--- a/src_py/agenthub/openai_responses/client.py
+++ b/src_py/agenthub/openai_responses/client.py
@@ -298,6 +298,7 @@ class OpenaiResponsesClient(LLMClient):
             "response.reasoning_summary_text.done",
             "response.content_part.added",
             "response.content_part.done",
+            "keepalive",  # gateway heartbeat on long generations; carries no content
         ):
             event_type = "unused"
 

--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.4.2"
+version = "0.4.3"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"
@@ -17,7 +17,7 @@ Repository = "https://github.com/Prism-Shadow/agenthub"
 Issues = "https://github.com/Prism-Shadow/agenthub/issues"
 
 [project.optional-dependencies]
-dev = ["httpx[socks]", "pytest>=8.4.2", "pytest-asyncio>=0.23.0", "ruff>=0.14.3", "pillow>=10.0.0"]
+dev = ["httpx[socks]", "pytest>=8.4.2", "pytest-asyncio>=0.23.0", "pytest-xdist>=3.6.0", "ruff>=0.14.3", "pillow>=10.0.0"]
 
 [build-system]
 requires = ["uv_build>=0.9.16,<0.10.0"]

--- a/src_py/tests/conftest.py
+++ b/src_py/tests/conftest.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Pin every test of one model to a single xdist worker.
+
+    Providers rate-limit per client, so under `-n <N> --dist loadgroup` distinct models run
+    in parallel while one model's tests stay serial on the worker that owns its group.
+    """
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        model = callspec.params.get("model") if callspec else None
+        if model is not None:
+            item.add_marker(pytest.mark.xdist_group(str(model)))

--- a/src_py/tests/test_keepalive_events.py
+++ b/src_py/tests/test_keepalive_events.py
@@ -1,0 +1,345 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from agenthub import AutoLLMClient
+
+
+@dataclass
+class StreamCase:
+    expected_client: str
+    model: str
+    client_type: str
+
+
+# Every client that parses the OpenAI Responses SSE shape.
+RESPONSES_STREAM_CASES = [
+    StreamCase(expected_client="GPT5_6Client", model="gpt-5.6", client_type="gpt-5.6"),
+    StreamCase(expected_client="OpenaiResponsesClient", model="gpt-5.6", client_type="openai-responses"),
+    StreamCase(expected_client="MiniMaxM3Client", model="minimax-m3", client_type="minimax-m3"),
+]
+
+# Every client that parses the OpenAI Chat Completions chunk shape.
+CHAT_STREAM_CASES = [
+    StreamCase(expected_client="OpenaiChatClient", model="gpt-5.6", client_type="openai-chat"),
+    StreamCase(expected_client="DeepSeekV4Client", model="deepseek-v4", client_type="deepseek-v4"),
+    StreamCase(expected_client="GLM5_3Client", model="glm-5.3", client_type="glm-5.3"),
+    StreamCase(expected_client="KimiK3Client", model="kimi-k3", client_type="kimi-k3"),
+]
+
+# Every client that parses the Anthropic Messages event shape.
+MESSAGES_STREAM_CASES = [
+    StreamCase(expected_client="Claude5Client", model="claude-sonnet-5", client_type="claude-sonnet-5"),
+    StreamCase(expected_client="AntMessagesClient", model="claude-sonnet-5", client_type="ant-messages"),
+]
+
+# Every client that parses the Gemini generateContent chunk shape.
+GEMINI_STREAM_CASES = [
+    StreamCase(expected_client="Gemini3_7Client", model="gemini-3.7-flash", client_type="gemini-3.7"),
+]
+
+MESSAGES = [{"role": "user", "content_items": [{"type": "text", "text": "Create a memo."}]}]
+
+
+def _create_auto_client(case: StreamCase) -> AutoLLMClient:
+    return AutoLLMClient(model=case.model, api_key="test-key", client_type=case.client_type)
+
+
+async def _stream_from_events(events: list[object]) -> AsyncIterator[object]:
+    for event in events:
+        yield event
+
+
+class _FakeCreateEndpoint:
+    """Stands in for an SDK endpoint whose create() returns a stream."""
+
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+
+    async def create(self, **_kwargs: object) -> AsyncIterator[object]:
+        return _stream_from_events(self._events)
+
+
+class _FakeGeminiModels:
+    def __init__(self, events: list[object]) -> None:
+        self._events = events
+
+    async def generate_content_stream(self, **_kwargs: object) -> AsyncIterator[object]:
+        return _stream_from_events(self._events)
+
+
+def _install_fake_responses_stream(client: AutoLLMClient, events: list[object]) -> None:
+    client._client._client = SimpleNamespace(responses=_FakeCreateEndpoint(events))  # noqa: SLF001
+
+
+def _install_fake_chat_stream(client: AutoLLMClient, events: list[object]) -> None:
+    client._client._client = SimpleNamespace(  # noqa: SLF001
+        base_url="https://api.test.invalid/v1",
+        chat=SimpleNamespace(completions=_FakeCreateEndpoint(events)),
+    )
+
+
+def _install_fake_messages_stream(client: AutoLLMClient, events: list[object]) -> None:
+    client._client._client = SimpleNamespace(  # noqa: SLF001
+        base_url="https://api.test.invalid",
+        beta=SimpleNamespace(messages=_FakeCreateEndpoint(events)),
+    )
+
+
+def _install_fake_gemini_stream(client: AutoLLMClient, events: list[object]) -> None:
+    client._client._client = SimpleNamespace(aio=SimpleNamespace(models=_FakeGeminiModels(events)))  # noqa: SLF001
+
+
+# Heartbeats come from gateways in front of the provider (one-api-style proxies), never from
+# the official APIs, so the event shapes below are synthesized from the report in
+# https://github.com/Prism-Shadow/penguin-harness/issues/286.
+def _responses_keepalive_event(sequence_number: int) -> object:
+    return SimpleNamespace(type="keepalive", sequence_number=sequence_number)
+
+
+def _responses_text_delta_event(text: str) -> object:
+    return SimpleNamespace(type="response.output_text.delta", delta=text)
+
+
+def _responses_completed_event() -> object:
+    return SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(
+            status="completed",
+            usage=SimpleNamespace(
+                input_tokens=2,
+                output_tokens=3,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+                output_tokens_details=SimpleNamespace(reasoning_tokens=1),
+            ),
+        ),
+    )
+
+
+def _chat_keepalive_chunk(sequence_number: int) -> object:
+    # A heartbeat is not a Chat Completions chunk, so the SDK's lenient parsing leaves every
+    # field it declares unset: choices arrives as None rather than an empty list.
+    return SimpleNamespace(type="keepalive", sequence_number=sequence_number, choices=None, usage=None)
+
+
+def _chat_text_chunk(text: str) -> object:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content=text, tool_calls=None, reasoning_content=None),
+                finish_reason=None,
+            )
+        ],
+        usage=None,
+    )
+
+
+def _chat_stop_chunk() -> object:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content=None, tool_calls=None), finish_reason="stop")],
+        usage=SimpleNamespace(
+            prompt_tokens=2,
+            completion_tokens=3,
+            prompt_tokens_details=None,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=1),
+            prompt_cache_hit_tokens=0,
+            prompt_cache_miss_tokens=2,
+        ),
+    )
+
+
+def _messages_ping_event() -> object:
+    return SimpleNamespace(type="ping")
+
+
+def _messages_start_event() -> object:
+    return SimpleNamespace(
+        type="message_start",
+        message=SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=2, cache_creation_input_tokens=0, cache_read_input_tokens=0)
+        ),
+    )
+
+
+def _messages_text_delta_event(text: str) -> object:
+    return SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(type="text_delta", text=text))
+
+
+def _messages_stop_event() -> object:
+    return SimpleNamespace(
+        type="message_delta",
+        delta=SimpleNamespace(stop_reason="end_turn"),
+        usage=SimpleNamespace(
+            input_tokens=2,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            output_tokens=3,
+            output_tokens_details=None,
+        ),
+    )
+
+
+def _gemini_keepalive_chunk() -> object:
+    # The SDK maps only the fields it knows onto the response, so a heartbeat reaches the
+    # client as a chunk carrying neither candidates nor usage.
+    return SimpleNamespace(candidates=None, usage_metadata=None)
+
+
+def _gemini_text_chunk(text: str) -> object:
+    part = SimpleNamespace(function_call=None, thought=None, text=text, inline_data=None, thought_signature=None)
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[part]), finish_reason=None)],
+        usage_metadata=None,
+    )
+
+
+def _gemini_stop_chunk() -> object:
+    return SimpleNamespace(
+        # FinishReason is a string enum, so the raw value keys the client's mapping
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]), finish_reason="STOP")],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=2,
+            cached_content_token_count=0,
+            thoughts_token_count=1,
+            candidates_token_count=3,
+        ),
+    )
+
+
+def _collected_texts(events: list[dict]) -> list[str]:
+    return [item["text"] for event in events for item in event["content_items"] if item["type"] == "text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", RESPONSES_STREAM_CASES, ids=[case.client_type for case in RESPONSES_STREAM_CASES])
+async def test_responses_clients_skip_keepalive_heartbeats(case: StreamCase):
+    client = _create_auto_client(case)
+    assert type(client._client).__name__ == case.expected_client  # noqa: SLF001
+    _install_fake_responses_stream(
+        client,
+        [
+            _responses_keepalive_event(1),
+            _responses_text_delta_event("Here is"),
+            _responses_keepalive_event(2),
+            _responses_text_delta_event(" the memo."),
+            _responses_completed_event(),
+            _responses_keepalive_event(3),
+        ],
+    )
+
+    events = [event async for event in client.streaming_response(MESSAGES, {})]
+    assert _collected_texts(events) == ["Here is", " the memo."]
+    assert events[-1]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", RESPONSES_STREAM_CASES, ids=[case.client_type for case in RESPONSES_STREAM_CASES])
+async def test_responses_clients_still_reject_unknown_events(case: StreamCase):
+    client = _create_auto_client(case)
+    _install_fake_responses_stream(
+        client,
+        [SimpleNamespace(type="response.mystery_event"), _responses_completed_event()],
+    )
+
+    with pytest.raises(ValueError, match="Unknown output"):
+        async for _event in client.streaming_response(MESSAGES, {}):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", CHAT_STREAM_CASES, ids=[case.client_type for case in CHAT_STREAM_CASES])
+async def test_chat_clients_skip_keepalive_heartbeats(case: StreamCase):
+    client = _create_auto_client(case)
+    assert type(client._client).__name__ == case.expected_client  # noqa: SLF001
+    _install_fake_chat_stream(
+        client,
+        [
+            _chat_keepalive_chunk(1),
+            _chat_text_chunk("Here is"),
+            _chat_keepalive_chunk(2),
+            _chat_text_chunk(" the memo."),
+            _chat_stop_chunk(),
+            _chat_keepalive_chunk(3),
+        ],
+    )
+
+    events = [event async for event in client.streaming_response(MESSAGES, {})]
+    assert _collected_texts(events) == ["Here is", " the memo."]
+    assert events[-1]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", MESSAGES_STREAM_CASES, ids=[case.client_type for case in MESSAGES_STREAM_CASES])
+async def test_messages_clients_skip_ping_heartbeats(case: StreamCase):
+    client = _create_auto_client(case)
+    assert type(client._client).__name__ == case.expected_client  # noqa: SLF001
+    _install_fake_messages_stream(
+        client,
+        [
+            _messages_ping_event(),
+            _messages_start_event(),
+            _messages_text_delta_event("Here is"),
+            _messages_ping_event(),
+            _messages_text_delta_event(" the memo."),
+            _messages_stop_event(),
+            _messages_ping_event(),
+        ],
+    )
+
+    events = [event async for event in client.streaming_response(MESSAGES, {})]
+    assert _collected_texts(events) == ["Here is", " the memo."]
+    assert events[-1]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", MESSAGES_STREAM_CASES, ids=[case.client_type for case in MESSAGES_STREAM_CASES])
+async def test_messages_clients_still_reject_unknown_events(case: StreamCase):
+    client = _create_auto_client(case)
+    _install_fake_messages_stream(
+        client,
+        [_messages_start_event(), SimpleNamespace(type="mystery_event"), _messages_stop_event()],
+    )
+
+    with pytest.raises(ValueError, match="Unknown output"):
+        async for _event in client.streaming_response(MESSAGES, {}):
+            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", GEMINI_STREAM_CASES, ids=[case.client_type for case in GEMINI_STREAM_CASES])
+async def test_gemini_client_skips_keepalive_heartbeats(case: StreamCase):
+    client = _create_auto_client(case)
+    assert type(client._client).__name__ == case.expected_client  # noqa: SLF001
+    _install_fake_gemini_stream(
+        client,
+        [
+            _gemini_keepalive_chunk(),
+            _gemini_text_chunk("Here is"),
+            _gemini_keepalive_chunk(),
+            _gemini_text_chunk(" the memo."),
+            _gemini_stop_chunk(),
+            _gemini_keepalive_chunk(),
+        ],
+    )
+
+    events = [event async for event in client.streaming_response(MESSAGES, {})]
+    assert _collected_texts(events) == ["Here is", " the memo."]
+    # a heartbeat must not surface as an empty event of its own
+    assert len(events) == 3
+    assert events[-1]["finish_reason"] == "stop"

--- a/src_ts/jest.config.js
+++ b/src_ts/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  // the e2e suite runs one concurrent test per model, so the cap has to clear the
+  // model count rather than the default 5
+  maxConcurrency: 64,
 };

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",
@@ -24,6 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^9.0.0",
+        "gaxios": "^7.1.3",
         "jest": "^30.2.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.6",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
+    "gaxios": "^7.1.3",
     "jest": "^30.2.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.6",

--- a/src_ts/src/ant_messages/client.ts
+++ b/src_ts/src/ant_messages/client.ts
@@ -386,8 +386,12 @@ export class AntMessagesClient extends LLMClient {
     } else if (antEventType === "message_stop") {
       eventType = "stop";
     } else if (
-      ["text", "thinking", "signature", "input_json"].includes(antEventType)
+      ["text", "thinking", "signature", "input_json", "ping"].includes(
+        antEventType,
+      )
     ) {
+      // the SDK drops the "ping" heartbeat at the SSE layer; it reaches here only
+      // from gateways that relabel it onto another event
       eventType = "unused";
     } else {
       throw new Error(`Unknown output: ${JSON.stringify(modelOutput)}`);

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -73,9 +73,6 @@ export class AutoLLMClient extends LLMClient {
   ): LLMClient {
     clientType = (clientType || process.env.CLIENT_TYPE || model).toLowerCase();
 
-    if (clientType === "minimax-m3") {
-      return new MiniMaxM3Client({ model, apiKey, baseUrl });
-    }
     // every Gemini generation shares the unified client ("gemini-3" also matches the
     // gemini-3.7/gemini-3.6/gemini-3.5-flash-lite client types)
     if (
@@ -108,6 +105,8 @@ export class AutoLLMClient extends LLMClient {
     ) {
       // the whole Kimi K2.5+ series shares the unified client
       return new KimiK3Client({ model, apiKey, baseUrl });
+    } else if (clientType === "minimax-m3") {
+      return new MiniMaxM3Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("deepseek-v4")) {
       return new DeepSeekV4Client({ model, apiKey, baseUrl });
     } else if (clientType.includes("ant-messages")) {

--- a/src_ts/src/claude5/client.ts
+++ b/src_ts/src/claude5/client.ts
@@ -450,8 +450,12 @@ export class Claude5Client extends LLMClient {
     } else if (claudeEventType === "message_stop") {
       eventType = "stop";
     } else if (
-      ["text", "thinking", "signature", "input_json"].includes(claudeEventType)
+      ["text", "thinking", "signature", "input_json", "ping"].includes(
+        claudeEventType,
+      )
     ) {
+      // the SDK drops the "ping" heartbeat at the SSE layer; it reaches here only
+      // from gateways that relabel it onto another event
       eventType = "unused";
     } else {
       throw new Error(`Unknown output: ${JSON.stringify(modelOutput)}`);

--- a/src_ts/src/deepseek_v4/client.ts
+++ b/src_ts/src/deepseek_v4/client.ts
@@ -244,7 +244,9 @@ export class DeepSeekV4Client extends LLMClient {
     let usageMetadata: UsageMetadata | null = null;
     let finishReason: FinishReason | null = null;
 
-    if (modelOutput.choices.length > 0) {
+    // gateways inject content-free heartbeat chunks on long generations, whose
+    // choices arrive as undefined rather than an empty list
+    if (modelOutput.choices?.length) {
       const choice = modelOutput.choices[0];
       const delta = choice?.delta;
 

--- a/src_ts/src/gemini3_7/client.ts
+++ b/src_ts/src/gemini3_7/client.ts
@@ -551,6 +551,12 @@ export class Gemini3_7Client extends LLMClient {
     let usageMetadata: UsageMetadata | null = null;
     let finishReason: FinishReason | null = null;
 
+    if (!modelOutput.candidates?.length && !modelOutput.usageMetadata) {
+      // gateways inject heartbeat chunks on long generations; they map to a chunk
+      // with neither candidates nor usage, so there is nothing to emit
+      eventType = "unused";
+    }
+
     if (
       modelOutput.candidates?.length !== undefined &&
       modelOutput.candidates?.length > 0
@@ -721,6 +727,10 @@ export class Gemini3_7Client extends LLMClient {
 
     for await (const chunk of responseStream) {
       const event = this.transformModelOutputToUniEvent(chunk);
+      if (event.event_type === "unused") {
+        continue;
+      }
+
       for (const item of event.content_items) {
         if (item.type === "tool_call") {
           // gemini 3.7 does not support partial tool call, mock a partial tool call event

--- a/src_ts/src/glm5_3/client.ts
+++ b/src_ts/src/glm5_3/client.ts
@@ -311,7 +311,9 @@ export class GLM5_3Client extends LLMClient {
     let usageMetadata: UsageMetadata | null = null;
     let finishReason: FinishReason | null = null;
 
-    if (modelOutput.choices.length > 0) {
+    // gateways inject content-free heartbeat chunks on long generations, whose
+    // choices arrive as undefined rather than an empty list
+    if (modelOutput.choices?.length) {
       const choice = modelOutput.choices[0];
       const delta = choice?.delta;
 

--- a/src_ts/src/gpt5_6/client.ts
+++ b/src_ts/src/gpt5_6/client.ts
@@ -389,6 +389,8 @@ export class GPT5_6Client extends LLMClient {
         "response.reasoning_text.done",
         "response.content_part.added",
         "response.content_part.done",
+        // gateway heartbeat on long generations; carries no content
+        "keepalive",
       ].includes(openaiEventType)
     ) {
       eventType = "unused";

--- a/src_ts/src/kimi_k3/client.ts
+++ b/src_ts/src/kimi_k3/client.ts
@@ -376,7 +376,9 @@ export class KimiK3Client extends LLMClient {
     let usageMetadata: UsageMetadata | null = null;
     let finishReason: FinishReason | null = null;
 
-    if (modelOutput.choices.length > 0) {
+    // gateways inject content-free heartbeat chunks on long generations, whose
+    // choices arrive as undefined rather than an empty list
+    if (modelOutput.choices?.length) {
       const choice = modelOutput.choices[0];
       const delta = choice?.delta;
 

--- a/src_ts/src/minimax_m3/client.ts
+++ b/src_ts/src/minimax_m3/client.ts
@@ -298,6 +298,8 @@ export class MiniMaxM3Client extends LLMClient {
         "response.output_item.done",
         "response.content_part.added",
         "response.content_part.done",
+        // gateway heartbeat on long generations; carries no content
+        "keepalive",
       ].includes(minimaxEventType)
     ) {
       throw new Error(`Unknown output: ${JSON.stringify(modelOutput)}`);

--- a/src_ts/src/openai_chat/client.ts
+++ b/src_ts/src/openai_chat/client.ts
@@ -302,7 +302,9 @@ export class OpenaiChatClient extends LLMClient {
     let usageMetadata: UsageMetadata | null = null;
     let finishReason: FinishReason | null = null;
 
-    if (modelOutput.choices.length > 0) {
+    // gateways inject content-free heartbeat chunks on long generations, whose
+    // choices arrive as undefined rather than an empty list
+    if (modelOutput.choices?.length) {
       const choice = modelOutput.choices[0];
       const delta = choice?.delta;
 

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -386,6 +386,8 @@ export class OpenaiResponsesClient extends LLMClient {
         "response.reasoning_summary_text.done",
         "response.content_part.added",
         "response.content_part.done",
+        // gateway heartbeat on long generations; carries no content
+        "keepalive",
       ].includes(openaiEventType)
     ) {
       eventType = "unused";

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -15,7 +15,8 @@
 import { AutoLLMClient } from "../src/autoClient";
 import { listSupportedModels } from "../src/registry";
 import { ThinkingLevel, UniMessage, UniConfig, UniEvent } from "../src/types";
-import { expect, describe, test } from "@jest/globals";
+import { beforeAll, expect, describe, test } from "@jest/globals";
+import { Gaxios } from "gaxios";
 
 const IMAGE =
   "https://cdn.britannica.com/80/120980-050-D1DA5C61/Poet-narcissus.jpg";
@@ -45,7 +46,6 @@ interface Model {
 const AVAILABLE_MODELS: Model[] = [];
 
 if (process.env.GEMINI_API_KEY) {
-
   AVAILABLE_MODELS.push({
     name: "gemini-3.7-flash",
     supportTextGeneration: true,
@@ -55,7 +55,6 @@ if (process.env.GEMINI_API_KEY) {
     supportEmbedding: false,
     provider: "official",
   });
-
 
   AVAILABLE_MODELS.push({
     name: "gemini-3.1-flash-image",
@@ -501,16 +500,52 @@ function checkEventIntegrity(event: UniEvent): void {
   }
 }
 
+const MODEL_CASES = AVAILABLE_MODELS.map((m): [string, Model] => [
+  m.clientType
+    ? `${m.name}:${m.provider}:${m.clientType}`
+    : `${m.name}:${m.provider}`,
+  m,
+]);
+
+/**
+ * Declare one check across every available model.
+ *
+ * Each check becomes its own describe block, and jest-circus runs describe blocks one
+ * after another, so a single model never has two checks in flight — providers rate-limit
+ * per client. Inside a block the models run concurrently, which is the wall-clock saving.
+ */
+function modelTest(
+  name: string,
+  // ahead of the body so Prettier keeps the body hugged against the call
+  timeout: number,
+  body: (model: Model) => void | Promise<void>,
+): void {
+  describe(name, () => {
+    test.concurrent.each(MODEL_CASES)(
+      "%s",
+      async (_caseName, model) => {
+        await body(model);
+      },
+      timeout,
+    );
+  });
+}
+
 if (AVAILABLE_MODELS.length > 0) {
-  describe.each(
-    AVAILABLE_MODELS.map((m): [string, Model] => [
-      m.clientType
-        ? `${m.name}:${m.provider}:${m.clientType}`
-        : `${m.name}:${m.provider}`,
-      m,
-    ]),
-  )("Client tests for %s", (_name, model: Model) => {
-    test("should stream basic response", async () => {
+  describe("Client tests", () => {
+    beforeAll(async () => {
+      // gaxios, the transport behind Vertex service-account auth, `import()`s node-fetch
+      // on its first request and caches it on the class. Jest keeps one
+      // `isInsideTestCode` flag for the whole runtime and clears it the moment any
+      // concurrent sibling finishes, after which a dynamic import throws
+      // "trying to `import` a file outside of the scope of the test code". Priming the
+      // cache from a hook, where the flag is set, keeps that import out of the tests.
+      await new Gaxios()
+        .request({ url: "http://127.0.0.1:1/" })
+        .catch(() => {});
+    });
+
+    modelTest("should stream basic response", 60000, async (model) => {
       if (!model.supportTextGeneration) {
         return;
       }
@@ -537,42 +572,46 @@ if (AVAILABLE_MODELS.length > 0) {
       }
 
       expect(text).toContain("5");
-    }, 60000);
+    });
 
-    test("should stream response with all parameters", async () => {
-      if (!model.supportTextGeneration) {
-        return;
-      }
-      const client = createClient(model);
-      const messages: UniMessage[] = [
-        {
-          role: "user",
-          content_items: [{ type: "text", text: "What is 2+3?" }],
-        },
-      ];
-      const config: UniConfig = {
-        max_tokens: 8192,
-        thinking_summary: true,
-        thinking_level: ThinkingLevel.LOW,
-      };
+    modelTest(
+      "should stream response with all parameters",
+      60000,
+      async (model) => {
+        if (!model.supportTextGeneration) {
+          return;
+        }
+        const client = createClient(model);
+        const messages: UniMessage[] = [
+          {
+            role: "user",
+            content_items: [{ type: "text", text: "What is 2+3?" }],
+          },
+        ];
+        const config: UniConfig = {
+          max_tokens: 8192,
+          thinking_summary: true,
+          thinking_level: ThinkingLevel.LOW,
+        };
 
-      let text = "";
-      for await (const event of client.streamingResponse({
-        messages,
-        config,
-      })) {
-        checkEventIntegrity(event);
-        for (const item of event.content_items) {
-          if (item.type === "text") {
-            text += item.text;
+        let text = "";
+        for await (const event of client.streamingResponse({
+          messages,
+          config,
+        })) {
+          checkEventIntegrity(event);
+          for (const item of event.content_items) {
+            if (item.type === "text") {
+              text += item.text;
+            }
           }
         }
-      }
 
-      expect(text).toContain("5");
-    }, 60000);
+        expect(text).toContain("5");
+      },
+    );
 
-    test("should handle stateful streaming", async () => {
+    modelTest("should handle stateful streaming", 60000, async (model) => {
       if (!model.supportTextGeneration) {
         return;
       }
@@ -611,9 +650,9 @@ if (AVAILABLE_MODELS.length > 0) {
 
       expect(text.toLowerCase()).toContain("alice");
       expect(client.getHistory().length).toBe(4);
-    }, 60000);
+    });
 
-    test("should set history", () => {
+    modelTest("should set history", 5000, (model) => {
       const client = createClient(model);
       const newHistory: UniMessage[] = [
         { role: "user", content_items: [{ type: "text", text: "Hi" }] },
@@ -631,7 +670,7 @@ if (AVAILABLE_MODELS.length > 0) {
       expect(client.getHistory().length).toBe(2);
     });
 
-    test("should clear history", async () => {
+    modelTest("should clear history", 5000, async (model) => {
       const client = createClient(model);
       const newHistory: UniMessage[] = [
         { role: "user", content_items: [{ type: "text", text: "Hi" }] },
@@ -648,7 +687,7 @@ if (AVAILABLE_MODELS.length > 0) {
       expect(client.getHistory().length).toBe(0);
     });
 
-    test("should concatenate events to message", async () => {
+    modelTest("should concatenate events to message", 60000, async (model) => {
       if (!model.supportTextGeneration) {
         return;
       }
@@ -688,9 +727,9 @@ if (AVAILABLE_MODELS.length > 0) {
         .map((item) => (item as { type: "text"; text: string }).text)
         .join("");
       expect(allText).toBe(text);
-    }, 60000);
+    });
 
-    test("should handle tool use", async () => {
+    modelTest("should handle tool use", 60000, async (model) => {
       if (!model.supportTextGeneration) {
         return;
       }
@@ -784,9 +823,9 @@ if (AVAILABLE_MODELS.length > 0) {
       }
 
       expect(text).toContain("20");
-    }, 60000);
+    });
 
-    test("should handle system prompt", async () => {
+    modelTest("should handle system prompt", 60000, async (model) => {
       if (!model.supportTextGeneration) {
         return;
       }
@@ -817,9 +856,9 @@ if (AVAILABLE_MODELS.length > 0) {
       }
 
       expect(text.toLowerCase()).toContain("meow");
-    }, 60000);
+    });
 
-    test("should handle image understanding", async () => {
+    modelTest("should handle image understanding", 60000, async (model) => {
       if (!model.supportImageUnderstanding) {
         return;
       }
@@ -855,55 +894,61 @@ if (AVAILABLE_MODELS.length > 0) {
       expect(
         IMAGE_KEYWORDS.some((keyword) => text.toLowerCase().includes(keyword)),
       ).toBe(true);
-    }, 60000);
+    });
 
-    test("should handle base64 encoded image understanding", async () => {
-      if (!model.supportImageUnderstanding) {
-        return;
-      }
+    modelTest(
+      "should handle base64 encoded image understanding",
+      60000,
+      async (model) => {
+        if (!model.supportImageUnderstanding) {
+          return;
+        }
 
-      const client = createClient(model);
-      const config: UniConfig = {};
+        const client = createClient(model);
+        const config: UniConfig = {};
 
-      const mimeType = "image/jpeg";
-      const response = await fetch(IMAGE);
-      const imageBuffer = await response.arrayBuffer();
-      const base64Image = Buffer.from(imageBuffer).toString("base64");
+        const mimeType = "image/jpeg";
+        const response = await fetch(IMAGE);
+        const imageBuffer = await response.arrayBuffer();
+        const base64Image = Buffer.from(imageBuffer).toString("base64");
 
-      const dataUri = `data:${mimeType};base64,${base64Image}`;
+        const dataUri = `data:${mimeType};base64,${base64Image}`;
 
-      const messages: UniMessage[] = [
-        {
-          role: "user",
-          content_items: [
-            {
-              type: "text",
-              text: "What's in this image? Describe it briefly.",
-            },
-            { type: "image_url", image_url: dataUri },
-          ],
-        },
-      ];
+        const messages: UniMessage[] = [
+          {
+            role: "user",
+            content_items: [
+              {
+                type: "text",
+                text: "What's in this image? Describe it briefly.",
+              },
+              { type: "image_url", image_url: dataUri },
+            ],
+          },
+        ];
 
-      let text = "";
-      for await (const event of client.streamingResponse({
-        messages,
-        config,
-      })) {
-        checkEventIntegrity(event);
-        for (const item of event.content_items) {
-          if (item.type === "text") {
-            text += item.text;
+        let text = "";
+        for await (const event of client.streamingResponse({
+          messages,
+          config,
+        })) {
+          checkEventIntegrity(event);
+          for (const item of event.content_items) {
+            if (item.type === "text") {
+              text += item.text;
+            }
           }
         }
-      }
 
-      expect(
-        IMAGE_KEYWORDS.some((keyword) => text.toLowerCase().includes(keyword)),
-      ).toBe(true);
-    }, 60000);
+        expect(
+          IMAGE_KEYWORDS.some((keyword) =>
+            text.toLowerCase().includes(keyword),
+          ),
+        ).toBe(true);
+      },
+    );
 
-    test("should handle tool result with image", async () => {
+    modelTest("should handle tool result with image", 60000, async (model) => {
       if (!model.supportImageUnderstanding) {
         return;
       }
@@ -981,9 +1026,9 @@ if (AVAILABLE_MODELS.length > 0) {
       expect(
         IMAGE_KEYWORDS.some((keyword) => text.toLowerCase().includes(keyword)),
       ).toBe(true);
-    }, 60000);
+    });
 
-    test("should handle image generation", async () => {
+    modelTest("should handle image generation", 180000, async (model) => {
       if (!model.supportImageGeneration) {
         return;
       }
@@ -1021,9 +1066,9 @@ if (AVAILABLE_MODELS.length > 0) {
         inlineItems.some((item) => item.mime_type.startsWith("image/")),
       ).toBe(true);
       expect(inlineItems.every((item) => item.data.length > 0)).toBe(true);
-    }, 180000);
+    });
 
-    test("should handle tts generation", async () => {
+    modelTest("should handle tts generation", 180000, async (model) => {
       if (!model.supportAudioGeneration) {
         return;
       }
@@ -1066,9 +1111,9 @@ if (AVAILABLE_MODELS.length > 0) {
         ),
       ).toBe(true);
       expect(inlineItems.every((item) => item.data.length > 0)).toBe(true);
-    }, 180000);
+    });
 
-    test("should stream text embeddings", async () => {
+    modelTest("should stream text embeddings", 60000, async (model) => {
       if (!model.supportEmbedding) {
         return;
       }
@@ -1105,7 +1150,7 @@ if (AVAILABLE_MODELS.length > 0) {
         expect(item.embedding.length).toBe(768);
         expect(item.embedding.every((v) => typeof v === "number")).toBe(true);
       }
-    }, 60000);
+    });
   });
 }
 

--- a/src_ts/tests/keepalive-events.test.ts
+++ b/src_ts/tests/keepalive-events.test.ts
@@ -1,0 +1,428 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, describe, test } from "@jest/globals";
+import {
+  AutoLLMClient,
+  TextContentItem,
+  UniConfig,
+  UniEvent,
+  UniMessage,
+} from "../src";
+
+type StreamClient = {
+  streamingResponse(options: {
+    messages: UniMessage[];
+    config: UniConfig;
+  }): AsyncIterable<UniEvent>;
+};
+
+interface StreamCase {
+  expectedClient: string;
+  model: string;
+  clientType: string;
+}
+
+// Every client that parses the OpenAI Responses SSE shape.
+const RESPONSES_STREAM_CASES: StreamCase[] = [
+  {
+    expectedClient: "GPT5_6Client",
+    model: "gpt-5.6",
+    clientType: "gpt-5.6",
+  },
+  {
+    expectedClient: "OpenaiResponsesClient",
+    model: "gpt-5.6",
+    clientType: "openai-responses",
+  },
+  {
+    expectedClient: "MiniMaxM3Client",
+    model: "minimax-m3",
+    clientType: "minimax-m3",
+  },
+];
+
+// Every client that parses the OpenAI Chat Completions chunk shape.
+const CHAT_STREAM_CASES: StreamCase[] = [
+  {
+    expectedClient: "OpenaiChatClient",
+    model: "gpt-5.6",
+    clientType: "openai-chat",
+  },
+  {
+    expectedClient: "DeepSeekV4Client",
+    model: "deepseek-v4",
+    clientType: "deepseek-v4",
+  },
+  {
+    expectedClient: "GLM5_3Client",
+    model: "glm-5.3",
+    clientType: "glm-5.3",
+  },
+  {
+    expectedClient: "KimiK3Client",
+    model: "kimi-k3",
+    clientType: "kimi-k3",
+  },
+];
+
+// Every client that parses the Anthropic Messages event shape.
+const MESSAGES_STREAM_CASES: StreamCase[] = [
+  {
+    expectedClient: "Claude5Client",
+    model: "claude-sonnet-5",
+    clientType: "claude-sonnet-5",
+  },
+  {
+    expectedClient: "AntMessagesClient",
+    model: "claude-sonnet-5",
+    clientType: "ant-messages",
+  },
+];
+
+// Every client that parses the Gemini generateContent chunk shape.
+const GEMINI_STREAM_CASES: StreamCase[] = [
+  {
+    expectedClient: "Gemini3_7Client",
+    model: "gemini-3.7-flash",
+    clientType: "gemini-3.7",
+  },
+];
+
+const messages: UniMessage[] = [
+  {
+    role: "user",
+    content_items: [{ type: "text", text: "Create a memo." }],
+  },
+];
+
+function streamFromEvents(events: unknown[]): AsyncIterable<unknown> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+function installFakeStream(client: StreamClient, fakeClient: unknown): void {
+  const routedClient = (client as unknown as { _client: { _client: unknown } })
+    ._client;
+  routedClient._client = fakeClient;
+}
+
+function installFakeResponsesStream(
+  client: StreamClient,
+  events: unknown[],
+): void {
+  installFakeStream(client, {
+    responses: { create: async () => streamFromEvents(events) },
+  });
+}
+
+function installFakeChatStream(client: StreamClient, events: unknown[]): void {
+  installFakeStream(client, {
+    baseURL: "https://api.test.invalid/v1",
+    chat: {
+      completions: { create: async () => streamFromEvents(events) },
+    },
+  });
+}
+
+function installFakeMessagesStream(
+  client: StreamClient,
+  events: unknown[],
+): void {
+  installFakeStream(client, {
+    baseURL: "https://api.test.invalid",
+    beta: { messages: { create: async () => streamFromEvents(events) } },
+  });
+}
+
+function installFakeGeminiStream(
+  client: StreamClient,
+  events: unknown[],
+): void {
+  installFakeStream(client, {
+    models: { generateContentStream: async () => streamFromEvents(events) },
+  });
+}
+
+function routedClientName(client: StreamClient): string {
+  return (client as unknown as { _client: object })._client.constructor.name;
+}
+
+function createAutoClient(testCase: StreamCase): AutoLLMClient {
+  return new AutoLLMClient({
+    model: testCase.model,
+    apiKey: "test-key",
+    clientType: testCase.clientType,
+  });
+}
+
+// Heartbeats come from gateways in front of the provider (one-api-style proxies), never
+// from the official APIs, so the event shapes below are synthesized from the report in
+// https://github.com/Prism-Shadow/penguin-harness/issues/286.
+function responsesKeepaliveEvent(sequenceNumber: number): unknown {
+  return { type: "keepalive", sequence_number: sequenceNumber };
+}
+
+function responsesTextDeltaEvent(text: string): unknown {
+  return { type: "response.output_text.delta", delta: text };
+}
+
+function responsesCompletedEvent(): unknown {
+  return {
+    type: "response.completed",
+    response: {
+      status: "completed",
+      usage: {
+        input_tokens: 2,
+        output_tokens: 3,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 1 },
+      },
+    },
+  };
+}
+
+function chatKeepaliveChunk(sequenceNumber: number): unknown {
+  // A heartbeat is not a Chat Completions chunk, so the fields the client reads are
+  // simply absent: choices arrives as undefined rather than an empty list.
+  return { type: "keepalive", sequence_number: sequenceNumber };
+}
+
+function chatTextChunk(text: string): unknown {
+  return {
+    choices: [{ delta: { content: text }, finish_reason: null }],
+  };
+}
+
+function chatStopChunk(): unknown {
+  return {
+    choices: [{ delta: {}, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: 2,
+      completion_tokens: 3,
+      completion_tokens_details: { reasoning_tokens: 1 },
+      prompt_cache_hit_tokens: 0,
+      prompt_cache_miss_tokens: 2,
+    },
+  };
+}
+
+function messagesPingEvent(): unknown {
+  return { type: "ping" };
+}
+
+function messagesStartEvent(): unknown {
+  return {
+    type: "message_start",
+    message: {
+      usage: {
+        input_tokens: 2,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  };
+}
+
+function messagesTextDeltaEvent(text: string): unknown {
+  return {
+    type: "content_block_delta",
+    delta: { type: "text_delta", text: text },
+  };
+}
+
+function messagesStopEvent(): unknown {
+  return {
+    type: "message_delta",
+    delta: { stop_reason: "end_turn" },
+    usage: {
+      input_tokens: 2,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      output_tokens: 3,
+    },
+  };
+}
+
+function geminiKeepaliveChunk(): unknown {
+  // The SDK maps only the fields it knows onto the response, so a heartbeat reaches the
+  // client as a chunk carrying neither candidates nor usage.
+  return {};
+}
+
+function geminiTextChunk(text: string): unknown {
+  return {
+    candidates: [{ content: { parts: [{ text: text }] }, finishReason: null }],
+  };
+}
+
+function geminiStopChunk(): unknown {
+  return {
+    // FinishReason is a string enum, so the raw value keys the client's mapping
+    candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+    usageMetadata: {
+      promptTokenCount: 2,
+      cachedContentTokenCount: 0,
+      thoughtsTokenCount: 1,
+      candidatesTokenCount: 3,
+    },
+  };
+}
+
+async function collectEvents(
+  stream: AsyncIterable<UniEvent>,
+): Promise<UniEvent[]> {
+  const events: UniEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+function collectedTexts(events: UniEvent[]): string[] {
+  return events.flatMap((event) =>
+    event.content_items
+      .filter((item): item is TextContentItem => item.type === "text")
+      .map((item) => item.text),
+  );
+}
+
+describe.each(RESPONSES_STREAM_CASES)(
+  "Keepalive handling for $clientType",
+  (testCase) => {
+    test("skips gateway keepalive heartbeats between stream events", async () => {
+      const client = createAutoClient(testCase);
+      expect(routedClientName(client)).toBe(testCase.expectedClient);
+      installFakeResponsesStream(client, [
+        responsesKeepaliveEvent(1),
+        responsesTextDeltaEvent("Here is"),
+        responsesKeepaliveEvent(2),
+        responsesTextDeltaEvent(" the memo."),
+        responsesCompletedEvent(),
+        responsesKeepaliveEvent(3),
+      ]);
+
+      const events = await collectEvents(
+        client.streamingResponse({ messages, config: {} }),
+      );
+      expect(collectedTexts(events)).toEqual(["Here is", " the memo."]);
+      expect(events[events.length - 1].finish_reason).toBe("stop");
+    });
+
+    test("still rejects genuinely unknown events", async () => {
+      const client = createAutoClient(testCase);
+      installFakeResponsesStream(client, [
+        { type: "response.mystery_event" },
+        responsesCompletedEvent(),
+      ]);
+
+      await expect(
+        collectEvents(client.streamingResponse({ messages, config: {} })),
+      ).rejects.toThrow("Unknown output");
+    });
+  },
+);
+
+describe.each(CHAT_STREAM_CASES)(
+  "Keepalive handling for $clientType",
+  (testCase) => {
+    test("skips gateway keepalive heartbeats between stream chunks", async () => {
+      const client = createAutoClient(testCase);
+      expect(routedClientName(client)).toBe(testCase.expectedClient);
+      installFakeChatStream(client, [
+        chatKeepaliveChunk(1),
+        chatTextChunk("Here is"),
+        chatKeepaliveChunk(2),
+        chatTextChunk(" the memo."),
+        chatStopChunk(),
+        chatKeepaliveChunk(3),
+      ]);
+
+      const events = await collectEvents(
+        client.streamingResponse({ messages, config: {} }),
+      );
+      expect(collectedTexts(events)).toEqual(["Here is", " the memo."]);
+      expect(events[events.length - 1].finish_reason).toBe("stop");
+    });
+  },
+);
+
+describe.each(MESSAGES_STREAM_CASES)(
+  "Keepalive handling for $clientType",
+  (testCase) => {
+    test("skips gateway ping heartbeats between stream events", async () => {
+      const client = createAutoClient(testCase);
+      expect(routedClientName(client)).toBe(testCase.expectedClient);
+      installFakeMessagesStream(client, [
+        messagesPingEvent(),
+        messagesStartEvent(),
+        messagesTextDeltaEvent("Here is"),
+        messagesPingEvent(),
+        messagesTextDeltaEvent(" the memo."),
+        messagesStopEvent(),
+        messagesPingEvent(),
+      ]);
+
+      const events = await collectEvents(
+        client.streamingResponse({ messages, config: {} }),
+      );
+      expect(collectedTexts(events)).toEqual(["Here is", " the memo."]);
+      expect(events[events.length - 1].finish_reason).toBe("stop");
+    });
+
+    test("still rejects genuinely unknown events", async () => {
+      const client = createAutoClient(testCase);
+      installFakeMessagesStream(client, [
+        messagesStartEvent(),
+        { type: "mystery_event" },
+        messagesStopEvent(),
+      ]);
+
+      await expect(
+        collectEvents(client.streamingResponse({ messages, config: {} })),
+      ).rejects.toThrow("Unknown output");
+    });
+  },
+);
+
+describe.each(GEMINI_STREAM_CASES)(
+  "Keepalive handling for $clientType",
+  (testCase) => {
+    test("skips gateway keepalive heartbeats between stream chunks", async () => {
+      const client = createAutoClient(testCase);
+      expect(routedClientName(client)).toBe(testCase.expectedClient);
+      installFakeGeminiStream(client, [
+        geminiKeepaliveChunk(),
+        geminiTextChunk("Here is"),
+        geminiKeepaliveChunk(),
+        geminiTextChunk(" the memo."),
+        geminiStopChunk(),
+        geminiKeepaliveChunk(),
+      ]);
+
+      const events = await collectEvents(
+        client.streamingResponse({ messages, config: {} }),
+      );
+      expect(collectedTexts(events)).toEqual(["Here is", " the memo."]);
+      // a heartbeat must not surface as an empty event of its own
+      expect(events).toHaveLength(3);
+      expect(events[events.length - 1].finish_reason).toBe("stop");
+    });
+  },
+);


### PR DESCRIPTION
Release 0.4.3 — merges dev into main.

Per-entry summaries: [changelog/0.4.3/README.md](https://github.com/Prism-Shadow/agenthub/blob/dev/changelog/0.4.3/README.md)

## Highlights

- **Gateway heartbeats no longer break streams.** Every streaming client now skips the heartbeat events gateways inject on long generations, across all four protocols: `keepalive` on OpenAI Responses (`gpt5_6`, `openai_responses`, `minimax_m3`), a chunk carrying no `choices` on Chat Completions (`openai_chat`, `deepseek_v4`, `glm5_3`, `kimi_k3`), `ping` on Anthropic Messages (`claude5`, `ant_messages`), and a candidate-less, usage-less chunk on Gemini (`gemini3_7`). Previously these failed the stream with `Unknown output`, a `TypeError` on `choices`, or `Last event must carry usage_metadata`, and downstream harnesses retried into a reconnect loop (Prism-Shadow/penguin-harness#286). The unknown-event guards are unchanged, so provider error events still raise.
- **E2E suites run one client per worker.** Python runs under `pytest -n 16 --dist loadgroup` with an `xdist_group` per model; TypeScript declares each check as a describe block holding one `test.concurrent` per model. Distinct models run in parallel while one model's checks stay serial, since providers rate-limit per client. CI dropped from 6m40s to 1m8s (Python) and 6m16s to 2m57s (Node) at identical coverage.
- **MiniMax routing** moved into the client-type chain, after the Kimi branch; routing results are unchanged.

**Breaking changes**: none.
