### PR TITLE
Read the E2E test image from a host DeepSeek can fetch

### DIFF
--- a/changelog/0.4.6/2026-08-21-e2e-image-host.md
+++ b/changelog/0.4.6/2026-08-21-e2e-image-host.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** process
 - **Scope:** `tests`
+- **PR:** [#188](https://github.com/Prism-Shadow/agenthub/pull/188)
 
 [中文版](2026-08-21-e2e-image-host.zh.md)
 

--- a/changelog/0.4.6/2026-08-21-e2e-image-host.md
+++ b/changelog/0.4.6/2026-08-21-e2e-image-host.md
@@ -1,0 +1,14 @@
+# The live E2E suites read their test image from a reachable host
+
+- **Date:** 2026-08-21
+- **Type:** process
+- **Scope:** `tests`
+
+[中文版](2026-08-21-e2e-image-host.zh.md)
+
+## What changed
+
+- `IMAGE` in `src_py/tests/test_client.py` and `src_ts/tests/client.test.ts` points at
+  `https://sghimages.shobserver.com/img/catch/2022/01/22/c1ae0300-9402-4128-a7e6-1244d3874167.jpg`,
+  a photograph of the same narcissus subject, so `IMAGE_KEYWORDS` is unchanged. DeepSeek's
+  server answered `400 Failed to download image` for the previous host on two CI runs.

--- a/changelog/0.4.6/2026-08-21-e2e-image-host.zh.md
+++ b/changelog/0.4.6/2026-08-21-e2e-image-host.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-08-21
 - **Type:** process
 - **Scope:** `tests`
+- **PR:** [#188](https://github.com/Prism-Shadow/agenthub/pull/188)
 
 [English](2026-08-21-e2e-image-host.md)
 

--- a/changelog/0.4.6/2026-08-21-e2e-image-host.zh.md
+++ b/changelog/0.4.6/2026-08-21-e2e-image-host.zh.md
@@ -1,0 +1,14 @@
+# 实况 E2E 套件改用可正常拉取的图片地址
+
+- **Date:** 2026-08-21
+- **Type:** process
+- **Scope:** `tests`
+
+[English](2026-08-21-e2e-image-host.md)
+
+## 变更内容
+
+- `src_py/tests/test_client.py` 与 `src_ts/tests/client.test.ts` 里的 `IMAGE` 改为
+  `https://sghimages.shobserver.com/img/catch/2022/01/22/c1ae0300-9402-4128-a7e6-1244d3874167.jpg`，
+  拍的仍是水仙，因此 `IMAGE_KEYWORDS` 不变。原地址曾让 DeepSeek 服务端在两次 CI 里返回
+  `400 Failed to download image`。

--- a/changelog/0.4.6/README.md
+++ b/changelog/0.4.6/README.md
@@ -2,6 +2,7 @@
 
 [中文版](README.zh.md)
 
+- [2026-08-21] The live E2E suites read their test image from a reachable host. ([details](2026-08-21-e2e-image-host.md))
 - [2026-08-21] An internal "unused" event never reaches a caller. ([details](2026-08-21-unused-event-guarantee.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] `deepseek-v4-flash-vision-exp` reads images, in a prompt and in a tool result. ([details](2026-08-21-deepseek-vision.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] DeepSeek moves onto the OpenAI Responses protocol. ([details](2026-08-21-deepseek-responses-protocol.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))

--- a/changelog/0.4.6/README.md
+++ b/changelog/0.4.6/README.md
@@ -2,7 +2,7 @@
 
 [中文版](README.zh.md)
 
-- [2026-08-21] The live E2E suites read their test image from a reachable host. ([details](2026-08-21-e2e-image-host.md))
+- [2026-08-21] The live E2E suites read their test image from a reachable host. ([details](2026-08-21-e2e-image-host.md), [#188](https://github.com/Prism-Shadow/agenthub/pull/188))
 - [2026-08-21] An internal "unused" event never reaches a caller. ([details](2026-08-21-unused-event-guarantee.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] `deepseek-v4-flash-vision-exp` reads images, in a prompt and in a tool result. ([details](2026-08-21-deepseek-vision.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] DeepSeek moves onto the OpenAI Responses protocol. ([details](2026-08-21-deepseek-responses-protocol.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))

--- a/changelog/0.4.6/README.zh.md
+++ b/changelog/0.4.6/README.zh.md
@@ -2,6 +2,7 @@
 
 [English](README.md)
 
+- [2026-08-21] 实况 E2E 套件改用可正常拉取的图片地址。([详情](2026-08-21-e2e-image-host.zh.md))
 - [2026-08-21] 内部的 "unused" 事件绝不会流到调用方。([详情](2026-08-21-unused-event-guarantee.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] `deepseek-v4-flash-vision-exp` 可读图片，提示词与工具返回都支持。([详情](2026-08-21-deepseek-vision.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] DeepSeek 改用 OpenAI Responses 协议。([详情](2026-08-21-deepseek-responses-protocol.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))

--- a/changelog/0.4.6/README.zh.md
+++ b/changelog/0.4.6/README.zh.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-- [2026-08-21] 实况 E2E 套件改用可正常拉取的图片地址。([详情](2026-08-21-e2e-image-host.zh.md))
+- [2026-08-21] 实况 E2E 套件改用可正常拉取的图片地址。([详情](2026-08-21-e2e-image-host.zh.md), [#188](https://github.com/Prism-Shadow/agenthub/pull/188))
 - [2026-08-21] 内部的 "unused" 事件绝不会流到调用方。([详情](2026-08-21-unused-event-guarantee.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] `deepseek-v4-flash-vision-exp` 可读图片，提示词与工具返回都支持。([详情](2026-08-21-deepseek-vision.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))
 - [2026-08-21] DeepSeek 改用 OpenAI Responses 协议。([详情](2026-08-21-deepseek-responses-protocol.zh.md), [#185](https://github.com/Prism-Shadow/agenthub/pull/185))

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -25,7 +25,7 @@ import pytest
 from agenthub import AutoLLMClient, ThinkingLevel, list_supported_models
 
 
-IMAGE = "https://cdn.britannica.com/80/120980-050-D1DA5C61/Poet-narcissus.jpg"
+IMAGE = "https://sghimages.shobserver.com/img/catch/2022/01/22/c1ae0300-9402-4128-a7e6-1244d3874167.jpg"
 IMAGE_KEYWORDS = ("flower", "narcissus", "daffodil", "bloom")
 
 

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -19,7 +19,7 @@ import { beforeAll, expect, describe, test } from "@jest/globals";
 import { Gaxios } from "gaxios";
 
 const IMAGE =
-  "https://cdn.britannica.com/80/120980-050-D1DA5C61/Poet-narcissus.jpg";
+  "https://sghimages.shobserver.com/img/catch/2022/01/22/c1ae0300-9402-4128-a7e6-1244d3874167.jpg";
 const IMAGE_KEYWORDS = ["flower", "narcissus", "daffodil", "bloom"];
 
 interface Model {


### PR DESCRIPTION
DeepSeek fetches an image URL on its own servers, and `cdn.britannica.com` answered
`400 input[0].image[0]: Failed to download image` on two CI runs — once in the Python suite,
once in the TypeScript one — while succeeding 5/5 from a developer machine. The suites now
point `IMAGE` at a photograph of the same narcissus subject on `sghimages.shobserver.com`, so
`IMAGE_KEYWORDS` needs no change.

Verified live against both fetch paths:

- Server-side fetch: `deepseek-v4-flash-vision-exp` (5/5 runs) and `gpt-5.6-luna`.
- Client-side download: `gemini-3.7-flash` and `kimi-k3`.

Every image test passes locally except `claude-sonnet-5`, whose three failures are
`401 API key is invalid` from this machine's Anthropic key; CI has valid secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBwEdjegVGtfY2yJKwhZ77