### PR TITLE
Release 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Here, we record the addition and removal times of models, major functional updates, bug fixes, and release times of key versions. Each release keeps one brief line here; the per-entry summaries live in `changelog/<version>/README.md`, and every entry links its detail file.
 
+- [2026-08-26] [Version 0.4.8](changelog/0.4.8/README.md): `glm-5.3-flash` joins the registry and reads images in a prompt and in a tool result, while every other GLM model refuses an image item instead of sending one.
+
 - [2026-08-25] [Version 0.4.7](changelog/0.4.7/README.md): the Gemini client splits function responses into their own contents, fixing the Vertex AI 400 `Requests ending with a model turn are not supported.` on messages that mix a tool result with text — an interrupted turn's carry-over resent with the next prompt, or tool outputs folded into a summarization request.
 
 - [2026-08-21] [Version 0.4.6](changelog/0.4.6/README.md): `deepseek-v4-flash-vision-exp` joins the registry and reads images in a prompt and in a tool result, the DeepSeek client moves onto the OpenAI Responses protocol, every Responses client replays content items in the order the model produced them, an internal `unused` event never reaches a caller, and the playground plays a spoken answer as one clip and keeps its configuration across a reload.

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -4,6 +4,8 @@
 
 在这里，我们记录模型的新增与移除时间、主要功能更新、缺陷修复，以及关键版本的发布时间。每个发布版本在此保留一行简述；逐条目的摘要位于 `changelog/<version>/README.md`，且每个条目都会链接到自己的详情文件。
 
+- [2026-08-26] [版本 0.4.8](changelog/0.4.8/README.zh.md)：注册表新增 `glm-5.3-flash`，提示词与工具返回里的图片都能读；其余 GLM 模型遇到图片条目会直接拒绝，而不是照发。
+
 - [2026-08-25] [版本 0.4.7](changelog/0.4.7/README.zh.md)：Gemini client 把 function response 拆分为独立的 content，修复消息里工具结果与文本混排时（被中断轮次的 carry-over 随下一条 prompt 重发、或工具输出折叠进摘要请求）Vertex AI 报 400 `Requests ending with a model turn are not supported.` 的问题。
 
 - [2026-08-21] [版本 0.4.6](changelog/0.4.6/README.zh.md)：注册表新增 `deepseek-v4-flash-vision-exp`，提示词与工具返回里的图片都能读；DeepSeek client 改用 OpenAI Responses 协议；全部 Responses client 按模型产出的顺序回放内容条目；内部的 `unused` 事件不会流到调用方；Playground 把语音回复合成一条音频播放，并在刷新后保留配置。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://github.com/user-attachments/assets/c49a21a1-5bf9-4768-a76d-f73c9a03ca87
 | GPT-5.4-5.6    | Official/OpenRouter/UModelVerse     | `gpt-5.6-sol`          | Text, Image      | Text, Embedding                |
 | Kimi-K2.5/K2.6/K3 | Official/OpenRouter/SiliconFlow  | `kimi-k3`              | Text, Image      | Text                           |
 | DeepSeek V4    | Official/OpenRouter/SiliconFlow     | `deepseek-v4-pro`      | Text, Image      | Text                           |
-| GLM-5.1-5.3    | Official/OpenRouter/SiliconFlow     | `glm-5.3`              | Text             | Text                           |
+| GLM-5.1-5.3    | Official/OpenRouter/SiliconFlow     | `glm-5.3`              | Text, Image      | Text                           |
 | MiniMax-M3     | Official                            | `MiniMax-M3`           | Text, Image      | Text                           |
 | Qwen3.6        | OpenRouter/SiliconFlow/vLLM         | `qwen/qwen3.6-35b-a3b` | Text, Image      | Text, Embedding                |
 

