### PR TITLE
Send an image over the 30,000-patch limit to GPT-5.6 at high detail

### DIFF
--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-01
 - **Type:** fix
 - **Scope:** `gpt5_6`, `openai_responses`, `openai_chat`, `utils`, `tests`
+- **PR:** [#194](https://github.com/Prism-Shadow/agenthub/pull/194)
 - **Issue:** penguin-harness [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573)
 
 [中文版](2026-09-01-gpt-5.6-image-patch-limit.zh.md)

--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
@@ -18,11 +18,15 @@
   Every other image keeps going out without a `detail`, so GPT-5.6's `auto` still reads it
   at its own dimensions, and no other model sees the field.
 - `imageDimensions` / `image_dimensions` in `utils` read the width and height from the header
-  of a PNG, JPEG, GIF or WebP, and `exceedsOpenaiPatchLimit` / `exceeds_openai_patch_limit`
-  apply OpenAI's `original` sizing rule to a base64 data URL: the 65,535-pixel cap on either
-  side, then `ceil(width / 32) × ceil(height / 32)` against the 30,000-patch limit. Only the
-  leading 64 KiB of the payload is decoded unless a JPEG's frame header sits further in. An
-  HTTP(S) URL is not measured and is sent as before.
+  of a PNG, JPEG, GIF or WebP, `exceedsOpenaiPatchLimit` / `exceeds_openai_patch_limit` apply
+  OpenAI's `original` sizing rule to a base64 data URL — the 65,535-pixel cap on either side,
+  then `ceil(width / 32) × ceil(height / 32)` against the 30,000-patch limit — and
+  `openaiImageDetail` / `openai_image_detail` hold the GPT-5.6 rule once for the three clients.
+  The payload is decoded a growing prefix at a time, from 64 characters up, so a JPEG's frame
+  header is found behind its metadata without decoding the whole image, and a payload that is
+  line-wrapped, unpadded or in the URL-safe alphabet reads the same in both languages. The
+  Responses clients do not measure an HTTP(S) URL and pass it through for the API to fetch;
+  the Chat client fetches it into a data URL first, so it measures the fetched bytes.
 - Offline tests cover the header parser for each format, the limit arithmetic at its
-  boundaries, and the three clients' `detail` placement, including that `gpt-5.5` and a
-  non-OpenAI model on the same protocol are left alone.
+  boundaries, the payload shapes above, and the three clients' `detail` placement, including
+  that `gpt-5.5` and a non-OpenAI model on the same protocol are left alone.

--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.md
@@ -1,0 +1,27 @@
+# GPT-5.6 reads an image over the 30,000-patch limit instead of rejecting it
+
+- **Date:** 2026-09-01
+- **Type:** fix
+- **Scope:** `gpt5_6`, `openai_responses`, `openai_chat`, `utils`, `tests`
+- **Issue:** penguin-harness [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573)
+
+[中文版](2026-09-01-gpt-5.6-image-patch-limit.zh.md)
+
+## What changed
+
+- `GPT5_6Client`, `OpenaiResponsesClient` and `OpenaiChatClient` send an image at
+  `detail: "high"` when the model id contains `gpt-5.6` and the image would need more than
+  30,000 patches at `original` detail, in a prompt and in a tool result alike. The API then
+  fits the image into 2,500 patches instead of answering
+  `400 The image you provided requires N patches after processing, exceeding the limit of 30000`.
+  Every other image keeps going out without a `detail`, so GPT-5.6's `auto` still reads it
+  at its own dimensions, and no other model sees the field.
+- `imageDimensions` / `image_dimensions` in `utils` read the width and height from the header
+  of a PNG, JPEG, GIF or WebP, and `exceedsOpenaiPatchLimit` / `exceeds_openai_patch_limit`
+  apply OpenAI's `original` sizing rule to a base64 data URL: the 65,535-pixel cap on either
+  side, then `ceil(width / 32) × ceil(height / 32)` against the 30,000-patch limit. Only the
+  leading 64 KiB of the payload is decoded unless a JPEG's frame header sits further in. An
+  HTTP(S) URL is not measured and is sent as before.
+- Offline tests cover the header parser for each format, the limit arithmetic at its
+  boundaries, and the three clients' `detail` placement, including that `gpt-5.5` and a
+  non-OpenAI model on the same protocol are left alone.

--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
@@ -17,8 +17,11 @@
   其余图片一律照旧不带 `detail`，GPT-5.6 的 `auto` 仍按原尺寸读图，其他模型也不会见到这个字段。
 - `utils` 里的 `imageDimensions` / `image_dimensions` 从 PNG、JPEG、GIF、WebP 的文件头读出宽高，
   `exceedsOpenaiPatchLimit` / `exceeds_openai_patch_limit` 对 base64 data URL 套用 OpenAI 的
-  `original` 尺寸规则：先按单边 65,535 像素封顶，再以 `ceil(width / 32) × ceil(height / 32)` 对照
-  30,000 patch 的上限。只解码载荷开头的 64 KiB，除非 JPEG 的帧头在更靠后的位置。HTTP(S) 链接不做
-  测量，照旧下发。
-- 离线测试覆盖各格式的文件头解析、上限算术的边界值，以及三个客户端的 `detail` 落位，包括
-  `gpt-5.5` 与同协议上的非 OpenAI 模型均不受影响。
+  `original` 尺寸规则——先按单边 65,535 像素封顶，再以 `ceil(width / 32) × ceil(height / 32)` 对照
+  30,000 patch 的上限——`openaiImageDetail` / `openai_image_detail` 则把 GPT-5.6 这条规则集中一处，
+  供三个客户端调用。载荷按逐步放大的前缀解码，从 64 个字符起步，JPEG 的帧头即使藏在元数据之后也无需
+  解码整张图片；换行、缺少补位或采用 URL-safe 字母表的载荷在两种语言里读数一致。Responses 客户端不
+  测量 HTTP(S) 链接，照旧交给 API 自行获取；Chat 客户端会先把它抓取为 data URL，因而测量的是抓取到
+  的字节。
+- 离线测试覆盖各格式的文件头解析、上限算术的边界值、上述几种载荷形态，以及三个客户端的 `detail`
+  落位，包括 `gpt-5.5` 与同协议上的非 OpenAI 模型均不受影响。

--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
@@ -1,0 +1,23 @@
+# GPT-5.6 可读超过 30,000 patch 上限的图片，不再拒收
+
+- **Date:** 2026-09-01
+- **Type:** fix
+- **Scope:** `gpt5_6`, `openai_responses`, `openai_chat`, `utils`, `tests`
+- **Issue:** penguin-harness [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573)
+
+[English](2026-09-01-gpt-5.6-image-patch-limit.md)
+
+## 变更内容
+
+- `GPT5_6Client`、`OpenaiResponsesClient` 与 `OpenaiChatClient` 在模型 id 含 `gpt-5.6`、且图片按
+  `original` 细节需要超过 30,000 个 patch 时，以 `detail: "high"` 下发该图片，提示词与工具返回里的
+  图片同样处理。API 随即把图片缩进 2,500 个 patch，而不再回答
+  `400 The image you provided requires N patches after processing, exceeding the limit of 30000`。
+  其余图片一律照旧不带 `detail`，GPT-5.6 的 `auto` 仍按原尺寸读图，其他模型也不会见到这个字段。
+- `utils` 里的 `imageDimensions` / `image_dimensions` 从 PNG、JPEG、GIF、WebP 的文件头读出宽高，
+  `exceedsOpenaiPatchLimit` / `exceeds_openai_patch_limit` 对 base64 data URL 套用 OpenAI 的
+  `original` 尺寸规则：先按单边 65,535 像素封顶，再以 `ceil(width / 32) × ceil(height / 32)` 对照
+  30,000 patch 的上限。只解码载荷开头的 64 KiB，除非 JPEG 的帧头在更靠后的位置。HTTP(S) 链接不做
+  测量，照旧下发。
+- 离线测试覆盖各格式的文件头解析、上限算术的边界值，以及三个客户端的 `detail` 落位，包括
+  `gpt-5.5` 与同协议上的非 OpenAI 模型均不受影响。

--- a/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
+++ b/changelog/unreleased/2026-09-01-gpt-5.6-image-patch-limit.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-01
 - **Type:** fix
 - **Scope:** `gpt5_6`, `openai_responses`, `openai_chat`, `utils`, `tests`
+- **PR:** [#194](https://github.com/Prism-Shadow/agenthub/pull/194)
 - **Issue:** penguin-harness [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573)
 
 [English](2026-09-01-gpt-5.6-image-patch-limit.md)

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+[中文版](README.zh.md)
+
+- [2026-09-01] GPT-5.6 reads an image over the 30,000-patch limit at high detail instead of rejecting it. ([details](2026-09-01-gpt-5.6-image-patch-limit.md))

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,4 +2,4 @@
 
 [中文版](README.zh.md)
 
-- [2026-09-01] GPT-5.6 reads an image over the 30,000-patch limit at high detail instead of rejecting it. ([details](2026-09-01-gpt-5.6-image-patch-limit.md))
+- [2026-09-01] GPT-5.6 reads an image over the 30,000-patch limit at high detail instead of rejecting it. ([details](2026-09-01-gpt-5.6-image-patch-limit.md), [#194](https://github.com/Prism-Shadow/agenthub/pull/194))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+[English](README.md)
+
+- [2026-09-01] GPT-5.6 对超过 30,000 patch 上限的图片改以高细节读取，不再拒收。([详情](2026-09-01-gpt-5.6-image-patch-limit.zh.md))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -2,4 +2,4 @@
 
 [English](README.md)
 
-- [2026-09-01] GPT-5.6 对超过 30,000 patch 上限的图片改以高细节读取，不再拒收。([详情](2026-09-01-gpt-5.6-image-patch-limit.zh.md))
+- [2026-09-01] GPT-5.6 对超过 30,000 patch 上限的图片改以高细节读取，不再拒收。([详情](2026-09-01-gpt-5.6-image-patch-limit.zh.md), [#194](https://github.com/Prism-Shadow/agenthub/pull/194))

--- a/src_py/agenthub/gpt5_6/client.py
+++ b/src_py/agenthub/gpt5_6/client.py
@@ -33,7 +33,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import exceeds_openai_patch_limit, is_debug_enabled
+from ..utils import is_debug_enabled, openai_image_detail
 
 
 class GPT5_6Client(LLMClient):
@@ -72,17 +72,12 @@ class GPT5_6Client(LLMClient):
         return tool_choice
 
     def _convert_image_url(self, image_url: str) -> dict[str, str]:
-        """
-        Convert an image URL to an input_image item.
+        """Convert an image URL to an input_image item, at the detail the API needs to read it."""
+        item = {"type": "input_image", "image_url": image_url}
+        if detail := openai_image_detail(self._model, image_url):
+            item["detail"] = detail
 
-        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-        API fit it into 2,500 patches, so the image is read instead of refused.
-        """
-        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(image_url):
-            return {"type": "input_image", "image_url": image_url, "detail": "high"}
-
-        return {"type": "input_image", "image_url": image_url}
+        return item
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """

--- a/src_py/agenthub/gpt5_6/client.py
+++ b/src_py/agenthub/gpt5_6/client.py
@@ -33,7 +33,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import is_debug_enabled
+from ..utils import exceeds_openai_patch_limit, is_debug_enabled
 
 
 class GPT5_6Client(LLMClient):
@@ -70,6 +70,19 @@ class GPT5_6Client(LLMClient):
         if isinstance(tool_choice, list):
             return {"mode": "required", "tools": [{"type": "function", "name": name} for name in tool_choice]}
         return tool_choice
+
+    def _convert_image_url(self, image_url: str) -> dict[str, str]:
+        """
+        Convert an image URL to an input_image item.
+
+        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+        API fit it into 2,500 patches, so the image is read instead of refused.
+        """
+        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(image_url):
+            return {"type": "input_image", "image_url": image_url, "detail": "high"}
+
+        return {"type": "input_image", "image_url": image_url}
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """
@@ -158,7 +171,7 @@ class GPT5_6Client(LLMClient):
                     else:
                         content_items.append({"type": "output_text", "text": item["text"]})
                 elif item["type"] == "image_url":
-                    content_items.append({"type": "input_image", "image_url": item["image_url"]})
+                    content_items.append(self._convert_image_url(item["image_url"]))
                 elif item["type"] == "thinking":
                     # rebuild the reasoning item from the recorded wire fields: the thinking
                     # text goes back through the channel that carried it (histories recorded
@@ -196,7 +209,7 @@ class GPT5_6Client(LLMClient):
                     tool_result = [{"type": "input_text", "text": item["text"]}]
                     if "images" in item:
                         for image_url in item["images"]:
-                            tool_result.append({"type": "input_image", "image_url": image_url})
+                            tool_result.append(self._convert_image_url(image_url))
 
                     input_list.append(
                         {"type": "function_call_output", "call_id": item["tool_call_id"], "output": tool_result}

--- a/src_py/agenthub/openai_chat/client.py
+++ b/src_py/agenthub/openai_chat/client.py
@@ -35,7 +35,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import exceeds_openai_patch_limit, fix_openrouter_usage_metadata
+from ..utils import fix_openrouter_usage_metadata, openai_image_detail
 
 
 class OpenaiChatClient(LLMClient):
@@ -89,17 +89,12 @@ class OpenaiChatClient(LLMClient):
         return tool_choice
 
     def _convert_image_url(self, data_url: str) -> dict[str, Any]:
-        """
-        Convert a fetched image to an image_url part.
+        """Convert a fetched image to an image_url part, at the detail the API needs to read it."""
+        image_url = {"url": data_url}
+        if detail := openai_image_detail(self._model, data_url):
+            image_url["detail"] = detail
 
-        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-        API fit it into 2,500 patches, so the image is read instead of refused.
-        """
-        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(data_url):
-            return {"type": "image_url", "image_url": {"url": data_url, "detail": "high"}}
-
-        return {"type": "image_url", "image_url": {"url": data_url}}
+        return {"type": "image_url", "image_url": image_url}
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """

--- a/src_py/agenthub/openai_chat/client.py
+++ b/src_py/agenthub/openai_chat/client.py
@@ -35,7 +35,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import fix_openrouter_usage_metadata
+from ..utils import exceeds_openai_patch_limit, fix_openrouter_usage_metadata
 
 
 class OpenaiChatClient(LLMClient):
@@ -87,6 +87,19 @@ class OpenaiChatClient(LLMClient):
             }
 
         return tool_choice
+
+    def _convert_image_url(self, data_url: str) -> dict[str, Any]:
+        """
+        Convert a fetched image to an image_url part.
+
+        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+        API fit it into 2,500 patches, so the image is read instead of refused.
+        """
+        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(data_url):
+            return {"type": "image_url", "image_url": {"url": data_url, "detail": "high"}}
+
+        return {"type": "image_url", "image_url": {"url": data_url}}
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """
@@ -146,7 +159,7 @@ class OpenaiChatClient(LLMClient):
                     content_parts.append({"type": "text", "text": item["text"]})
                 elif item["type"] == "image_url":
                     base64_image = await self._convert_image_url_to_base64(item["image_url"])
-                    content_parts.append({"type": "image_url", "image_url": {"url": base64_image}})
+                    content_parts.append(self._convert_image_url(base64_image))
                 elif item["type"] == "thinking":
                     thinking += item["thinking"]
                     thinking_fields.add((item.get("fidelity") or {}).get("reasoning_field"))
@@ -169,12 +182,12 @@ class OpenaiChatClient(LLMClient):
 
                     if "images" in item and item["images"]:
                         for image_url in item["images"]:
-                            base64_image = await self._convert_image_url_to_base64(image_url)
+                            part = self._convert_image_url(await self._convert_image_url_to_base64(image_url))
                             if "siliconflow.cn" in str(self._client.base_url):
                                 # siliconflow does not support image_url in tool result
-                                content_parts.append({"type": "image_url", "image_url": {"url": base64_image}})
+                                content_parts.append(part)
                             else:
-                                content.append({"type": "image_url", "image_url": {"url": base64_image}})
+                                content.append(part)
 
                     # Tool results are sent as separate messages
                     openai_messages.append(

--- a/src_py/agenthub/openai_responses/client.py
+++ b/src_py/agenthub/openai_responses/client.py
@@ -33,7 +33,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import is_debug_enabled
+from ..utils import exceeds_openai_patch_limit, is_debug_enabled
 
 
 class OpenaiResponsesClient(LLMClient):
@@ -70,6 +70,19 @@ class OpenaiResponsesClient(LLMClient):
         if isinstance(tool_choice, list):
             return {"mode": "required", "tools": [{"type": "function", "name": name} for name in tool_choice]}
         return tool_choice
+
+    def _convert_image_url(self, image_url: str) -> dict[str, str]:
+        """
+        Convert an image URL to an input_image item.
+
+        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+        API fit it into 2,500 patches, so the image is read instead of refused.
+        """
+        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(image_url):
+            return {"type": "input_image", "image_url": image_url, "detail": "high"}
+
+        return {"type": "input_image", "image_url": image_url}
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """
@@ -156,7 +169,7 @@ class OpenaiResponsesClient(LLMClient):
                     else:
                         content_items.append({"type": "output_text", "text": item["text"]})
                 elif item["type"] == "image_url":
-                    content_items.append({"type": "input_image", "image_url": item["image_url"]})
+                    content_items.append(self._convert_image_url(item["image_url"]))
                 elif item["type"] == "thinking":
                     # the wire shape differs by server: OpenAI-style servers stream summaries and
                     # demand the summary key back (with encrypted_content preserved), while
@@ -192,7 +205,7 @@ class OpenaiResponsesClient(LLMClient):
                     tool_result = [{"type": "input_text", "text": item["text"]}]
                     if "images" in item:
                         for image_url in item["images"]:
-                            tool_result.append({"type": "input_image", "image_url": image_url})
+                            tool_result.append(self._convert_image_url(image_url))
 
                     input_list.append(
                         {"type": "function_call_output", "call_id": item["tool_call_id"], "output": tool_result}

--- a/src_py/agenthub/openai_responses/client.py
+++ b/src_py/agenthub/openai_responses/client.py
@@ -33,7 +33,7 @@ from ..types import (
     UniMessage,
     UsageMetadata,
 )
-from ..utils import exceeds_openai_patch_limit, is_debug_enabled
+from ..utils import is_debug_enabled, openai_image_detail
 
 
 class OpenaiResponsesClient(LLMClient):
@@ -72,17 +72,12 @@ class OpenaiResponsesClient(LLMClient):
         return tool_choice
 
     def _convert_image_url(self, image_url: str) -> dict[str, str]:
-        """
-        Convert an image URL to an input_image item.
+        """Convert an image URL to an input_image item, at the detail the API needs to read it."""
+        item = {"type": "input_image", "image_url": image_url}
+        if detail := openai_image_detail(self._model, image_url):
+            item["detail"] = detail
 
-        GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-        dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-        API fit it into 2,500 patches, so the image is read instead of refused.
-        """
-        if "gpt-5.6" in self._model.lower() and exceeds_openai_patch_limit(image_url):
-            return {"type": "input_image", "image_url": image_url, "detail": "high"}
-
-        return {"type": "input_image", "image_url": image_url}
+        return item
 
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
         """

--- a/src_py/agenthub/utils.py
+++ b/src_py/agenthub/utils.py
@@ -68,11 +68,11 @@ def image_dimensions(data: bytes) -> tuple[int, int] | None:
         tuple[int, int] | None: The width and height, or None when the bytes are not a recognized image.
     """
     # PNG: an 8-byte signature, then the IHDR chunk with width and height
-    if len(data) >= 24 and data[1:4] == b"PNG" and data[12:16] == b"IHDR":
+    if len(data) >= 24 and data[:8] == b"\x89PNG\r\n\x1a\n" and data[12:16] == b"IHDR":
         return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
 
     # GIF: the logical screen size follows the 6-byte signature
-    if len(data) >= 10 and data[:3] == b"GIF":
+    if len(data) >= 10 and data[:6] in (b"GIF87a", b"GIF89a"):
         return int.from_bytes(data[6:8], "little"), int.from_bytes(data[8:10], "little")
 
     # WebP: a RIFF container whose first chunk names the bitstream flavour

--- a/src_py/agenthub/utils.py
+++ b/src_py/agenthub/utils.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import binascii
+import math
 import os
 
 from .types import UsageMetadata
@@ -49,3 +52,142 @@ def is_debug_enabled() -> bool:
         bool: Whether debug mode is on.
     """
     return os.getenv("AGENTHUB_DEBUG", "").strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def image_dimensions(data: bytes) -> tuple[int, int] | None:
+    """
+    Read the pixel dimensions from the header of a PNG, JPEG, GIF or WebP image.
+
+    Only the header is inspected, so the bytes may be a prefix of the file; a prefix that ends
+    before the dimensions are reached reads as unrecognized.
+
+    Args:
+        data (bytes): The image bytes, or a prefix of them.
+
+    Returns:
+        tuple[int, int] | None: The width and height, or None when the bytes are not a recognized image.
+    """
+    # PNG: an 8-byte signature, then the IHDR chunk with width and height
+    if len(data) >= 24 and data[1:4] == b"PNG" and data[12:16] == b"IHDR":
+        return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+
+    # GIF: the logical screen size follows the 6-byte signature
+    if len(data) >= 10 and data[:3] == b"GIF":
+        return int.from_bytes(data[6:8], "little"), int.from_bytes(data[8:10], "little")
+
+    # WebP: a RIFF container whose first chunk names the bitstream flavour
+    if len(data) >= 30 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        chunk = data[12:16]
+        if chunk == b"VP8 " and data[23:26] == b"\x9d\x01\x2a":
+            # lossy: a 3-byte frame tag and the key frame start code precede the size, whose top
+            # two bits are a scaling hint
+            width = int.from_bytes(data[26:28], "little") & 0x3FFF
+            height = int.from_bytes(data[28:30], "little") & 0x3FFF
+            return width, height
+        if chunk == b"VP8L" and data[20] == 0x2F:
+            # lossless: 14 bits of width minus one, then 14 bits of height minus one
+            bits = int.from_bytes(data[21:25], "little")
+            return (bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1
+        if chunk == b"VP8X":
+            # extended: the canvas size minus one, 24 bits each, after the flags
+            return int.from_bytes(data[24:27], "little") + 1, int.from_bytes(data[27:30], "little") + 1
+        return None
+
+    # JPEG: walk the marker segments to the first frame header (SOFn)
+    if len(data) >= 4 and data[:2] == b"\xff\xd8":
+        offset = 2
+        while offset + 3 < len(data):
+            if data[offset] != 0xFF:
+                return None
+            marker = data[offset + 1]
+            if marker == 0xFF:  # fill byte ahead of a marker
+                offset += 1
+                continue
+            if marker in (0x01, 0xD8) or 0xD0 <= marker <= 0xD7:  # TEM, SOI and RSTn stand alone, without a length
+                offset += 2
+                continue
+            if marker in (0xD9, 0xDA):  # end of image, or scan data before any frame header
+                return None
+            if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                if offset + 8 >= len(data):
+                    return None
+                # length, precision, then height before width
+                height = int.from_bytes(data[offset + 5 : offset + 7], "big")
+                width = int.from_bytes(data[offset + 7 : offset + 9], "big")
+                return width, height
+            offset += 2 + int.from_bytes(data[offset + 2 : offset + 4], "big")
+        return None
+
+    return None
+
+
+# The patch count above which the OpenAI vision API rejects an image instead of resizing it.
+_OPENAI_PATCH_LIMIT = 30000
+
+# The longest side the OpenAI vision API keeps at `original` detail; a larger image is scaled
+# down to fit it before the patches are counted.
+_OPENAI_ORIGINAL_MAX_SIDE = 65535
+
+# Base64 characters decoded on the first attempt: enough for any PNG, GIF or WebP header, and
+# for a JPEG whose metadata segments are of ordinary size.
+_HEADER_PREFIX_CHARS = 64 * 1024
+
+
+def _data_url_bytes(data_url: str, max_chars: int | None) -> bytes | None:
+    """
+    Decode the leading bytes of a base64 data URL.
+
+    Args:
+        data_url (str): The URL.
+        max_chars (int | None): How many base64 characters to decode at most, or None for all of them.
+
+    Returns:
+        bytes | None: The decoded bytes, or None when the URL is not a base64 data URL.
+    """
+    if not data_url.startswith("data:"):
+        return None
+    comma = data_url.find(",")
+    if comma < 0 or "base64" not in data_url[5:comma].split(";"):
+        return None
+    payload = data_url[comma + 1 :]
+    if max_chars is not None:
+        # whole 4-character groups only, so the cut cannot land inside one
+        payload = payload[: min(len(payload), max_chars) & ~3]
+    try:
+        return base64.b64decode(payload)
+    except (binascii.Error, ValueError):
+        return None
+
+
+def exceeds_openai_patch_limit(image_url: str) -> bool:
+    """
+    Whether the OpenAI vision API would reject an image at `original` detail.
+
+    The API covers an image with 32-pixel patches and rejects one that needs more than 30,000 of
+    them after its own resizing; at `original` detail the only resizing is the 65,535-pixel cap
+    on either side. Only a base64 data URL can be measured here: an HTTP(S) URL is fetched by
+    the API itself and answers False.
+
+    Args:
+        image_url (str): The image URL.
+
+    Returns:
+        bool: Whether the API would reject the image.
+    """
+    data = _data_url_bytes(image_url, _HEADER_PREFIX_CHARS)
+    if data is None:
+        return False
+    size = image_dimensions(data)
+    if size is None and data[:2] == b"\xff\xd8":
+        # a JPEG may carry more metadata than the prefix before its frame header
+        data = _data_url_bytes(image_url, None)
+        size = image_dimensions(data) if data is not None else None
+    if size is None:
+        return False
+
+    width, height = size
+    longest = max(width, height)
+    if longest > _OPENAI_ORIGINAL_MAX_SIDE:
+        width = math.floor(width * _OPENAI_ORIGINAL_MAX_SIDE / longest + 0.5)
+        height = math.floor(height * _OPENAI_ORIGINAL_MAX_SIDE / longest + 0.5)
+    return math.ceil(width / 32) * math.ceil(height / 32) > _OPENAI_PATCH_LIMIT

--- a/src_py/agenthub/utils.py
+++ b/src_py/agenthub/utils.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import base64
-import binascii
 import math
 import os
+import re
+from typing import Literal
 
 from .types import UsageMetadata
 
@@ -121,42 +122,65 @@ def image_dimensions(data: bytes) -> tuple[int, int] | None:
     return None
 
 
-# The patch count above which the OpenAI vision API rejects an image instead of resizing it.
+# The patch count above which the OpenAI vision API rejects an image instead of resizing it
+# (Images and vision guide, "Choose an image detail level":
+# https://developers.openai.com/api/docs/guides/images-vision).
 _OPENAI_PATCH_LIMIT = 30000
 
 # The longest side the OpenAI vision API keeps at `original` detail; a larger image is scaled
-# down to fit it before the patches are counted.
+# down to fit it before the patches are counted (the same guide, model sizing table).
 _OPENAI_ORIGINAL_MAX_SIDE = 65535
 
-# Base64 characters decoded on the first attempt: enough for any PNG, GIF or WebP header, and
-# for a JPEG whose metadata segments are of ordinary size.
-_HEADER_PREFIX_CHARS = 64 * 1024
+# Base64 characters decoded first: 48 bytes, enough for any PNG, GIF or WebP header. A JPEG's
+# frame header may sit behind metadata segments, so its window grows by the factor below until
+# the header is found or the payload runs out.
+_HEADER_PROBE_CHARS = 64
+_HEADER_WINDOW_GROWTH = 4
+
+# Characters outside the base64 alphabet, URL-safe variant included, and the map from that
+# variant back to the standard alphabet.
+_NOT_BASE64 = re.compile(r"[^A-Za-z0-9+/_-]")
+_URL_SAFE_TO_STANDARD = str.maketrans("-_", "+/")
 
 
-def _data_url_bytes(data_url: str, max_chars: int | None) -> bytes | None:
+def _base64_payload_start(data_url: str) -> int:
     """
-    Decode the leading bytes of a base64 data URL.
+    Locate the payload of a base64 data URL.
 
     Args:
         data_url (str): The URL.
-        max_chars (int | None): How many base64 characters to decode at most, or None for all of them.
 
     Returns:
-        bytes | None: The decoded bytes, or None when the URL is not a base64 data URL.
+        int: The index of the payload's first character, or -1 when the URL is not a base64 data URL.
     """
     if not data_url.startswith("data:"):
-        return None
+        return -1
     comma = data_url.find(",")
-    if comma < 0 or "base64" not in data_url[5:comma].split(";"):
-        return None
-    payload = data_url[comma + 1 :]
-    if max_chars is not None:
-        # whole 4-character groups only, so the cut cannot land inside one
-        payload = payload[: min(len(payload), max_chars) & ~3]
-    try:
-        return base64.b64decode(payload)
-    except (binascii.Error, ValueError):
-        return None
+    if comma < 0:
+        return -1
+    # the token is case-insensitive and may follow a space, as a browser reads it
+    params = [param.strip().lower() for param in data_url[5:comma].split(";")]
+    return comma + 1 if "base64" in params else -1
+
+
+def _decode_base64_prefix(text: str) -> bytes:
+    """
+    Decode a prefix of a base64 payload the way Node's Buffer does.
+
+    Whitespace and other stray characters are skipped, the URL-safe alphabet is accepted, and a
+    cut inside a 4-character group or missing padding yields the bytes that are complete, so the
+    Python and TypeScript clients measure the same image alike.
+
+    Args:
+        text (str): The leading characters of the payload.
+
+    Returns:
+        bytes: The decoded bytes.
+    """
+    chars = _NOT_BASE64.sub("", text).translate(_URL_SAFE_TO_STANDARD)
+    if len(chars) % 4 == 1:  # a lone trailing character carries no whole byte
+        chars = chars[:-1]
+    return base64.b64decode(chars + "=" * (-len(chars) % 4))
 
 
 def exceeds_openai_patch_limit(image_url: str) -> bool:
@@ -165,8 +189,9 @@ def exceeds_openai_patch_limit(image_url: str) -> bool:
 
     The API covers an image with 32-pixel patches and rejects one that needs more than 30,000 of
     them after its own resizing; at `original` detail the only resizing is the 65,535-pixel cap
-    on either side. Only a base64 data URL can be measured here: an HTTP(S) URL is fetched by
-    the API itself and answers False.
+    on either side. Only a base64 data URL can be measured here: an HTTP(S) URL answers False.
+    The Responses clients pass such a URL through for the API to fetch; the Chat client fetches
+    it into a data URL first, so it measures the fetched bytes.
 
     Args:
         image_url (str): The image URL.
@@ -174,14 +199,17 @@ def exceeds_openai_patch_limit(image_url: str) -> bool:
     Returns:
         bool: Whether the API would reject the image.
     """
-    data = _data_url_bytes(image_url, _HEADER_PREFIX_CHARS)
-    if data is None:
+    start = _base64_payload_start(image_url)
+    if start < 0:
         return False
-    size = image_dimensions(data)
-    if size is None and data[:2] == b"\xff\xd8":
-        # a JPEG may carry more metadata than the prefix before its frame header
-        data = _data_url_bytes(image_url, None)
-        size = image_dimensions(data) if data is not None else None
+    # decode a growing prefix rather than the whole payload
+    chars = _HEADER_PROBE_CHARS
+    while True:
+        data = _decode_base64_prefix(image_url[start : start + chars])
+        size = image_dimensions(data)
+        if size is not None or data[:2] != b"\xff\xd8" or start + chars >= len(image_url):
+            break
+        chars *= _HEADER_WINDOW_GROWTH
     if size is None:
         return False
 
@@ -191,3 +219,25 @@ def exceeds_openai_patch_limit(image_url: str) -> bool:
         width = math.floor(width * _OPENAI_ORIGINAL_MAX_SIDE / longest + 0.5)
         height = math.floor(height * _OPENAI_ORIGINAL_MAX_SIDE / longest + 0.5)
     return math.ceil(width / 32) * math.ceil(height / 32) > _OPENAI_PATCH_LIMIT
+
+
+def openai_image_detail(model: str, image_url: str) -> Literal["high"] | None:
+    """
+    The `detail` an OpenAI image part needs so that the API reads the image.
+
+    GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+    dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the API
+    fit it into 2,500 patches, so the image is read instead of refused. Every other model keeps
+    a patch budget at every detail level, so no other model gets the field.
+
+    Args:
+        model (str): The model id the request is sent with.
+        image_url (str): The image URL as it goes on the wire.
+
+    Returns:
+        Literal["high"] | None: "high" when the image needs it, otherwise None.
+    """
+    if "gpt-5.6" in model.lower() and exceeds_openai_patch_limit(image_url):
+        return "high"
+
+    return None

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -35,6 +35,11 @@ def _gif(width: int, height: int) -> bytes:
     return b"GIF89a" + struct.pack("<HH", width, height) + bytes(3)
 
 
+def _sof(width: int, height: int, marker: int = 0xC0) -> bytes:
+    """A frame header: baseline (SOF0) by default, progressive with 0xC2."""
+    return bytes([0xFF, marker]) + struct.pack(">HBHHB", 8, 8, height, width, 3)
+
+
 def _jpeg(width: int, height: int, metadata_bytes: int = 0) -> bytes:
     """
     The frame header follows `metadata_bytes` of APP1 payload, the way EXIF does; a segment
@@ -49,7 +54,7 @@ def _jpeg(width: int, height: int, metadata_bytes: int = 0) -> bytes:
         if remaining <= 0:
             break
 
-    parts.append(b"\xff\xc0" + struct.pack(">HBHHB", 8, 8, height, width, 3))
+    parts.append(_sof(width, height))
     return b"".join(parts)
 
 
@@ -78,62 +83,89 @@ def _data_url(data: bytes, mime: str = "image/png") -> str:
     return f"data:{mime};base64," + base64.b64encode(data).decode("ascii")
 
 
+# A JPEG whose frame header follows the SOI directly, and a progressive one that puts fill bytes,
+# an empty APP1 segment and a restart marker ahead of it.
+_SOF_FIRST_JPEG = b"\xff\xd8" + _sof(4032, 3024)
+_PROGRESSIVE_JPEG = b"\xff\xd8\xff\xff\xff\xe1\x00\x02\xff\xd0" + _sof(4032, 3024, 0xC2)
+
+# Payloads an encoder other than the clients' own may produce: wrapped at 76 columns the way
+# `base64.encodebytes` and MIME tooling do, without its padding, and in the URL-safe alphabet.
+_WRAPPED_URL = "data:image/png;base64," + base64.encodebytes(_png(6400, 8608) + bytes(100 * 1024)).decode("ascii")
+_UNPADDED_URL = _data_url(_jpeg(8000, 8000, 100 * 1024) + b"\x00", "image/jpeg").rstrip("=")
+_URL_SAFE_URL = "data:image/png;base64," + base64.urlsafe_b64encode(
+    _png(6400, 8608) + b"\xfb\xff\xbf" * 4 + b"\xfb"
+).decode("ascii")
+
+
 @pytest.mark.parametrize(
-    ("name", "data", "expected"),
+    ("data", "expected"),
     [
-        ("PNG", _png(6400, 8608), (6400, 8608)),
-        ("GIF", _gif(640, 480), (640, 480)),
-        ("JPEG", _jpeg(4032, 3024), (4032, 3024)),
-        ("JPEG behind 100 KiB of metadata", _jpeg(4032, 3024, 100 * 1024), (4032, 3024)),
-        ("lossy WebP", _webp_lossy(1920, 1080), (1920, 1080)),
-        ("lossless WebP", _webp_lossless(1920, 1080), (1920, 1080)),
-        ("extended WebP", _webp_extended(1920, 1080), (1920, 1080)),
+        pytest.param(_png(6400, 8608), (6400, 8608), id="PNG"),
+        pytest.param(_gif(640, 480), (640, 480), id="GIF"),
+        pytest.param(_jpeg(4032, 3024), (4032, 3024), id="JPEG"),
+        pytest.param(_jpeg(4032, 3024, 100 * 1024), (4032, 3024), id="JPEG behind 100 KiB of metadata"),
+        pytest.param(_SOF_FIRST_JPEG, (4032, 3024), id="JPEG whose frame header comes first"),
+        pytest.param(_PROGRESSIVE_JPEG, (4032, 3024), id="progressive JPEG behind fill bytes and a restart marker"),
+        pytest.param(_webp_lossy(1920, 1080), (1920, 1080), id="lossy WebP"),
+        pytest.param(_webp_lossless(1920, 1080), (1920, 1080), id="lossless WebP"),
+        pytest.param(_webp_extended(1920, 1080), (1920, 1080), id="extended WebP"),
     ],
-    ids=lambda value: value if isinstance(value, str) else "",
 )
-def test_image_dimensions_reads_the_header(name: str, data: bytes, expected: tuple[int, int]):
+def test_image_dimensions_reads_the_header(data: bytes, expected: tuple[int, int]):
     assert image_dimensions(data) == expected
 
 
 @pytest.mark.parametrize(
-    ("name", "data"),
+    "data",
     [
-        ("empty input", b""),
-        ("text", b"not an image"),
-        ("a PNG cut before its IHDR chunk", _png(6400, 8608)[:16]),
-        ("bytes that spell PNG and IHDR without the PNG signature", b"\x00PNG" + bytes(8) + b"IHDR" + bytes(8)),
-        ("a GIF signature without its version", b"GIFxxx" + bytes(7)),
-        ("a JPEG cut inside a metadata segment", _jpeg(4032, 3024, 1024)[:512]),
-        ("a JPEG whose scan starts before any frame header", b"\xff\xd8\xff\xda\x00\x02\x00\x00"),
-        ("a WebP whose first chunk is not a bitstream", _riff(b"ALPH", bytes(10))),
+        pytest.param(b"", id="empty input"),
+        pytest.param(b"not an image", id="text"),
+        pytest.param(_png(6400, 8608)[:16], id="a PNG cut before its IHDR chunk"),
+        pytest.param(
+            b"\x00PNG" + bytes(8) + b"IHDR" + bytes(8), id="bytes that spell PNG and IHDR without the PNG signature"
+        ),
+        pytest.param(b"GIFxxx" + bytes(7), id="a GIF signature without its version"),
+        pytest.param(_jpeg(4032, 3024, 1024)[:512], id="a JPEG cut inside a metadata segment"),
+        pytest.param(b"\xff\xd8\xff\xda\x00\x02\x00\x00", id="a JPEG whose scan starts before any frame header"),
+        pytest.param(_riff(b"ALPH", bytes(10)), id="a WebP whose first chunk is not a bitstream"),
     ],
-    ids=lambda value: value if isinstance(value, str) else "",
 )
-def test_image_dimensions_reads_unrecognized_bytes_as_none(name: str, data: bytes):
+def test_image_dimensions_reads_unrecognized_bytes_as_none(data: bytes):
     assert image_dimensions(data) is None
 
 
 @pytest.mark.parametrize(
-    ("name", "url", "expected"),
+    ("url", "expected"),
     [
-        ("a 6400x8608 screenshot (53,800 patches)", _data_url(_png(6400, 8608)), True),
-        ("5600x5600 (30,625 patches)", _data_url(_png(5600, 5600)), True),
-        ("5504x5504 (29,584 patches)", _data_url(_png(5504, 5504)), False),
-        ("1024x1024", _data_url(_png(1024, 1024)), False),
-        (
-            "an 8000x8000 JPEG whose frame header sits behind 100 KiB of metadata",
+        pytest.param(_data_url(_png(6400, 8608)), True, id="a 6400x8608 screenshot (53,800 patches)"),
+        pytest.param(_data_url(_png(5600, 5600)), True, id="5600x5600 (30,625 patches)"),
+        pytest.param(_data_url(_png(6400, 4832)), True, id="6400x4832 (30,200 patches)"),
+        pytest.param(_data_url(_png(6400, 4800)), False, id="6400x4800 (exactly 30,000 patches)"),
+        pytest.param(_data_url(_png(5504, 5504)), False, id="5504x5504 (29,584 patches)"),
+        pytest.param(_data_url(_png(1024, 1024)), False, id="1024x1024"),
+        pytest.param(
             _data_url(_jpeg(8000, 8000, 100 * 1024), "image/jpeg"),
             True,
+            id="an 8000x8000 JPEG whose frame header sits behind 100 KiB of metadata",
         ),
-        ("a 131070x500 strip, once scaled to the 65,535-pixel side", _data_url(_png(131070, 500)), False),
-        ("a 131070x1500 strip, still over the limit once scaled", _data_url(_png(131070, 1500)), True),
-        ("an http URL", "https://example.com/huge.png", False),
-        ("a data URL that is not base64", "data:image/png," + quote("not base64"), False),
-        ("a data URL of something that is not an image", _data_url(b"hello"), False),
+        pytest.param(
+            _data_url(_png(131070, 500)), False, id="a 131070x500 strip, once scaled to the 65,535-pixel side"
+        ),
+        pytest.param(_data_url(_png(131070, 1500)), True, id="a 131070x1500 strip, still over the limit once scaled"),
+        pytest.param(_WRAPPED_URL, True, id="a payload wrapped at 76 columns"),
+        pytest.param(_UNPADDED_URL, True, id="an unpadded payload of a JPEG with a deep frame header"),
+        pytest.param(_URL_SAFE_URL, True, id="a payload in the URL-safe alphabet"),
+        pytest.param(
+            "data:image/png;BASE64," + base64.b64encode(_png(6400, 8608)).decode("ascii"),
+            True,
+            id="an upper-case base64 marker",
+        ),
+        pytest.param("https://example.com/huge.png", False, id="an http URL"),
+        pytest.param("data:image/png," + quote("not base64"), False, id="a data URL that is not base64"),
+        pytest.param(_data_url(b"hello"), False, id="a data URL of something that is not an image"),
     ],
-    ids=lambda value: value if isinstance(value, str) and not value.startswith(("data:", "http")) else "",
 )
-def test_exceeds_openai_patch_limit(name: str, url: str, expected: bool):
+def test_exceeds_openai_patch_limit(url: str, expected: bool):
     assert exceeds_openai_patch_limit(url) is expected
 
 
@@ -184,16 +216,18 @@ MESSAGES: list[dict[str, Any]] = [
 ]
 
 
-def _details(case: ImageDetailCase, model_input: list[dict[str, Any]]) -> list[str | None]:
-    """The detail of each image part, in order: the prompt's two images, then the tool result's two."""
-    if case.protocol == "responses":
-        return [part.get("detail") for part in model_input[0]["content"][1:]] + [
-            part.get("detail") for part in model_input[2]["output"][1:]
-        ]
+def _details(case: ImageDetailCase, model_input: list[dict[str, Any]]) -> list[str]:
+    """
+    The detail of each image part, in order: the prompt's two images, then the tool result's two.
 
-    return [part["image_url"].get("detail") for part in model_input[0]["content"][1:]] + [
-        part["image_url"].get("detail") for part in model_input[2]["content"][1:]
-    ]
+    An absent key and an explicit None differ on the wire, so the key itself is reported.
+    """
+    if case.protocol == "responses":
+        parts = model_input[0]["content"][1:] + model_input[2]["output"][1:]
+    else:
+        parts = [part["image_url"] for part in model_input[0]["content"][1:] + model_input[2]["content"][1:]]
+
+    return [part.get("detail", "absent") for part in parts]
 
 
 @pytest.mark.asyncio
@@ -210,5 +244,5 @@ async def test_image_over_the_patch_limit_goes_out_at_high_detail_on_gpt_5_6(cas
     if inspect.isawaitable(model_input):
         model_input = await model_input
 
-    shrunk = "high" if case.shrinks else None
-    assert _details(case, model_input) == [shrunk, None, shrunk, None]
+    shrunk = "high" if case.shrinks else "absent"
+    assert _details(case, model_input) == [shrunk, "absent", shrunk, "absent"]

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -1,0 +1,212 @@
+# Copyright 2025 Prism Shadow. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import inspect
+import struct
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import pytest
+
+from agenthub import AutoLLMClient
+from agenthub.utils import exceeds_openai_patch_limit, image_dimensions
+
+
+# Header builders. Only the bytes the parser reads have to be right, so none of these is a
+# decodable picture; a real file carries the same leading bytes.
+def _png(width: int, height: int) -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + struct.pack(">I", 13) + b"IHDR" + struct.pack(">II", width, height)
+
+
+def _gif(width: int, height: int) -> bytes:
+    return b"GIF89a" + struct.pack("<HH", width, height) + bytes(3)
+
+
+def _jpeg(width: int, height: int, metadata_bytes: int = 0) -> bytes:
+    """
+    The frame header follows `metadata_bytes` of APP1 payload, the way EXIF does; a segment
+    holds at most 65,533 bytes, so a larger amount spans several of them.
+    """
+    parts = [b"\xff\xd8"]
+    remaining = metadata_bytes
+    while True:
+        payload = min(remaining, 65533)
+        parts.append(b"\xff\xe1" + struct.pack(">H", 2 + payload) + bytes(payload))
+        remaining -= payload
+        if remaining <= 0:
+            break
+
+    parts.append(b"\xff\xc0" + struct.pack(">HBHHB", 8, 8, height, width, 3))
+    return b"".join(parts)
+
+
+def _riff(chunk: bytes, payload: bytes) -> bytes:
+    return (
+        b"RIFF" + struct.pack("<I", 4 + 8 + len(payload)) + b"WEBP" + chunk + struct.pack("<I", len(payload)) + payload
+    )
+
+
+def _webp_lossy(width: int, height: int) -> bytes:
+    """The scaling bits above the 14-bit size are set, to prove they are masked off."""
+    return _riff(b"VP8 ", bytes(3) + b"\x9d\x01\x2a" + struct.pack("<HH", width | (2 << 14), height | (1 << 14)))
+
+
+def _webp_lossless(width: int, height: int) -> bytes:
+    """The alpha flag above the two 14-bit sizes is set, to prove it is masked off."""
+    bits = (width - 1) | ((height - 1) << 14) | (1 << 28)
+    return _riff(b"VP8L", b"\x2f" + struct.pack("<I", bits) + bytes(5))
+
+
+def _webp_extended(width: int, height: int) -> bytes:
+    return _riff(b"VP8X", b"\x10\x00\x00\x00" + (width - 1).to_bytes(3, "little") + (height - 1).to_bytes(3, "little"))
+
+
+def _data_url(data: bytes, mime: str = "image/png") -> str:
+    return f"data:{mime};base64," + base64.b64encode(data).decode("ascii")
+
+
+@pytest.mark.parametrize(
+    ("name", "data", "expected"),
+    [
+        ("PNG", _png(6400, 8608), (6400, 8608)),
+        ("GIF", _gif(640, 480), (640, 480)),
+        ("JPEG", _jpeg(4032, 3024), (4032, 3024)),
+        ("JPEG behind 100 KiB of metadata", _jpeg(4032, 3024, 100 * 1024), (4032, 3024)),
+        ("lossy WebP", _webp_lossy(1920, 1080), (1920, 1080)),
+        ("lossless WebP", _webp_lossless(1920, 1080), (1920, 1080)),
+        ("extended WebP", _webp_extended(1920, 1080), (1920, 1080)),
+    ],
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_image_dimensions_reads_the_header(name: str, data: bytes, expected: tuple[int, int]):
+    assert image_dimensions(data) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "data"),
+    [
+        ("empty input", b""),
+        ("text", b"not an image"),
+        ("a PNG cut before its IHDR chunk", _png(6400, 8608)[:16]),
+        ("a JPEG cut inside a metadata segment", _jpeg(4032, 3024, 1024)[:512]),
+        ("a JPEG whose scan starts before any frame header", b"\xff\xd8\xff\xda\x00\x02\x00\x00"),
+        ("a WebP whose first chunk is not a bitstream", _riff(b"ALPH", bytes(10))),
+    ],
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_image_dimensions_reads_unrecognized_bytes_as_none(name: str, data: bytes):
+    assert image_dimensions(data) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "url", "expected"),
+    [
+        ("a 6400x8608 screenshot (53,800 patches)", _data_url(_png(6400, 8608)), True),
+        ("5600x5600 (30,625 patches)", _data_url(_png(5600, 5600)), True),
+        ("5504x5504 (29,584 patches)", _data_url(_png(5504, 5504)), False),
+        ("1024x1024", _data_url(_png(1024, 1024)), False),
+        (
+            "an 8000x8000 JPEG whose frame header sits behind 100 KiB of metadata",
+            _data_url(_jpeg(8000, 8000, 100 * 1024), "image/jpeg"),
+            True,
+        ),
+        ("a 131070x500 strip, once scaled to the 65,535-pixel side", _data_url(_png(131070, 500)), False),
+        ("a 131070x1500 strip, still over the limit once scaled", _data_url(_png(131070, 1500)), True),
+        ("an http URL", "https://example.com/huge.png", False),
+        ("a data URL that is not base64", "data:image/png," + quote("not base64"), False),
+        ("a data URL of something that is not an image", _data_url(b"hello"), False),
+    ],
+    ids=lambda value: value if isinstance(value, str) and not value.startswith(("data:", "http")) else "",
+)
+def test_exceeds_openai_patch_limit(name: str, url: str, expected: bool):
+    assert exceeds_openai_patch_limit(url) is expected
+
+
+@dataclass
+class ImageDetailCase:
+    expected_client: str
+    model: str
+    client_type: str | None
+    protocol: str
+    # whether an image over the patch limit goes out at high detail
+    shrinks: bool
+
+
+IMAGE_DETAIL_CASES = [
+    ImageDetailCase("GPT5_6Client", "gpt-5.6-terra", None, "responses", True),
+    ImageDetailCase("GPT5_6Client", "gpt-5.5", None, "responses", False),
+    ImageDetailCase("OpenaiResponsesClient", "openai/gpt-5.6-terra", "openai-responses", "responses", True),
+    ImageDetailCase("OpenaiResponsesClient", "deepseek-v4-flash-vision-exp", "openai-responses", "responses", False),
+    ImageDetailCase("OpenaiChatClient", "GPT-5.6-Sol", "openai-chat", "chat", True),
+    ImageDetailCase("OpenaiChatClient", "gpt-5.5", "openai-chat", "chat", False),
+]
+
+OVERSIZED = _data_url(_png(6400, 8608))
+SMALL = _data_url(_png(1024, 1024))
+
+# A prompt carrying an oversized image next to a small one, and a tool result carrying both again.
+MESSAGES: list[dict[str, Any]] = [
+    {
+        "role": "user",
+        "content_items": [
+            {"type": "text", "text": "What is in these?"},
+            {"type": "image_url", "image_url": OVERSIZED},
+            {"type": "image_url", "image_url": SMALL},
+        ],
+    },
+    {
+        "role": "assistant",
+        "content_items": [
+            {"type": "tool_call", "name": "read_image", "arguments": {"path": "shot.png"}, "tool_call_id": "call_1"}
+        ],
+    },
+    {
+        "role": "user",
+        "content_items": [
+            {"type": "tool_result", "text": "image/png", "images": [OVERSIZED, SMALL], "tool_call_id": "call_1"}
+        ],
+    },
+]
+
+
+def _details(case: ImageDetailCase, model_input: list[dict[str, Any]]) -> list[str | None]:
+    """The detail of each image part, in order: the prompt's two images, then the tool result's two."""
+    if case.protocol == "responses":
+        return [part.get("detail") for part in model_input[0]["content"][1:]] + [
+            part.get("detail") for part in model_input[2]["output"][1:]
+        ]
+
+    return [part["image_url"].get("detail") for part in model_input[0]["content"][1:]] + [
+        part["image_url"].get("detail") for part in model_input[2]["content"][1:]
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    IMAGE_DETAIL_CASES,
+    ids=[f"{case.model}:{case.client_type or 'auto'}" for case in IMAGE_DETAIL_CASES],
+)
+async def test_image_over_the_patch_limit_goes_out_at_high_detail_on_gpt_5_6(case: ImageDetailCase):
+    client = AutoLLMClient(model=case.model, api_key="test-key", client_type=case.client_type)
+    assert client._client.__class__.__name__ == case.expected_client  # noqa: SLF001
+
+    model_input = client._client.transform_uni_message_to_model_input(MESSAGES)  # noqa: SLF001
+    if inspect.isawaitable(model_input):
+        model_input = await model_input
+
+    shrunk = "high" if case.shrinks else None
+    assert _details(case, model_input) == [shrunk, None, shrunk, None]

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -101,6 +101,8 @@ def test_image_dimensions_reads_the_header(name: str, data: bytes, expected: tup
         ("empty input", b""),
         ("text", b"not an image"),
         ("a PNG cut before its IHDR chunk", _png(6400, 8608)[:16]),
+        ("bytes that spell PNG and IHDR without the PNG signature", b"\x00PNG" + bytes(8) + b"IHDR" + bytes(8)),
+        ("a GIF signature without its version", b"GIFxxx" + bytes(7)),
         ("a JPEG cut inside a metadata segment", _jpeg(4032, 3024, 1024)[:512]),
         ("a JPEG whose scan starts before any frame header", b"\xff\xd8\xff\xda\x00\x02\x00\x00"),
         ("a WebP whose first chunk is not a bitstream", _riff(b"ALPH", bytes(10))),

--- a/src_ts/src/gpt5_6/client.ts
+++ b/src_ts/src/gpt5_6/client.ts
@@ -35,7 +35,7 @@ import {
   PromptCaching,
   UsageMetadata,
 } from "../types";
-import { isDebugEnabled } from "../utils";
+import { exceedsOpenaiPatchLimit, isDebugEnabled } from "../utils";
 
 /**
  * GPT-5.6-specific LLM client implementation (also serves GPT-5.4 and GPT-5.5).
@@ -93,6 +93,28 @@ export class GPT5_6Client extends LLMClient {
     }
 
     return toolChoice;
+  }
+
+  /**
+   * Convert an image URL to an input_image item.
+   *
+   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+   * API fit it into 2,500 patches, so the image is read instead of refused.
+   */
+  private _convertImageUrl(imageUrl: string): {
+    type: "input_image";
+    image_url: string;
+    detail?: "high";
+  } {
+    if (
+      this._model.toLowerCase().includes("gpt-5.6") &&
+      exceedsOpenaiPatchLimit(imageUrl)
+    ) {
+      return { type: "input_image", image_url: imageUrl, detail: "high" };
+    }
+
+    return { type: "input_image", image_url: imageUrl };
   }
 
   /**
@@ -218,10 +240,7 @@ export class GPT5_6Client extends LLMClient {
             contentItems.push({ type: "output_text", text: item.text });
           }
         } else if (item.type === "image_url") {
-          contentItems.push({
-            type: "input_image",
-            image_url: item.image_url,
-          });
+          contentItems.push(this._convertImageUrl(item.image_url));
         } else if (item.type === "thinking") {
           // rebuild the reasoning item from the recorded wire fields: the thinking
           // text goes back through the channel that carried it (histories recorded
@@ -269,7 +288,7 @@ export class GPT5_6Client extends LLMClient {
 
           if (item.images) {
             for (const imageUrl of item.images) {
-              toolResult.push({ type: "input_image", image_url: imageUrl });
+              toolResult.push(this._convertImageUrl(imageUrl));
             }
           }
 

--- a/src_ts/src/gpt5_6/client.ts
+++ b/src_ts/src/gpt5_6/client.ts
@@ -35,7 +35,7 @@ import {
   PromptCaching,
   UsageMetadata,
 } from "../types";
-import { exceedsOpenaiPatchLimit, isDebugEnabled } from "../utils";
+import { isDebugEnabled, openaiImageDetail } from "../utils";
 
 /**
  * GPT-5.6-specific LLM client implementation (also serves GPT-5.4 and GPT-5.5).
@@ -96,25 +96,18 @@ export class GPT5_6Client extends LLMClient {
   }
 
   /**
-   * Convert an image URL to an input_image item.
-   *
-   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-   * API fit it into 2,500 patches, so the image is read instead of refused.
+   * Convert an image URL to an input_image item, at the detail the API needs
+   * to read it.
    */
   private _convertImageUrl(imageUrl: string): {
     type: "input_image";
     image_url: string;
     detail?: "high";
   } {
-    if (
-      this._model.toLowerCase().includes("gpt-5.6") &&
-      exceedsOpenaiPatchLimit(imageUrl)
-    ) {
-      return { type: "input_image", image_url: imageUrl, detail: "high" };
-    }
-
-    return { type: "input_image", image_url: imageUrl };
+    const detail = openaiImageDetail(this._model, imageUrl);
+    return detail
+      ? { type: "input_image", image_url: imageUrl, detail }
+      : { type: "input_image", image_url: imageUrl };
   }
 
   /**

--- a/src_ts/src/openai_chat/client.ts
+++ b/src_ts/src/openai_chat/client.ts
@@ -35,7 +35,7 @@ import {
   UniMessage,
   UsageMetadata,
 } from "../types";
-import { fixOpenrouterUsageMetadata } from "../utils";
+import { exceedsOpenaiPatchLimit, fixOpenrouterUsageMetadata } from "../utils";
 
 /**
  * OpenAI Chat Completions-compatible client implementation.
@@ -129,6 +129,27 @@ export class OpenaiChatClient extends LLMClient {
   }
 
   /**
+   * Convert a fetched image to an image_url part.
+   *
+   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+   * API fit it into 2,500 patches, so the image is read instead of refused.
+   */
+  private _convertImageUrl(dataUrl: string): {
+    type: "image_url";
+    image_url: { url: string; detail?: "high" };
+  } {
+    if (
+      this._model.toLowerCase().includes("gpt-5.6") &&
+      exceedsOpenaiPatchLimit(dataUrl)
+    ) {
+      return { type: "image_url", image_url: { url: dataUrl, detail: "high" } };
+    }
+
+    return { type: "image_url", image_url: { url: dataUrl } };
+  }
+
+  /**
    * Transform universal configuration to OpenAI Chat Completions configuration.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -190,7 +211,7 @@ export class OpenaiChatClient extends LLMClient {
       const contentParts: Array<{
         type: string;
         text?: string;
-        image_url?: { url: string };
+        image_url?: { url: string; detail?: string };
       }> = [];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const toolCalls: any[] = [];
@@ -205,10 +226,7 @@ export class OpenaiChatClient extends LLMClient {
             item.image_url,
             signal,
           );
-          contentParts.push({
-            type: "image_url",
-            image_url: { url: base64Image },
-          });
+          contentParts.push(this._convertImageUrl(base64Image));
         } else if (item.type === "thinking") {
           thinking += item.thinking;
           thinkingFields.add(item.fidelity?.reasoning_field);
@@ -235,16 +253,11 @@ export class OpenaiChatClient extends LLMClient {
                 imageUrl,
                 signal,
               );
+              const part = this._convertImageUrl(base64Image);
               if (this._client.baseURL.includes("siliconflow.cn")) {
-                contentParts.push({
-                  type: "image_url",
-                  image_url: { url: base64Image },
-                });
+                contentParts.push(part);
               } else {
-                content.push({
-                  type: "image_url",
-                  image_url: { url: base64Image },
-                });
+                content.push(part);
               }
             }
           }

--- a/src_ts/src/openai_chat/client.ts
+++ b/src_ts/src/openai_chat/client.ts
@@ -35,7 +35,7 @@ import {
   UniMessage,
   UsageMetadata,
 } from "../types";
-import { exceedsOpenaiPatchLimit, fixOpenrouterUsageMetadata } from "../utils";
+import { fixOpenrouterUsageMetadata, openaiImageDetail } from "../utils";
 
 /**
  * OpenAI Chat Completions-compatible client implementation.
@@ -129,24 +129,17 @@ export class OpenaiChatClient extends LLMClient {
   }
 
   /**
-   * Convert a fetched image to an image_url part.
-   *
-   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-   * API fit it into 2,500 patches, so the image is read instead of refused.
+   * Convert a fetched image to an image_url part, at the detail the API needs
+   * to read it.
    */
   private _convertImageUrl(dataUrl: string): {
     type: "image_url";
     image_url: { url: string; detail?: "high" };
   } {
-    if (
-      this._model.toLowerCase().includes("gpt-5.6") &&
-      exceedsOpenaiPatchLimit(dataUrl)
-    ) {
-      return { type: "image_url", image_url: { url: dataUrl, detail: "high" } };
-    }
-
-    return { type: "image_url", image_url: { url: dataUrl } };
+    const detail = openaiImageDetail(this._model, dataUrl);
+    return detail
+      ? { type: "image_url", image_url: { url: dataUrl, detail } }
+      : { type: "image_url", image_url: { url: dataUrl } };
   }
 
   /**
@@ -211,7 +204,7 @@ export class OpenaiChatClient extends LLMClient {
       const contentParts: Array<{
         type: string;
         text?: string;
-        image_url?: { url: string; detail?: string };
+        image_url?: { url: string; detail?: "high" };
       }> = [];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const toolCalls: any[] = [];

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -35,7 +35,7 @@ import {
   PromptCaching,
   UsageMetadata,
 } from "../types";
-import { isDebugEnabled } from "../utils";
+import { exceedsOpenaiPatchLimit, isDebugEnabled } from "../utils";
 
 /**
  * OpenAI Responses-compatible client implementation.
@@ -93,6 +93,28 @@ export class OpenaiResponsesClient extends LLMClient {
     }
 
     return toolChoice;
+  }
+
+  /**
+   * Convert an image URL to an input_image item.
+   *
+   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
+   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
+   * API fit it into 2,500 patches, so the image is read instead of refused.
+   */
+  private _convertImageUrl(imageUrl: string): {
+    type: "input_image";
+    image_url: string;
+    detail?: "high";
+  } {
+    if (
+      this._model.toLowerCase().includes("gpt-5.6") &&
+      exceedsOpenaiPatchLimit(imageUrl)
+    ) {
+      return { type: "input_image", image_url: imageUrl, detail: "high" };
+    }
+
+    return { type: "input_image", image_url: imageUrl };
   }
 
   /**
@@ -215,10 +237,7 @@ export class OpenaiResponsesClient extends LLMClient {
             contentItems.push({ type: "output_text", text: item.text });
           }
         } else if (item.type === "image_url") {
-          contentItems.push({
-            type: "input_image",
-            image_url: item.image_url,
-          });
+          contentItems.push(this._convertImageUrl(item.image_url));
         } else if (item.type === "thinking") {
           // the wire shape differs by server: OpenAI-style servers stream summaries and
           // demand the summary key back (with encrypted_content preserved), while
@@ -262,7 +281,7 @@ export class OpenaiResponsesClient extends LLMClient {
 
           if (item.images) {
             for (const imageUrl of item.images) {
-              toolResult.push({ type: "input_image", image_url: imageUrl });
+              toolResult.push(this._convertImageUrl(imageUrl));
             }
           }
 

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -35,7 +35,7 @@ import {
   PromptCaching,
   UsageMetadata,
 } from "../types";
-import { exceedsOpenaiPatchLimit, isDebugEnabled } from "../utils";
+import { isDebugEnabled, openaiImageDetail } from "../utils";
 
 /**
  * OpenAI Responses-compatible client implementation.
@@ -96,25 +96,18 @@ export class OpenaiResponsesClient extends LLMClient {
   }
 
   /**
-   * Convert an image URL to an input_image item.
-   *
-   * GPT-5.6 reads the default `auto` detail as `original`, which keeps the image's own
-   * dimensions and rejects one over 30,000 patches instead of resizing it; `high` has the
-   * API fit it into 2,500 patches, so the image is read instead of refused.
+   * Convert an image URL to an input_image item, at the detail the API needs
+   * to read it.
    */
   private _convertImageUrl(imageUrl: string): {
     type: "input_image";
     image_url: string;
     detail?: "high";
   } {
-    if (
-      this._model.toLowerCase().includes("gpt-5.6") &&
-      exceedsOpenaiPatchLimit(imageUrl)
-    ) {
-      return { type: "input_image", image_url: imageUrl, detail: "high" };
-    }
-
-    return { type: "input_image", image_url: imageUrl };
+    const detail = openaiImageDetail(this._model, imageUrl);
+    return detail
+      ? { type: "input_image", image_url: imageUrl, detail }
+      : { type: "input_image", image_url: imageUrl };
   }
 
   /**

--- a/src_ts/src/utils.ts
+++ b/src_ts/src/utils.ts
@@ -69,39 +69,31 @@ export interface ImageDimensions {
  * @param bytes - The image bytes, or a prefix of them.
  * @returns The dimensions, or null when the bytes are not a recognized image.
  */
-export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
-  const ascii = (offset: number, length: number): string =>
-    String.fromCharCode(...bytes.subarray(offset, offset + length));
-  const u16be = (offset: number): number =>
-    (bytes[offset] << 8) | bytes[offset + 1];
-  const u16le = (offset: number): number =>
-    bytes[offset] | (bytes[offset + 1] << 8);
-  const u24le = (offset: number): number =>
-    bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
-  const u32be = (offset: number): number =>
-    ((bytes[offset] << 24) |
-      (bytes[offset + 1] << 16) |
-      (bytes[offset + 2] << 8) |
-      bytes[offset + 3]) >>>
-    0;
-
+export function imageDimensions(bytes: Buffer): ImageDimensions | null {
   // PNG: an 8-byte signature, then the IHDR chunk with width and height
   if (
     bytes.length >= 24 &&
-    ascii(0, 8) === "\x89PNG\r\n\x1a\n" &&
-    ascii(12, 4) === "IHDR"
+    bytes.toString("latin1", 0, 8) === "\x89PNG\r\n\x1a\n" &&
+    bytes.toString("latin1", 12, 16) === "IHDR"
   ) {
-    return { width: u32be(16), height: u32be(20) };
+    return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
   }
 
   // GIF: the logical screen size follows the 6-byte signature
-  if (bytes.length >= 10 && ["GIF87a", "GIF89a"].includes(ascii(0, 6))) {
-    return { width: u16le(6), height: u16le(8) };
+  if (
+    bytes.length >= 10 &&
+    ["GIF87a", "GIF89a"].includes(bytes.toString("latin1", 0, 6))
+  ) {
+    return { width: bytes.readUInt16LE(6), height: bytes.readUInt16LE(8) };
   }
 
   // WebP: a RIFF container whose first chunk names the bitstream flavour
-  if (bytes.length >= 30 && ascii(0, 4) === "RIFF" && ascii(8, 4) === "WEBP") {
-    const chunk = ascii(12, 4);
+  if (
+    bytes.length >= 30 &&
+    bytes.toString("latin1", 0, 4) === "RIFF" &&
+    bytes.toString("latin1", 8, 12) === "WEBP"
+  ) {
+    const chunk = bytes.toString("latin1", 12, 16);
     if (
       chunk === "VP8 " &&
       bytes[23] === 0x9d &&
@@ -110,11 +102,14 @@ export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
     ) {
       // lossy: a 3-byte frame tag and the key frame start code precede the size,
       // whose top two bits are a scaling hint
-      return { width: u16le(26) & 0x3fff, height: u16le(28) & 0x3fff };
+      return {
+        width: bytes.readUInt16LE(26) & 0x3fff,
+        height: bytes.readUInt16LE(28) & 0x3fff,
+      };
     }
     if (chunk === "VP8L" && bytes[20] === 0x2f) {
       // lossless: 14 bits of width minus one, then 14 bits of height minus one
-      const bits = u24le(21) | (bytes[24] << 24);
+      const bits = bytes.readUInt32LE(21);
       return {
         width: (bits & 0x3fff) + 1,
         height: ((bits >>> 14) & 0x3fff) + 1,
@@ -122,7 +117,10 @@ export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
     }
     if (chunk === "VP8X") {
       // extended: the canvas size minus one, 24 bits each, after the flags
-      return { width: u24le(24) + 1, height: u24le(27) + 1 };
+      return {
+        width: bytes.readUIntLE(24, 3) + 1,
+        height: bytes.readUIntLE(27, 3) + 1,
+      };
     }
     return null;
   }
@@ -164,9 +162,12 @@ export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
           return null;
         }
         // length, precision, then height before width
-        return { width: u16be(offset + 7), height: u16be(offset + 5) };
+        return {
+          width: bytes.readUInt16BE(offset + 7),
+          height: bytes.readUInt16BE(offset + 5),
+        };
       }
-      offset += 2 + u16be(offset + 2);
+      offset += 2 + bytes.readUInt16BE(offset + 2);
     }
     return null;
   }
@@ -176,40 +177,48 @@ export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
 
 /**
  * The patch count above which the OpenAI vision API rejects an image instead
- * of resizing it.
+ * of resizing it (Images and vision guide, "Choose an image detail level":
+ * https://developers.openai.com/api/docs/guides/images-vision).
  */
 const OPENAI_PATCH_LIMIT = 30000;
 
 /**
  * The longest side the OpenAI vision API keeps at `original` detail; a larger
- * image is scaled down to fit it before the patches are counted.
+ * image is scaled down to fit it before the patches are counted (the same
+ * guide, model sizing table).
  */
 const OPENAI_ORIGINAL_MAX_SIDE = 65535;
 
 /**
- * Base64 characters decoded on the first attempt: enough for any PNG, GIF or
- * WebP header, and for a JPEG whose metadata segments are of ordinary size.
+ * Base64 characters decoded first: 48 bytes, enough for any PNG, GIF or WebP
+ * header. A JPEG's frame header may sit behind metadata segments, so its
+ * window grows by the factor below until the header is found or the payload
+ * runs out.
  */
-const HEADER_PREFIX_CHARS = 64 * 1024;
+const HEADER_PROBE_CHARS = 64;
+const HEADER_WINDOW_GROWTH = 4;
 
 /**
- * Decode the leading bytes of a base64 data URL.
+ * Locate the payload of a base64 data URL.
  *
  * @param dataUrl - The URL.
- * @param maxChars - How many base64 characters to decode at most.
- * @returns The decoded bytes, or null when the URL is not a base64 data URL.
+ * @returns The index of the payload's first character, or -1 when the URL is
+ *   not a base64 data URL.
  */
-function dataUrlBytes(dataUrl: string, maxChars: number): Buffer | null {
+function base64PayloadStart(dataUrl: string): number {
   if (!dataUrl.startsWith("data:")) {
-    return null;
+    return -1;
   }
   const comma = dataUrl.indexOf(",");
-  if (comma < 0 || !dataUrl.slice(5, comma).split(";").includes("base64")) {
-    return null;
+  if (comma < 0) {
+    return -1;
   }
-  // whole 4-character groups only, so the cut cannot land inside one
-  const chars = Math.min(dataUrl.length - comma - 1, maxChars) & ~3;
-  return Buffer.from(dataUrl.slice(comma + 1, comma + 1 + chars), "base64");
+  // the token is case-insensitive and may follow a space, as a browser reads it
+  const params = dataUrl
+    .slice(5, comma)
+    .split(";")
+    .map((param) => param.trim().toLowerCase());
+  return params.includes("base64") ? comma + 1 : -1;
 }
 
 /**
@@ -218,22 +227,33 @@ function dataUrlBytes(dataUrl: string, maxChars: number): Buffer | null {
  * The API covers an image with 32-pixel patches and rejects one that needs
  * more than 30,000 of them after its own resizing; at `original` detail the
  * only resizing is the 65,535-pixel cap on either side. Only a base64 data URL
- * can be measured here: an HTTP(S) URL is fetched by the API itself and
- * answers false.
+ * can be measured here: an HTTP(S) URL answers false. The Responses clients
+ * pass such a URL through for the API to fetch; the Chat client fetches it
+ * into a data URL first, so it measures the fetched bytes.
  *
  * @param imageUrl - The image URL.
  * @returns Whether the API would reject the image.
  */
 export function exceedsOpenaiPatchLimit(imageUrl: string): boolean {
-  let bytes = dataUrlBytes(imageUrl, HEADER_PREFIX_CHARS);
-  if (bytes === null) {
+  const start = base64PayloadStart(imageUrl);
+  if (start < 0) {
     return false;
   }
-  let size = imageDimensions(bytes);
-  if (size === null && bytes[0] === 0xff && bytes[1] === 0xd8) {
-    // a JPEG may carry more metadata than the prefix before its frame header
-    bytes = dataUrlBytes(imageUrl, Infinity) as Buffer;
+  // Decode a growing prefix rather than the whole payload. Node's decoder
+  // skips whitespace, accepts the URL-safe alphabet and yields the bytes that
+  // are complete at a cut, so the window is sliced by character count alone.
+  let size: ImageDimensions | null = null;
+  for (let chars = HEADER_PROBE_CHARS; ; chars *= HEADER_WINDOW_GROWTH) {
+    const bytes = Buffer.from(imageUrl.slice(start, start + chars), "base64");
     size = imageDimensions(bytes);
+    if (
+      size !== null ||
+      bytes[0] !== 0xff ||
+      bytes[1] !== 0xd8 ||
+      start + chars >= imageUrl.length
+    ) {
+      break;
+    }
   }
   if (size === null) {
     return false;
@@ -246,4 +266,27 @@ export function exceedsOpenaiPatchLimit(imageUrl: string): boolean {
     height = Math.round((height * OPENAI_ORIGINAL_MAX_SIDE) / longest);
   }
   return Math.ceil(width / 32) * Math.ceil(height / 32) > OPENAI_PATCH_LIMIT;
+}
+
+/**
+ * The `detail` an OpenAI image part needs so that the API reads the image.
+ *
+ * GPT-5.6 reads the default `auto` detail as `original`, which keeps the
+ * image's own dimensions and rejects one over 30,000 patches instead of
+ * resizing it; `high` has the API fit it into 2,500 patches, so the image is
+ * read instead of refused. Every other model keeps a patch budget at every
+ * detail level, so no other model gets the field.
+ *
+ * @param model - The model id the request is sent with.
+ * @param imageUrl - The image URL as it goes on the wire.
+ * @returns `"high"` when the image needs it, otherwise undefined.
+ */
+export function openaiImageDetail(
+  model: string,
+  imageUrl: string,
+): "high" | undefined {
+  return model.toLowerCase().includes("gpt-5.6") &&
+    exceedsOpenaiPatchLimit(imageUrl)
+    ? "high"
+    : undefined;
 }

--- a/src_ts/src/utils.ts
+++ b/src_ts/src/utils.ts
@@ -86,12 +86,16 @@ export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
     0;
 
   // PNG: an 8-byte signature, then the IHDR chunk with width and height
-  if (bytes.length >= 24 && ascii(1, 3) === "PNG" && ascii(12, 4) === "IHDR") {
+  if (
+    bytes.length >= 24 &&
+    ascii(0, 8) === "\x89PNG\r\n\x1a\n" &&
+    ascii(12, 4) === "IHDR"
+  ) {
     return { width: u32be(16), height: u32be(20) };
   }
 
   // GIF: the logical screen size follows the 6-byte signature
-  if (bytes.length >= 10 && ascii(0, 3) === "GIF") {
+  if (bytes.length >= 10 && ["GIF87a", "GIF89a"].includes(ascii(0, 6))) {
     return { width: u16le(6), height: u16le(8) };
   }
 

--- a/src_ts/src/utils.ts
+++ b/src_ts/src/utils.ts
@@ -53,3 +53,193 @@ export function isDebugEnabled(): boolean {
   const flag = (process.env.AGENTHUB_DEBUG || "").trim().toLowerCase();
   return !["", "0", "false", "no", "off"].includes(flag);
 }
+
+/** Pixel dimensions read from an image header. */
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Read the pixel dimensions from the header of a PNG, JPEG, GIF or WebP image.
+ *
+ * Only the header is inspected, so the bytes may be a prefix of the file; a
+ * prefix that ends before the dimensions are reached reads as unrecognized.
+ *
+ * @param bytes - The image bytes, or a prefix of them.
+ * @returns The dimensions, or null when the bytes are not a recognized image.
+ */
+export function imageDimensions(bytes: Uint8Array): ImageDimensions | null {
+  const ascii = (offset: number, length: number): string =>
+    String.fromCharCode(...bytes.subarray(offset, offset + length));
+  const u16be = (offset: number): number =>
+    (bytes[offset] << 8) | bytes[offset + 1];
+  const u16le = (offset: number): number =>
+    bytes[offset] | (bytes[offset + 1] << 8);
+  const u24le = (offset: number): number =>
+    bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+  const u32be = (offset: number): number =>
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0;
+
+  // PNG: an 8-byte signature, then the IHDR chunk with width and height
+  if (bytes.length >= 24 && ascii(1, 3) === "PNG" && ascii(12, 4) === "IHDR") {
+    return { width: u32be(16), height: u32be(20) };
+  }
+
+  // GIF: the logical screen size follows the 6-byte signature
+  if (bytes.length >= 10 && ascii(0, 3) === "GIF") {
+    return { width: u16le(6), height: u16le(8) };
+  }
+
+  // WebP: a RIFF container whose first chunk names the bitstream flavour
+  if (bytes.length >= 30 && ascii(0, 4) === "RIFF" && ascii(8, 4) === "WEBP") {
+    const chunk = ascii(12, 4);
+    if (
+      chunk === "VP8 " &&
+      bytes[23] === 0x9d &&
+      bytes[24] === 0x01 &&
+      bytes[25] === 0x2a
+    ) {
+      // lossy: a 3-byte frame tag and the key frame start code precede the size,
+      // whose top two bits are a scaling hint
+      return { width: u16le(26) & 0x3fff, height: u16le(28) & 0x3fff };
+    }
+    if (chunk === "VP8L" && bytes[20] === 0x2f) {
+      // lossless: 14 bits of width minus one, then 14 bits of height minus one
+      const bits = u24le(21) | (bytes[24] << 24);
+      return {
+        width: (bits & 0x3fff) + 1,
+        height: ((bits >>> 14) & 0x3fff) + 1,
+      };
+    }
+    if (chunk === "VP8X") {
+      // extended: the canvas size minus one, 24 bits each, after the flags
+      return { width: u24le(24) + 1, height: u24le(27) + 1 };
+    }
+    return null;
+  }
+
+  // JPEG: walk the marker segments to the first frame header (SOFn)
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    let offset = 2;
+    while (offset + 3 < bytes.length) {
+      if (bytes[offset] !== 0xff) {
+        return null;
+      }
+      const marker = bytes[offset + 1];
+      if (marker === 0xff) {
+        // fill byte ahead of a marker
+        offset += 1;
+        continue;
+      }
+      if (
+        marker === 0x01 ||
+        marker === 0xd8 ||
+        (marker >= 0xd0 && marker <= 0xd7)
+      ) {
+        // TEM, SOI and RSTn stand alone, without a length
+        offset += 2;
+        continue;
+      }
+      if (marker === 0xd9 || marker === 0xda) {
+        // end of image, or scan data before any frame header
+        return null;
+      }
+      const frameHeader =
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc;
+      if (frameHeader) {
+        if (offset + 8 >= bytes.length) {
+          return null;
+        }
+        // length, precision, then height before width
+        return { width: u16be(offset + 7), height: u16be(offset + 5) };
+      }
+      offset += 2 + u16be(offset + 2);
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * The patch count above which the OpenAI vision API rejects an image instead
+ * of resizing it.
+ */
+const OPENAI_PATCH_LIMIT = 30000;
+
+/**
+ * The longest side the OpenAI vision API keeps at `original` detail; a larger
+ * image is scaled down to fit it before the patches are counted.
+ */
+const OPENAI_ORIGINAL_MAX_SIDE = 65535;
+
+/**
+ * Base64 characters decoded on the first attempt: enough for any PNG, GIF or
+ * WebP header, and for a JPEG whose metadata segments are of ordinary size.
+ */
+const HEADER_PREFIX_CHARS = 64 * 1024;
+
+/**
+ * Decode the leading bytes of a base64 data URL.
+ *
+ * @param dataUrl - The URL.
+ * @param maxChars - How many base64 characters to decode at most.
+ * @returns The decoded bytes, or null when the URL is not a base64 data URL.
+ */
+function dataUrlBytes(dataUrl: string, maxChars: number): Buffer | null {
+  if (!dataUrl.startsWith("data:")) {
+    return null;
+  }
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0 || !dataUrl.slice(5, comma).split(";").includes("base64")) {
+    return null;
+  }
+  // whole 4-character groups only, so the cut cannot land inside one
+  const chars = Math.min(dataUrl.length - comma - 1, maxChars) & ~3;
+  return Buffer.from(dataUrl.slice(comma + 1, comma + 1 + chars), "base64");
+}
+
+/**
+ * Whether the OpenAI vision API would reject an image at `original` detail.
+ *
+ * The API covers an image with 32-pixel patches and rejects one that needs
+ * more than 30,000 of them after its own resizing; at `original` detail the
+ * only resizing is the 65,535-pixel cap on either side. Only a base64 data URL
+ * can be measured here: an HTTP(S) URL is fetched by the API itself and
+ * answers false.
+ *
+ * @param imageUrl - The image URL.
+ * @returns Whether the API would reject the image.
+ */
+export function exceedsOpenaiPatchLimit(imageUrl: string): boolean {
+  let bytes = dataUrlBytes(imageUrl, HEADER_PREFIX_CHARS);
+  if (bytes === null) {
+    return false;
+  }
+  let size = imageDimensions(bytes);
+  if (size === null && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    // a JPEG may carry more metadata than the prefix before its frame header
+    bytes = dataUrlBytes(imageUrl, Infinity) as Buffer;
+    size = imageDimensions(bytes);
+  }
+  if (size === null) {
+    return false;
+  }
+
+  let { width, height } = size;
+  const longest = Math.max(width, height);
+  if (longest > OPENAI_ORIGINAL_MAX_SIDE) {
+    width = Math.round((width * OPENAI_ORIGINAL_MAX_SIDE) / longest);
+    height = Math.round((height * OPENAI_ORIGINAL_MAX_SIDE) / longest);
+  }
+  return Math.ceil(width / 32) * Math.ceil(height / 32) > OPENAI_PATCH_LIMIT;
+}

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -1,0 +1,331 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, describe, test } from "@jest/globals";
+import { AutoLLMClient, UniMessage } from "../src";
+import { exceedsOpenaiPatchLimit, imageDimensions } from "../src/utils";
+
+// Header builders. Only the bytes the parser reads have to be right, so none of these is a
+// decodable picture; a real file carries the same leading bytes.
+function png(width: number, height: number): Buffer {
+  const header = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header);
+  header.writeUInt32BE(13, 8);
+  header.write("IHDR", 12, "latin1");
+  header.writeUInt32BE(width, 16);
+  header.writeUInt32BE(height, 20);
+  return header;
+}
+
+function gif(width: number, height: number): Buffer {
+  const header = Buffer.alloc(13);
+  header.write("GIF89a", 0, "latin1");
+  header.writeUInt16LE(width, 6);
+  header.writeUInt16LE(height, 8);
+  return header;
+}
+
+// The frame header follows `metadataBytes` of APP1 payload, the way EXIF does; a segment
+// holds at most 65,533 bytes, so a larger amount spans several of them.
+function jpeg(width: number, height: number, metadataBytes = 0): Buffer {
+  const parts: Buffer[] = [Buffer.from([0xff, 0xd8])];
+  let remaining = metadataBytes;
+  do {
+    const payload = Math.min(remaining, 65533);
+    const app1 = Buffer.alloc(4 + payload);
+    app1[0] = 0xff;
+    app1[1] = 0xe1;
+    app1.writeUInt16BE(2 + payload, 2);
+    parts.push(app1);
+    remaining -= payload;
+  } while (remaining > 0);
+  const sof0 = Buffer.alloc(10);
+  sof0[0] = 0xff;
+  sof0[1] = 0xc0;
+  sof0.writeUInt16BE(8, 2);
+  sof0[4] = 8;
+  sof0.writeUInt16BE(height, 5);
+  sof0.writeUInt16BE(width, 7);
+  sof0[9] = 3;
+  return Buffer.concat([...parts, sof0]);
+}
+
+function riff(chunk: string, payload: Buffer): Buffer {
+  const header = Buffer.alloc(20);
+  header.write("RIFF", 0, "latin1");
+  header.writeUInt32LE(4 + 8 + payload.length, 4);
+  header.write("WEBP", 8, "latin1");
+  header.write(chunk, 12, "latin1");
+  header.writeUInt32LE(payload.length, 16);
+  return Buffer.concat([header, payload]);
+}
+
+// The scaling bits above the 14-bit size are set, to prove they are masked off.
+function webpLossy(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(10);
+  payload[3] = 0x9d;
+  payload[4] = 0x01;
+  payload[5] = 0x2a;
+  payload.writeUInt16LE(width | (2 << 14), 6);
+  payload.writeUInt16LE(height | (1 << 14), 8);
+  return riff("VP8 ", payload);
+}
+
+// The alpha flag above the two 14-bit sizes is set, to prove it is masked off.
+function webpLossless(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(10);
+  payload[0] = 0x2f;
+  payload.writeUInt32LE(
+    ((width - 1) | ((height - 1) << 14) | (1 << 28)) >>> 0,
+    1,
+  );
+  return riff("VP8L", payload);
+}
+
+function webpExtended(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(10);
+  payload[0] = 0x10;
+  payload.writeUIntLE(width - 1, 4, 3);
+  payload.writeUIntLE(height - 1, 7, 3);
+  return riff("VP8X", payload);
+}
+
+function dataUrl(bytes: Buffer, mime = "image/png"): string {
+  return `data:${mime};base64,${bytes.toString("base64")}`;
+}
+
+describe("imageDimensions", () => {
+  test.each([
+    ["PNG", png(6400, 8608), { width: 6400, height: 8608 }],
+    ["GIF", gif(640, 480), { width: 640, height: 480 }],
+    ["JPEG", jpeg(4032, 3024), { width: 4032, height: 3024 }],
+    [
+      "JPEG behind 100 KiB of metadata",
+      jpeg(4032, 3024, 100 * 1024),
+      { width: 4032, height: 3024 },
+    ],
+    ["lossy WebP", webpLossy(1920, 1080), { width: 1920, height: 1080 }],
+    ["lossless WebP", webpLossless(1920, 1080), { width: 1920, height: 1080 }],
+    ["extended WebP", webpExtended(1920, 1080), { width: 1920, height: 1080 }],
+  ])("reads the size of a %s header", (_name, bytes, expected) => {
+    expect(imageDimensions(bytes)).toEqual(expected);
+  });
+
+  test.each([
+    ["empty input", Buffer.alloc(0)],
+    ["text", Buffer.from("not an image")],
+    ["a PNG cut before its IHDR chunk", png(6400, 8608).subarray(0, 16)],
+    [
+      "a JPEG cut inside a metadata segment",
+      jpeg(4032, 3024, 1024).subarray(0, 512),
+    ],
+    [
+      "a JPEG whose scan starts before any frame header",
+      Buffer.from([0xff, 0xd8, 0xff, 0xda, 0x00, 0x02, 0x00, 0x00]),
+    ],
+    [
+      "a WebP whose first chunk is not a bitstream",
+      riff("ALPH", Buffer.alloc(10)),
+    ],
+  ])("reads %s as unrecognized", (_name, bytes) => {
+    expect(imageDimensions(bytes)).toBeNull();
+  });
+});
+
+describe("exceedsOpenaiPatchLimit", () => {
+  test.each([
+    ["a 6400x8608 screenshot (53,800 patches)", dataUrl(png(6400, 8608)), true],
+    ["5600x5600 (30,625 patches)", dataUrl(png(5600, 5600)), true],
+    ["5504x5504 (29,584 patches)", dataUrl(png(5504, 5504)), false],
+    ["1024x1024", dataUrl(png(1024, 1024)), false],
+    [
+      "an 8000x8000 JPEG whose frame header sits behind 100 KiB of metadata",
+      dataUrl(jpeg(8000, 8000, 100 * 1024), "image/jpeg"),
+      true,
+    ],
+    [
+      "a 131070x500 strip, once scaled to the 65,535-pixel side",
+      dataUrl(png(131070, 500)),
+      false,
+    ],
+    [
+      "a 131070x1500 strip, still over the limit once scaled",
+      dataUrl(png(131070, 1500)),
+      true,
+    ],
+    ["an http URL", "https://example.com/huge.png", false],
+    [
+      "a data URL that is not base64",
+      `data:image/png,${encodeURIComponent("not base64")}`,
+      false,
+    ],
+    [
+      "a data URL of something that is not an image",
+      dataUrl(Buffer.from("hello")),
+      false,
+    ],
+  ])("%s", (_name, url, expected) => {
+    expect(exceedsOpenaiPatchLimit(url)).toBe(expected);
+  });
+});
+
+interface ImageDetailCase {
+  expectedClient: string;
+  model: string;
+  clientType?: string;
+  protocol: "responses" | "chat";
+  // whether an image over the patch limit goes out at high detail
+  shrinks: boolean;
+}
+
+const IMAGE_DETAIL_CASES: ImageDetailCase[] = [
+  {
+    expectedClient: "GPT5_6Client",
+    model: "gpt-5.6-terra",
+    protocol: "responses",
+    shrinks: true,
+  },
+  {
+    expectedClient: "GPT5_6Client",
+    model: "gpt-5.5",
+    protocol: "responses",
+    shrinks: false,
+  },
+  {
+    expectedClient: "OpenaiResponsesClient",
+    model: "openai/gpt-5.6-terra",
+    clientType: "openai-responses",
+    protocol: "responses",
+    shrinks: true,
+  },
+  {
+    expectedClient: "OpenaiResponsesClient",
+    model: "deepseek-v4-flash-vision-exp",
+    clientType: "openai-responses",
+    protocol: "responses",
+    shrinks: false,
+  },
+  {
+    expectedClient: "OpenaiChatClient",
+    model: "GPT-5.6-Sol",
+    clientType: "openai-chat",
+    protocol: "chat",
+    shrinks: true,
+  },
+  {
+    expectedClient: "OpenaiChatClient",
+    model: "gpt-5.5",
+    clientType: "openai-chat",
+    protocol: "chat",
+    shrinks: false,
+  },
+];
+
+const OVERSIZED = dataUrl(png(6400, 8608));
+const SMALL = dataUrl(png(1024, 1024));
+
+// A prompt carrying an oversized image next to a small one, and a tool result carrying both again.
+const MESSAGES: UniMessage[] = [
+  {
+    role: "user",
+    content_items: [
+      { type: "text", text: "What is in these?" },
+      { type: "image_url", image_url: OVERSIZED },
+      { type: "image_url", image_url: SMALL },
+    ],
+  },
+  {
+    role: "assistant",
+    content_items: [
+      {
+        type: "tool_call",
+        name: "read_image",
+        arguments: { path: "shot.png" },
+        tool_call_id: "call_1",
+      },
+    ],
+  },
+  {
+    role: "user",
+    content_items: [
+      {
+        type: "tool_result",
+        text: "image/png",
+        images: [OVERSIZED, SMALL],
+        tool_call_id: "call_1",
+      },
+    ],
+  },
+];
+
+// The detail of each image part, in order: the prompt's two images, then the tool result's two.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function details(testCase: ImageDetailCase, modelInput: any[]): unknown[] {
+  if (testCase.protocol === "responses") {
+    return [
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...modelInput[0].content.slice(1).map((part: any) => part.detail),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...modelInput[2].output.slice(1).map((part: any) => part.detail),
+    ];
+  }
+
+  return [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...modelInput[0].content.slice(1).map((part: any) => part.image_url.detail),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...modelInput[2].content.slice(1).map((part: any) => part.image_url.detail),
+  ];
+}
+
+describe.each(IMAGE_DETAIL_CASES)(
+  "Image detail for $expectedClient on $model",
+  (testCase) => {
+    test(
+      testCase.shrinks
+        ? "sends an image over the patch limit at high detail"
+        : "leaves the detail level to the model",
+      async () => {
+        const client = new AutoLLMClient({
+          model: testCase.model,
+          apiKey: "test-key",
+          clientType: testCase.clientType,
+        });
+        const routedClient = (
+          client as unknown as {
+            _client: {
+              constructor: { name: string };
+              transformUniMessageToModelInput(
+                messages: UniMessage[],
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ): Promise<any[]> | any[];
+            };
+          }
+        )._client;
+        expect(routedClient.constructor.name).toBe(testCase.expectedClient);
+
+        const modelInput =
+          await routedClient.transformUniMessageToModelInput(MESSAGES);
+
+        const shrunk = testCase.shrinks ? "high" : undefined;
+        expect(details(testCase, modelInput)).toEqual([
+          shrunk,
+          undefined,
+          shrunk,
+          undefined,
+        ]);
+      },
+    );
+  },
+);

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -127,6 +127,19 @@ describe("imageDimensions", () => {
     ["text", Buffer.from("not an image")],
     ["a PNG cut before its IHDR chunk", png(6400, 8608).subarray(0, 16)],
     [
+      "bytes that spell PNG and IHDR without the PNG signature",
+      Buffer.concat([
+        Buffer.from("\0PNG", "latin1"),
+        Buffer.alloc(8),
+        Buffer.from("IHDR", "latin1"),
+        Buffer.alloc(8),
+      ]),
+    ],
+    [
+      "a GIF signature without its version",
+      Buffer.from("GIFxxx\0\0\0\0\0\0\0", "latin1"),
+    ],
+    [
       "a JPEG cut inside a metadata segment",
       jpeg(4032, 3024, 1024).subarray(0, 512),
     ],

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -36,6 +36,19 @@ function gif(width: number, height: number): Buffer {
   return header;
 }
 
+// A frame header: baseline (SOF0) by default, progressive with 0xc2.
+function sof(width: number, height: number, marker = 0xc0): Buffer {
+  const header = Buffer.alloc(10);
+  header[0] = 0xff;
+  header[1] = marker;
+  header.writeUInt16BE(8, 2);
+  header[4] = 8;
+  header.writeUInt16BE(height, 5);
+  header.writeUInt16BE(width, 7);
+  header[9] = 3;
+  return header;
+}
+
 // The frame header follows `metadataBytes` of APP1 payload, the way EXIF does; a segment
 // holds at most 65,533 bytes, so a larger amount spans several of them.
 function jpeg(width: number, height: number, metadataBytes = 0): Buffer {
@@ -50,16 +63,19 @@ function jpeg(width: number, height: number, metadataBytes = 0): Buffer {
     parts.push(app1);
     remaining -= payload;
   } while (remaining > 0);
-  const sof0 = Buffer.alloc(10);
-  sof0[0] = 0xff;
-  sof0[1] = 0xc0;
-  sof0.writeUInt16BE(8, 2);
-  sof0[4] = 8;
-  sof0.writeUInt16BE(height, 5);
-  sof0.writeUInt16BE(width, 7);
-  sof0[9] = 3;
-  return Buffer.concat([...parts, sof0]);
+  return Buffer.concat([...parts, sof(width, height)]);
 }
+
+// A JPEG whose frame header follows the SOI directly, and a progressive one that puts fill
+// bytes, an empty APP1 segment and a restart marker ahead of it.
+const SOF_FIRST_JPEG = Buffer.concat([
+  Buffer.from([0xff, 0xd8]),
+  sof(4032, 3024),
+]);
+const PROGRESSIVE_JPEG = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xff, 0xff, 0xe1, 0x00, 0x02, 0xff, 0xd0]),
+  sof(4032, 3024, 0xc2),
+]);
 
 function riff(chunk: string, payload: Buffer): Buffer {
   const header = Buffer.alloc(20);
@@ -105,6 +121,23 @@ function dataUrl(bytes: Buffer, mime = "image/png"): string {
   return `data:${mime};base64,${bytes.toString("base64")}`;
 }
 
+// Payloads an encoder other than the clients' own may produce: wrapped at 76 columns the way
+// MIME tooling does, without its padding, and in the URL-safe alphabet.
+const WRAPPED_URL = `data:image/png;base64,${Buffer.concat([
+  png(6400, 8608),
+  Buffer.alloc(100 * 1024),
+])
+  .toString("base64")
+  .replace(/.{76}/g, "$&\n")}\n`;
+const UNPADDED_URL = dataUrl(
+  Buffer.concat([jpeg(8000, 8000, 100 * 1024), Buffer.alloc(1)]),
+  "image/jpeg",
+).replace(/=+$/, "");
+const URL_SAFE_URL = `data:image/png;base64,${Buffer.concat([
+  png(6400, 8608),
+  Buffer.alloc(13, Buffer.from([0xfb, 0xff, 0xbf])),
+]).toString("base64url")}`;
+
 describe("imageDimensions", () => {
   test.each([
     ["PNG", png(6400, 8608), { width: 6400, height: 8608 }],
@@ -113,6 +146,16 @@ describe("imageDimensions", () => {
     [
       "JPEG behind 100 KiB of metadata",
       jpeg(4032, 3024, 100 * 1024),
+      { width: 4032, height: 3024 },
+    ],
+    [
+      "JPEG whose frame header comes first",
+      SOF_FIRST_JPEG,
+      { width: 4032, height: 3024 },
+    ],
+    [
+      "progressive JPEG behind fill bytes and a restart marker",
+      PROGRESSIVE_JPEG,
       { width: 4032, height: 3024 },
     ],
     ["lossy WebP", webpLossy(1920, 1080), { width: 1920, height: 1080 }],
@@ -160,6 +203,8 @@ describe("exceedsOpenaiPatchLimit", () => {
   test.each([
     ["a 6400x8608 screenshot (53,800 patches)", dataUrl(png(6400, 8608)), true],
     ["5600x5600 (30,625 patches)", dataUrl(png(5600, 5600)), true],
+    ["6400x4832 (30,200 patches)", dataUrl(png(6400, 4832)), true],
+    ["6400x4800 (exactly 30,000 patches)", dataUrl(png(6400, 4800)), false],
     ["5504x5504 (29,584 patches)", dataUrl(png(5504, 5504)), false],
     ["1024x1024", dataUrl(png(1024, 1024)), false],
     [
@@ -175,6 +220,18 @@ describe("exceedsOpenaiPatchLimit", () => {
     [
       "a 131070x1500 strip, still over the limit once scaled",
       dataUrl(png(131070, 1500)),
+      true,
+    ],
+    ["a payload wrapped at 76 columns", WRAPPED_URL, true],
+    [
+      "an unpadded payload of a JPEG with a deep frame header",
+      UNPADDED_URL,
+      true,
+    ],
+    ["a payload in the URL-safe alphabet", URL_SAFE_URL, true],
+    [
+      "an upper-case base64 marker",
+      `data:image/png;BASE64,${png(6400, 8608).toString("base64")}`,
       true,
     ],
     ["an http URL", "https://example.com/huge.png", false],
@@ -283,23 +340,19 @@ const MESSAGES: UniMessage[] = [
 ];
 
 // The detail of each image part, in order: the prompt's two images, then the tool result's two.
+// An absent key and an explicit undefined differ on the wire, so the key itself is reported.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function details(testCase: ImageDetailCase, modelInput: any[]): unknown[] {
-  if (testCase.protocol === "responses") {
-    return [
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...modelInput[0].content.slice(1).map((part: any) => part.detail),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...modelInput[2].output.slice(1).map((part: any) => part.detail),
-    ];
-  }
-
-  return [
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...modelInput[0].content.slice(1).map((part: any) => part.image_url.detail),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...modelInput[2].content.slice(1).map((part: any) => part.image_url.detail),
-  ];
+function details(testCase: ImageDetailCase, modelInput: any[]): string[] {
+  const parts =
+    testCase.protocol === "responses"
+      ? [...modelInput[0].content.slice(1), ...modelInput[2].output.slice(1)]
+      : [
+          ...modelInput[0].content.slice(1),
+          ...modelInput[2].content.slice(1),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ].map((part: any) => part.image_url);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return parts.map((part: any) => ("detail" in part ? part.detail : "absent"));
 }
 
 describe.each(IMAGE_DETAIL_CASES)(
@@ -331,12 +384,12 @@ describe.each(IMAGE_DETAIL_CASES)(
         const modelInput =
           await routedClient.transformUniMessageToModelInput(MESSAGES);
 
-        const shrunk = testCase.shrinks ? "high" : undefined;
+        const shrunk = testCase.shrinks ? "high" : "absent";
         expect(details(testCase, modelInput)).toEqual([
           shrunk,
-          undefined,
+          "absent",
           shrunk,
-          undefined,
+          "absent",
         ]);
       },
     );


### PR DESCRIPTION
## Summary

Reported in penguin-harness [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573): attaching a large screenshot to a `gpt-5.6-terra` session fails with

```
400 The image you provided requires 53800 patches after processing, exceeding the limit of 30000. Please resize the image and try again.
```

**Cause.** OpenAI's [Images and vision guide](https://developers.openai.com/api/docs/guides/images-vision) (model sizing table) says that on the `gpt-5.6` family the default `auto` detail — what an omitted `detail` means — behaves like `original`: the API keeps the image's own dimensions (only a 65,535-pixel side cap applies) and rejects an image over 30,000 patches instead of resizing it. `high` fits the image into 2048×2048 pixels and 2,500 patches. `gpt-5.5` and `gpt-5.4` carry a patch budget at every detail level, so only `gpt-5.6` is exposed. The clients sent every `input_image` without a `detail`.

**Fix.** `GPT5_6Client`, `OpenaiResponsesClient` and `OpenaiChatClient` (penguin-harness pins its OpenRouter `openai/gpt-5.6-*` rows to `openai-responses`) read the image's width and height from the data URL's header and send `detail: "high"` only when the model id contains `gpt-5.6` and the image would exceed 30,000 patches at `original` detail — in a prompt and in a tool result alike. The rule lives once, in `openaiImageDetail` / `openai_image_detail` in `utils`; the clients only shape the item. Everything else is unchanged: a fitting image still goes out without `detail` (so `auto` keeps reading it at its own size and cost), no other model ever sees the field, and the Responses clients do not measure an HTTP(S) URL but pass it through for the API to fetch (the Chat client fetches it into a data URL first, so it measures the fetched bytes).

The header parser (`imageDimensions` / `image_dimensions`) covers PNG, JPEG (walking the marker segments to SOFn), GIF and WebP (VP8, VP8L, VP8X), and decodes a growing prefix of the base64 payload — 64 characters, then fourfold — until the header is found or the payload runs out, so a JPEG's frame header is reached behind its metadata without decoding the whole image. Python decodes a prefix the way Node's `Buffer` does (whitespace skipped, URL-safe alphabet accepted, missing padding tolerated), so both language implementations are identical in behaviour, wrapped or unpadded payloads included.

## Alternatives considered

- **Resizing the image locally** to just under 30,000 patches would keep up to 12× more pixels than `high` (2,500 patches) for such an image, but needs an image codec in both languages (`sharp` / Pillow), which AgentHub does not depend on today. This change is codec-free, always makes the request succeed, and a local resize can be layered on top later without undoing it.
- **Always sending an explicit `detail` on `gpt-5.6`** would change the cost and fidelity of every image; the change only intervenes where the API would otherwise reject.
- **Applying the fallback for every model** on the generic clients would send `detail` to servers that may not accept it, and would cut `gpt-5.5` from its 10,000-patch `original` budget down to 2,500; the gate is the explicit version match the repository uses elsewhere.

## Verification

- Live probes with `OPENAI_API_KEY` against `gpt-5.6-terra`, using a synthetic 6400×8608 PNG (exactly 53,800 patches, the number in the report):
  - raw Responses request without `detail` → the 400 above; the same request with `detail: "high"` → answered, 2,965 input tokens;
  - through the patched clients — TypeScript `GPT5_6Client`, `OpenaiResponsesClient`, `OpenaiChatClient` and Python `GPT5_6Client` — all answered `"Red on top, blue below."` (the image is red over blue) at ≈2,965 input tokens;
  - a 1024×1024 image still goes out without `detail` (1,252 input tokens).
- `src_ts`: `npm run lint`, `npm run build`, `npm test -- tests/image-detail.test.ts tests/message-order.test.ts` — 49 passed.
- `src_py`: `uvx ruff check`, `uvx ruff format --check`, `pytest tests/test_image_detail.py tests/test_message_order.py` — 49 passed.
- The new offline tests build format headers by hand (no image library) and cover each parser (a SOF-first and a progressive JPEG included), the limit arithmetic at its boundaries (29,584, exactly 30,000, 30,200 and 30,625 patches, the 65,535-pixel side cap, a JPEG with 100 KiB of metadata), a payload wrapped at 76 columns, without padding, in the URL-safe alphabet and with an upper-case `base64` marker, and the `detail` placement on the three clients — asserting the key is absent, not undefined — including that `gpt-5.5` and a non-OpenAI model on the same protocol are left alone.
- Prettier (`make lint`) would also reflow a few pre-existing lines in the three clients; they are left as they are on `dev` so this diff stays the change.

## Review follow-up

The second commit answers the inline review: the Python decoder matched Node's leniency (a wrapped, unpadded or URL-safe payload was measured in TypeScript but not in Python), the fixed 64 KiB prefix plus whole-payload retry became a growing window, the Python side stopped copying the whole payload before the cut, the GPT-5.6 rule moved into one `utils` helper, the chat client's part type narrowed to `detail?: "high"`, the TypeScript header reader uses Buffer's read methods, the tests pin the exact boundary and the absence of `detail`, and the changelog and docstrings state the per-client HTTP(S) behaviour. Left alone: the pre-existing http(s) asymmetry between the Chat and Responses clients, the `clientType` that `AutoLLMClient` does not pass to the routed client, a shared data-URL parser for the ant_messages/gemini3_7/claude5 clients, and an `llmsdk_docs/gpt5_6/docs/images-vision.md` snapshot (needs an explicit request).

## Follow-up

- penguin-harness: bump `@prismshadow/agenthub` once this ships, and close [#573](https://github.com/Prism-Shadow/penguin-harness/issues/573) with that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R43b1hAA1nbrECSjt2oshY