--- a/changelog/0.4.8/2026-08-26-glm-5.3-flash-vision.md
+++ b/changelog/0.4.8/2026-08-26-glm-5.3-flash-vision.md
@@ -1,0 +1,42 @@
+# glm-5.3-flash reads images, in a prompt and in a tool result
+
+- **Date:** 2026-08-26
+- **Type:** feature
+- **Scope:** `glm5_3`, `registry`, `integration`, `tests`
+- **PR:** [#192](https://github.com/Prism-Shadow/agenthub/pull/192)
+
+[中文版](2026-08-26-glm-5.3-flash-vision.zh.md)
+
+## What changed
+
+- `glm-5.3-flash` joined the registry on the official Z.AI API with `Text, Image` input, a
+  1M context window, and its own price.
+- `GLM5_3Client` sends an `image_url` item as an `image_url` content part carrying
+  `image_url.url`, and a `tool_result` image as the same part inside the `role: "tool"`
+  message, so a tool can hand the model a picture it produced. Both an HTTP(S) URL and a
+  base64 data URL are passed through unchanged, which is what the Chat Completion API
+  accepts. A tool result without images keeps its plain-string content.
+- A GLM model without vision refuses an image item with
+  `GLM <model> does not support image inputs.`, and an image in a tool result with
+  `GLM <model> does not support images in tool results.`, rather than sending one. The
+  version match is case-insensitive so provider-hosted ids (`z-ai/glm-5.3-flash`,
+  `zai-org/GLM-5.3-Flash`) are recognised too.
+- `glm-5.3-flash` replaced `glm-5.3` as the official Z.AI entry in both E2E model lists,
+  with image understanding enabled, and in both playground model dropdowns. The three Z.AI
+  protocol-mode entries stay on `glm-5.3`/`glm-5.2` and the OpenRouter entry on
+  `z-ai/glm-5.3`, all without image understanding.
+- The GLM thinking-level mapping cases gained a `glm-5.3-flash` row: the id routes to
+  `GLM5_3Client` and takes the GLM-5.3 thinking contract, which is what Z.AI recommends for
+  the model (`thinking.type` only `enabled`, `reasoning_effort` `max`).
+- The supported-model tables in `README.md` and both `skills/*/reference/models.md` record
+  image input for the GLM family and the new official model id.
+
+## Registry metadata
+
+`glm-5.3-flash` carries the official list price published at
+https://docs.z.ai/guides/overview/pricing: $0.15 input, $0.03 cached input, and $0.50
+output per million tokens, with a launch discount halving all three through 2026-09-09
+(UTC+8). Its context window is 1,000,000 tokens and it routes on the `glm-5.3` client.
+
+Z.AI documents video and file input for the model as well; the registry declares
+`Text, Image` because those are the modalities AgentHub's content items carry.

--- a/changelog/0.4.8/2026-08-26-glm-5.3-flash-vision.zh.md
+++ b/changelog/0.4.8/2026-08-26-glm-5.3-flash-vision.zh.md
@@ -1,0 +1,36 @@
+# glm-5.3-flash 可读图片，提示词与工具返回都支持
+
+- **Date:** 2026-08-26
+- **Type:** feature
+- **Scope:** `glm5_3`, `registry`, `integration`, `tests`
+- **PR:** [#192](https://github.com/Prism-Shadow/agenthub/pull/192)
+
+[English](2026-08-26-glm-5.3-flash-vision.md)
+
+## 变更内容
+
+- 注册表新增官方 Z.AI API 上的 `glm-5.3-flash`，输入模态为 `Text, Image`，上下文窗口 1M，并带有
+  自己的价格。
+- `GLM5_3Client` 把 `image_url` 条目发成携带 `image_url.url` 的 `image_url` 内容块，把
+  `tool_result` 里的图片发成 `role: "tool"` 消息内的同一种内容块，于是工具可以把自己产出的图片交给
+  模型。HTTP(S) 链接与 base64 data URL 都原样下发，这正是 Chat Completion API 接受的形式。不带图片的
+  工具返回仍保持纯字符串 content。
+- 不带视觉能力的 GLM 模型遇到图片条目会直接报 `GLM <model> does not support image inputs.`，工具返回
+  里的图片则报 `GLM <model> does not support images in tool results.`，而不是照发。版本匹配不区分
+  大小写，因此各平台托管的模型 id（`z-ai/glm-5.3-flash`、`zai-org/GLM-5.3-Flash`）同样被识别。
+- 两份 E2E 模型清单与两个 Playground 模型下拉里，官方 Z.AI 条目由 `glm-5.3` 换成 `glm-5.3-flash`
+  并打开图像理解。三个 Z.AI 协议模式条目仍用 `glm-5.3`/`glm-5.2`，OpenRouter 条目仍用
+  `z-ai/glm-5.3`，均不带图像理解。
+- GLM 思考等级映射用例新增一行 `glm-5.3-flash`：该 id 路由到 `GLM5_3Client`，并采用 GLM-5.3 的思考
+  契约，与 Z.AI 对该模型的推荐一致（`thinking.type` 只能为 `enabled`，`reasoning_effort` 取 `max`）。
+- `README.md` 与两份 `skills/*/reference/models.md` 的支持模型表记录了 GLM 系列的图片输入能力以及
+  新的官方模型 id。
+
+## 注册表元数据
+
+`glm-5.3-flash` 采用 https://docs.z.ai/guides/overview/pricing 公布的官方标价：每百万 token 输入
+$0.15、命中缓存 $0.03、输出 $0.50，三项在 2026-09-09（UTC+8）之前均享受五折上线优惠。上下文窗口为
+1,000,000 token，路由到 `glm-5.3` 客户端。
+
+Z.AI 同时说明该模型支持视频与文件输入；注册表声明为 `Text, Image`，因为这是 AgentHub 内容条目所能
+承载的模态。

--- a/changelog/0.4.8/README.md
+++ b/changelog/0.4.8/README.md
@@ -1,0 +1,5 @@
+# 0.4.8
+
+[中文版](README.zh.md)
+
+- [2026-08-26] `glm-5.3-flash` reads images, in a prompt and in a tool result. ([details](2026-08-26-glm-5.3-flash-vision.md), [#192](https://github.com/Prism-Shadow/agenthub/pull/192))

--- a/changelog/0.4.8/README.zh.md
+++ b/changelog/0.4.8/README.zh.md
@@ -1,0 +1,5 @@
+# 0.4.8
+
+[English](README.md)
+
+- [2026-08-26] `glm-5.3-flash` 可读图片，提示词与工具返回都支持。([详情](2026-08-26-glm-5.3-flash-vision.zh.md), [#192](https://github.com/Prism-Shadow/agenthub/pull/192))

--- a/skills/agenthub-python/reference/models.md
+++ b/skills/agenthub-python/reference/models.md
@@ -37,7 +37,7 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | GLM-5.2 | Official | `glm-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.2 | OpenRouter | `z-ai/glm-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.2 | SiliconFlow | `zai-org/GLM-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5.3 | Official | `glm-5.3` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.3 | Official | `glm-5.3`, `glm-5.3-flash` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.3 | OpenRouter | `z-ai/glm-5.3` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | MiniMax-M3 | Official | `MiniMax-M3` | `MINIMAX_API_KEY` | `MINIMAX_BASE_URL` |
 

--- a/skills/agenthub-typescript/reference/models.md
+++ b/skills/agenthub-typescript/reference/models.md
@@ -37,7 +37,7 @@ Use exact model IDs. If a model ID is not listed, ask the user to confirm the ex
 | GLM-5.2 | Official | `glm-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.2 | OpenRouter | `z-ai/glm-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.2 | SiliconFlow | `zai-org/GLM-5.2` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
-| GLM-5.3 | Official | `glm-5.3` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
+| GLM-5.3 | Official | `glm-5.3`, `glm-5.3-flash` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | GLM-5.3 | OpenRouter | `z-ai/glm-5.3` | `ZAI_API_KEY` | `ZAI_BASE_URL` |
 | MiniMax-M3 | Official | `MiniMax-M3` | `MINIMAX_API_KEY` | `MINIMAX_BASE_URL` |
 

--- a/src_py/agenthub/glm5_3/client.py
+++ b/src_py/agenthub/glm5_3/client.py
@@ -164,6 +164,12 @@ class GLM5_3Client(LLMClient):
         Returns:
             List of OpenAI message dictionaries
         """
+        # glm-5.3-flash is the natively multimodal GLM and the only one that reads image
+        # parts (https://docs.z.ai/guides/vlm/glm-5.3-flash); every other GLM answers a request
+        # carrying one with an error, so the item is refused here rather than dropped.
+        # Provider-hosted ids keep their own casing (e.g. z-ai/glm-5.3-flash), so the version
+        # match is case-insensitive.
+        supports_image = "glm-5.3-flash" in self._model.lower()
         openai_messages = []
 
         for msg in messages:
@@ -175,7 +181,10 @@ class GLM5_3Client(LLMClient):
                 if item["type"] == "text":
                     content_parts.append({"type": "text", "text": item["text"]})
                 elif item["type"] == "image_url":
-                    raise ValueError("GLM-5 does not support image inputs.")
+                    if not supports_image:
+                        raise ValueError(f"GLM {self._model} does not support image inputs.")
+
+                    content_parts.append({"type": "image_url", "image_url": {"url": item["image_url"]}})
                 elif item["type"] == "thinking":
                     thinking += item["thinking"]
                     thinking_fields.add((item.get("fidelity") or {}).get("reasoning_field"))
@@ -194,15 +203,23 @@ class GLM5_3Client(LLMClient):
                     if "tool_call_id" not in item:
                         raise ValueError("tool_call_id is required for tool result.")
 
+                    # a tool result without images stays a plain string, the only content shape
+                    # the Chat Completion schema documents for a tool message
+                    content = item["text"]
                     if "images" in item and item["images"]:
-                        raise ValueError("GLM-5 does not support images in tool results.")
+                        if not supports_image:
+                            raise ValueError(f"GLM {self._model} does not support images in tool results.")
+
+                        content = [{"type": "text", "text": item["text"]}]
+                        for image_url in item["images"]:
+                            content.append({"type": "image_url", "image_url": {"url": image_url}})
 
                     # Tool results are sent as separate messages
                     openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
-                            "content": item["text"],
+                            "content": content,
                         }
                     )
                 else:

--- a/src_py/agenthub/integration/playground.py
+++ b/src_py/agenthub/integration/playground.py
@@ -225,8 +225,8 @@ def create_chat_app() -> Flask:
                             <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="claude-sonnet-5" data-label="Claude Sonnet 5" data-description="claude-sonnet-5" onclick="selectComboboxOption('modelCombobox', this)">
                                 <span class="block truncate text-sm font-medium text-gray-900">Claude Sonnet 5</span>
                             </button>
-                            <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.3" data-label="GLM 5.3" data-description="glm-5.3" onclick="selectComboboxOption('modelCombobox', this)">
-                                <span class="block truncate text-sm font-medium text-gray-900">GLM 5.3</span>
+                            <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.3-flash" data-label="GLM 5.3 Flash" data-description="glm-5.3-flash" onclick="selectComboboxOption('modelCombobox', this)">
+                                <span class="block truncate text-sm font-medium text-gray-900">GLM 5.3 Flash</span>
                             </button>
                             <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="kimi-k3" data-label="Kimi K3" data-description="kimi-k3" onclick="selectComboboxOption('modelCombobox', this)">
                                 <span class="block truncate text-sm font-medium text-gray-900">Kimi K3</span>

--- a/src_py/agenthub/registry.py
+++ b/src_py/agenthub/registry.py
@@ -263,6 +263,17 @@ _SUPPORTED_MODELS: list[SupportedModel] = [
         "pricing": _usd(1.4, 4.4, cached=0.26),
     },
     {
+        "model": "glm-5.3-flash",
+        "base_url": _ZAI,
+        "client": "glm-5.3",
+        "input_modalities": ["Text", "Image"],
+        "output_modalities": ["Text"],
+        "context_window": 1000000,
+        # official list price (verified 2026-08-26); a launch discount halves all three rates
+        # through 2026-09-09 (UTC+8)
+        "pricing": _usd(0.15, 0.5, cached=0.03),
+    },
+    {
         "model": "glm-5.2",
         "base_url": _ZAI,
         "client": "glm-5.3",

--- a/src_py/pyproject.toml
+++ b/src_py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agenthub-python"
-version = "0.4.7"
+version = "0.4.8"
 description = "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents."
 keywords = ["agent", "llm", "gemini", "claude", "gpt"]
 readme = "README.md"

--- a/src_py/tests/test_client.py
+++ b/src_py/tests/test_client.py
@@ -121,7 +121,7 @@ _PROTOCOL_BASE_URLS = {
 }
 
 if os.getenv("ZAI_API_KEY"):
-    AVAILABLE_MODELS.append(Model(name="glm-5.3", support_image_understanding=False))
+    AVAILABLE_MODELS.append(Model(name="glm-5.3-flash"))
 
 if os.getenv("MOONSHOT_API_KEY"):
     AVAILABLE_MODELS.append(Model(name="kimi-k3"))

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -117,6 +117,7 @@ GLM_THINKING_LEVEL_CASES = [
     ("glm-5.3", ThinkingLevel.HIGH, "enabled", "high"),
     ("glm-5.3", ThinkingLevel.XHIGH, "enabled", "max"),
     ("glm-5.3", ThinkingLevel.MAX, "enabled", "max"),
+    ("glm-5.3-flash", ThinkingLevel.MAX, "enabled", "max"),
     ("glm-5.2", ThinkingLevel.NONE, "disabled", None),
     ("glm-5.2", ThinkingLevel.MEDIUM, "enabled", "medium"),
     ("glm-5.2", ThinkingLevel.XHIGH, "enabled", "xhigh"),

--- a/src_ts/package-lock.json
+++ b/src_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismshadow/agenthub",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",

--- a/src_ts/package.json
+++ b/src_ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismshadow/agenthub",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "AgentHub is the LLM API Hub for the Agent era, built for high-precision autonomous agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src_ts/src/glm5_3/client.ts
+++ b/src_ts/src/glm5_3/client.ts
@@ -221,6 +221,12 @@ export class GLM5_3Client extends LLMClient {
     messages: UniMessage[],
     _signal?: AbortSignal,
   ): ChatCompletionMessageParam[] {
+    // glm-5.3-flash is the natively multimodal GLM and the only one that reads image
+    // parts (https://docs.z.ai/guides/vlm/glm-5.3-flash); every other GLM answers a
+    // request carrying one with an error, so the item is refused here rather than
+    // dropped. Provider-hosted ids keep their own casing (e.g. z-ai/glm-5.3-flash),
+    // so the version match is case-insensitive.
+    const supportsImage = this._model.toLowerCase().includes("glm-5.3-flash");
     const openaiMessages: ChatCompletionMessageParam[] = [];
 
     for (const msg of messages) {
@@ -238,7 +244,16 @@ export class GLM5_3Client extends LLMClient {
         if (item.type === "text") {
           contentParts.push({ type: "text", text: item.text });
         } else if (item.type === "image_url") {
-          throw new Error("GLM-5 does not support image inputs.");
+          if (!supportsImage) {
+            throw new Error(
+              `GLM ${this._model} does not support image inputs.`,
+            );
+          }
+
+          contentParts.push({
+            type: "image_url",
+            image_url: { url: item.image_url },
+          });
         } else if (item.type === "thinking") {
           thinking += item.thinking;
           thinkingFields.add(item.fidelity?.reasoning_field);
@@ -256,14 +271,31 @@ export class GLM5_3Client extends LLMClient {
             throw new Error("tool_call_id is required for tool result.");
           }
 
+          // a tool result without images stays a plain string, the only content shape
+          // the Chat Completion schema documents for a tool message
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let content: any = item.text;
+
           if (item.images && item.images.length > 0) {
-            throw new Error("GLM-5 does not support images in tool results.");
+            if (!supportsImage) {
+              throw new Error(
+                `GLM ${this._model} does not support images in tool results.`,
+              );
+            }
+
+            content = [{ type: "text", text: item.text }];
+            for (const imageUrl of item.images) {
+              content.push({
+                type: "image_url",
+                image_url: { url: imageUrl },
+              });
+            }
           }
 
           openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
-            content: item.text,
+            content,
           });
         } else {
           throw new Error(

--- a/src_ts/src/integration/playground.ts
+++ b/src_ts/src/integration/playground.ts
@@ -236,8 +236,8 @@ export function createChatApp(): Express {
                           <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="claude-sonnet-5" data-label="Claude Sonnet 5" data-description="claude-sonnet-5" onclick="selectComboboxOption('modelCombobox', this)">
                               <span class="block truncate text-sm font-medium text-gray-900">Claude Sonnet 5</span>
                           </button>
-                          <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.3" data-label="GLM 5.3" data-description="glm-5.3" onclick="selectComboboxOption('modelCombobox', this)">
-                              <span class="block truncate text-sm font-medium text-gray-900">GLM 5.3</span>
+                          <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="glm-5.3-flash" data-label="GLM 5.3 Flash" data-description="glm-5.3-flash" onclick="selectComboboxOption('modelCombobox', this)">
+                              <span class="block truncate text-sm font-medium text-gray-900">GLM 5.3 Flash</span>
                           </button>
                           <button type="button" role="option" aria-selected="false" class="w-full px-3 py-2 text-left hover:bg-gray-50 focus:bg-gray-50 focus:outline-none" data-combobox-option data-value="kimi-k3" data-label="Kimi K3" data-description="kimi-k3" onclick="selectComboboxOption('modelCombobox', this)">
                               <span class="block truncate text-sm font-medium text-gray-900">Kimi K3</span>

--- a/src_ts/src/registry.ts
+++ b/src_ts/src/registry.ts
@@ -258,6 +258,17 @@ const SUPPORTED_MODELS: SupportedModel[] = [
     pricing: usd(1.4, 4.4, 0.26),
   },
   {
+    model: "glm-5.3-flash",
+    base_url: ZAI,
+    client: "glm-5.3",
+    input_modalities: ["Text", "Image"],
+    output_modalities: ["Text"],
+    context_window: 1000000,
+    // official list price (verified 2026-08-26); a launch discount halves all three
+    // rates through 2026-09-09 (UTC+8)
+    pricing: usd(0.15, 0.5, 0.03),
+  },
+  {
     model: "glm-5.2",
     base_url: ZAI,
     client: "glm-5.3",

--- a/src_ts/tests/client.test.ts
+++ b/src_ts/tests/client.test.ts
@@ -150,9 +150,9 @@ const PROTOCOL_BASE_URLS: { [provider: string]: { [mode: string]: string } } = {
 
 if (process.env.ZAI_API_KEY) {
   AVAILABLE_MODELS.push({
-    name: "glm-5.3",
+    name: "glm-5.3-flash",
     supportTextGeneration: true,
-    supportImageUnderstanding: false,
+    supportImageUnderstanding: true,
     supportImageGeneration: false,
     supportAudioGeneration: false,
     supportEmbedding: false,

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -136,6 +136,7 @@ const GLM_THINKING_LEVEL_CASES: Array<
   ["glm-5.3", ThinkingLevel.HIGH, "enabled", "high"],
   ["glm-5.3", ThinkingLevel.XHIGH, "enabled", "max"],
   ["glm-5.3", ThinkingLevel.MAX, "enabled", "max"],
+  ["glm-5.3-flash", ThinkingLevel.MAX, "enabled", "max"],
   ["glm-5.2", ThinkingLevel.NONE, "disabled", undefined],
   ["glm-5.2", ThinkingLevel.MEDIUM, "enabled", "medium"],
   ["glm-5.2", ThinkingLevel.XHIGH, "enabled", "xhigh"],


### PR DESCRIPTION
Cuts 0.4.8 onto `main`.

Carries one change: `glm-5.3-flash` joins the registry and reads images in a prompt and in a tool result, while every other GLM model refuses an image item instead of sending one. Details in [changelog/0.4.8/README.md](changelog/0.4.8/README.md).

Version bumped in `src_ts/package.json`, `src_ts/package-lock.json` and `src_py/pyproject.toml`; `changelog/unreleased/` folded into `changelog/0.4.8/`; one line added to `CHANGELOG.md` and `CHANGELOG.zh.md`.

## Verification

`src_ts`: eslint clean, `npm run build` clean, `make test` 11 suites / 319 tests pass. `src_py`: `ruff check` + `ruff format --check` clean, `make test` 281 passed / 52 skipped. `uv build` produces the 0.4.8 sdist and wheel.

The `ZAI_API_KEY`-gated E2E cases for the new model (`test_image_understanding`, `test_image_understanding_base64`, `test_tool_result_with_image`) could not run locally for want of the secret — CI has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)