### PR TITLE
Pick the vLLM thinking switch from the served model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Vendored chat templates are stored byte-identical to the model repositories they come
+# from, so they must survive whitespace normalisation unchanged.
+exclude: '^llmsdk_docs/openai_chat_vllm_adapter/chat_templates/'
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ endpoint:
 
 - **`client_type="openai-chat"`** — OpenAI Chat Completions. Bare `"openai"` is an alias.
 - **`client_type="vllm-openai-chat"`** — Chat Completions as served by vLLM, mapping
-  `thinking_level` onto `chat_template_kwargs.enable_thinking`: `"none"` off, the rest on.
+  `thinking_level` onto the `chat_template_kwargs` the served model's template reads.
 - **`client_type="openai-responses"`** — OpenAI Responses, served by OpenAI, OpenRouter,
   DeepSeek, Z.AI, and MiniMax.
 - **`client_type="ant-messages"`** — Anthropic Messages, served by Anthropic, OpenRouter,

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Beyond the model-specific clients, four generic protocol clients call any compat
 endpoint:
 
 - **`client_type="openai-chat"`** — OpenAI Chat Completions. Bare `"openai"` is an alias.
-- **`client_type="vllm-openai-chat"`** — Chat Completions as served by vLLM, mapping
+- **`client_type="openai-chat-vllm-adapter"`** — Chat Completions as served by vLLM, mapping
   `thinking_level` onto the `chat_template_kwargs` the served model's template reads.
 - **`client_type="openai-responses"`** — OpenAI Responses, served by OpenAI, OpenRouter,
   DeepSeek, Z.AI, and MiniMax.
@@ -129,7 +129,7 @@ AgentHub provides Codex/Claude Code skill files for assistants that need to help
 
 - `(async) streaming_response(messages, config)`: Streams the response of LLMs in a stateless manner.
 - `(async) streaming_response_stateful(message, config)`: Streams the response of LLMs in a stateful manner.
-- `(async) list_models()`: Lists the model ids the configured endpoint serves. A protocol client (`openai-chat`, `vllm-openai-chat`, `openai-responses`, `ant-messages`, `openai-embedding`) is named explicitly and lists everything the endpoint serves; a client deduced from a model id lists only the ids that deduce back to it.
+- `(async) list_models()`: Lists the model ids the configured endpoint serves. A protocol client (`openai-chat`, `openai-chat-vllm-adapter`, `openai-responses`, `ant-messages`, `openai-embedding`) is named explicitly and lists everything the endpoint serves; a client deduced from a model id lists only the ids that deduce back to it.
 - `clear_history()`: Clears the history of the stateful LLM client.
 - `get_history()`: Returns the history of the stateful LLM client.
 - `set_history(history)`: Replaces the history of the stateful LLM client with a copy of the provided list.
@@ -701,7 +701,7 @@ Every client speaks one vendor protocol on the wire, whichever `client_type` rea
 | `glm-5.3`, `glm-5.2`, `glm-5.1`                            | `openai-chat`      |
 | `kimi-k3`, `kimi-k2.6`, `kimi-k2.5`                        | `openai-chat`      |
 | `openai-chat` (alias `openai`)                             | `openai-chat`      |
-| `vllm-openai-chat`                                         | `openai-chat`      |
+| `openai-chat-vllm-adapter`                                 | `openai-chat`      |
 | `openai-embedding`                                         | `openai-embedding` |
 
 ## Related Work

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
@@ -2,15 +2,15 @@
 
 - **Date:** 2026-09-03
 - **Type:** fix
-- **Scope:** `vllm_openai_chat`, `docs`
+- **Scope:** `openai_chat_vllm_adapter`, `docs`
 - **PR:** [#198](https://github.com/Prism-Shadow/agenthub/pull/198)
 
 [中文版](2026-09-03-vllm-per-model-thinking.zh.md)
 
 ## What changed
 
-- `vllm-openai-chat` now picks the `chat_template_kwargs` shape from the served model id, matched
-  as a lowercased substring, instead of sending `enable_thinking` to every model.
+- `openai-chat-vllm-adapter` now picks the `chat_template_kwargs` shape from the served model
+  id, matched as a lowercased substring, instead of sending `enable_thinking` to every model.
 - Qwen3.8-Flash-Next, Qwen3.6-35B-A3B, Qwen3.5-0.8B and Qwen3.5-9B keep the `enable_thinking`
   boolean.
 - Qwen3.8-27B disables thinking with `enable_thinking: false` and selects its adaptive modes with

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
@@ -11,14 +11,20 @@
 
 - `openai-chat-vllm-adapter` now picks the `chat_template_kwargs` shape from the served model
   id, matched as a lowercased substring, instead of sending `enable_thinking` to every model.
-- Qwen3.8-Flash-Next, Qwen3.6-35B-A3B, Qwen3.5-0.8B and Qwen3.5-9B keep the `enable_thinking`
-  boolean.
-- Qwen3.8-27B disables thinking with `enable_thinking: false` and selects its adaptive modes with
-  `reasoning_effort`, which accepts only `low`/`medium`/`xhigh`, so `high` and `max` clamp to
-  `xhigh`.
-- DeepSeek-V4-Pro, DeepSeek-V4-Flash and DeepSeek-V4-Flash-Vision-Exp pair `thinking: true` with
-  `reasoning_effort`, which accepts only `low`/`high`/`max`, so `medium` and `xhigh` clamp to
-  `high`; `none` sends no `chat_template_kwargs` at all, which is how those models read as off.
+- Qwen3.6-35B-A3B, Qwen3.5-0.8B and Qwen3.5-9B keep the `enable_thinking` boolean.
+- Qwen3.8-27B and Qwen3.8-Flash-Next ship the same chat template byte for byte and share one
+  profile: thinking off is `enable_thinking: false`, and the adaptive modes are selected with
+  `reasoning_effort`, which the template accepts only as `low`/`medium`/`xhigh`, so `high` and
+  `max` clamp to `xhigh`.
+- DeepSeek-V4-Pro and DeepSeek-V4-Flash pair `thinking: true` with `reasoning_effort`. Their
+  encoding module asserts `reasoning_effort in ['max', None, 'high']`, so `low` through `xhigh`
+  all send `high` — `low` would fail the request outright — and because that module branches on
+  `max` alone, every level below `max` renders the same prompt.
+- DeepSeek-V4-Flash-Vision-Exp has a different copy of that module, which accepts
+  `low`/`high`/`max`, so it keeps the finer scale on its own profile: `low` sends `low`, and
+  `medium` and `xhigh` clamp to `high`.
+- For all three DeepSeek models, `none` sends no `chat_template_kwargs` at all, which is how they
+  read as off.
 - A model outside the table falls back to the `enable_thinking` boolean.
 - New reference section `llmsdk_docs/openai_chat_vllm_adapter/`: the five Qwen chat templates
   snapshotted byte-identical from Hugging Face with their source URL, snapshot date, license and

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
@@ -1,0 +1,22 @@
+# Map the vLLM thinking switch per served model
+
+- **Date:** 2026-09-03
+- **Type:** fix
+- **Scope:** `vllm_openai_chat`, `docs`
+- **PR:** [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING)
+
+[中文版](2026-09-03-vllm-per-model-thinking.zh.md)
+
+## What changed
+
+- `vllm-openai-chat` now picks the `chat_template_kwargs` shape from the served model id, matched
+  as a lowercased substring, instead of sending `enable_thinking` to every model.
+- Qwen3.8-Flash-Next, Qwen3.6-35B-A3B, Qwen3.5-0.8B and Qwen3.5-9B keep the `enable_thinking`
+  boolean.
+- Qwen3.8-27B disables thinking with `enable_thinking: false` and selects its adaptive modes with
+  `reasoning_effort`, which accepts only `low`/`medium`/`xhigh`, so `high` and `max` clamp to
+  `xhigh`.
+- DeepSeek-V4-Pro, DeepSeek-V4-Flash and DeepSeek-V4-Flash-Vision-Exp pair `thinking: true` with
+  `reasoning_effort`, which accepts only `low`/`high`/`max`, so `medium` and `xhigh` clamp to
+  `high`; `none` sends no `chat_template_kwargs` at all, which is how those templates read as off.
+- A model outside the table falls back to the `enable_thinking` boolean.

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
@@ -18,5 +18,10 @@
   `xhigh`.
 - DeepSeek-V4-Pro, DeepSeek-V4-Flash and DeepSeek-V4-Flash-Vision-Exp pair `thinking: true` with
   `reasoning_effort`, which accepts only `low`/`high`/`max`, so `medium` and `xhigh` clamp to
-  `high`; `none` sends no `chat_template_kwargs` at all, which is how those templates read as off.
+  `high`; `none` sends no `chat_template_kwargs` at all, which is how those models read as off.
 - A model outside the table falls back to the `enable_thinking` boolean.
+- New reference section `llmsdk_docs/openai_chat_vllm_adapter/`: the five Qwen chat templates
+  snapshotted byte-identical from Hugging Face with their source URL, snapshot date, license and
+  checksum, plus a note on the three DeepSeek V4 models, which publish no chat template and
+  define their parameters in an `encoding/encoding_dsv4.py` module instead. The section states
+  the convention that a model added to the adapter has its template added here too.

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-09-03
 - **Type:** fix
 - **Scope:** `vllm_openai_chat`, `docs`
-- **PR:** [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING)
+- **PR:** [#198](https://github.com/Prism-Shadow/agenthub/pull/198)
 
 [中文版](2026-09-03-vllm-per-model-thinking.zh.md)
 

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
@@ -2,15 +2,15 @@
 
 - **Date:** 2026-09-03
 - **Type:** fix
-- **Scope:** `vllm_openai_chat`, `docs`
+- **Scope:** `openai_chat_vllm_adapter`, `docs`
 - **PR:** [#198](https://github.com/Prism-Shadow/agenthub/pull/198)
 
 [English](2026-09-03-vllm-per-model-thinking.md)
 
 ## 变更内容
 
-- `vllm-openai-chat` 改为按所服务的模型 id（转小写后按子串匹配）选择 `chat_template_kwargs` 的形态，
-  不再对所有模型一律发送 `enable_thinking`。
+- `openai-chat-vllm-adapter` 改为按所服务的模型 id（转小写后按子串匹配）选择
+  `chat_template_kwargs` 的形态，不再对所有模型一律发送 `enable_thinking`。
 - Qwen3.8-Flash-Next、Qwen3.6-35B-A3B、Qwen3.5-0.8B 与 Qwen3.5-9B 仍使用 `enable_thinking` 布尔开关。
 - Qwen3.8-27B 以 `enable_thinking: false` 关闭思考，并以 `reasoning_effort` 选择自适应模式；该字段只接受
   `low`/`medium`/`xhigh`，因此 `high` 与 `max` 收敛到 `xhigh`。

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
@@ -16,5 +16,9 @@
   `low`/`medium`/`xhigh`，因此 `high` 与 `max` 收敛到 `xhigh`。
 - DeepSeek-V4-Pro、DeepSeek-V4-Flash 与 DeepSeek-V4-Flash-Vision-Exp 以 `thinking: true` 搭配
   `reasoning_effort`；该字段只接受 `low`/`high`/`max`，因此 `medium` 与 `xhigh` 收敛到 `high`；`none`
-  完全不发送 `chat_template_kwargs`，这正是这些模板判定为关闭的方式。
+  完全不发送 `chat_template_kwargs`，这正是这些模型判定为关闭的方式。
 - 不在表内的模型回退到 `enable_thinking` 布尔开关。
+- 新增参考文档目录 `llmsdk_docs/openai_chat_vllm_adapter/`：五个 Qwen 模型的 chat template 按字节
+  原样自 Hugging Face 快照，并记录来源 URL、快照日期、许可证与校验和；另附一篇说明，交代三个
+  DeepSeek V4 模型并不发布 chat template，其参数定义在 `encoding/encoding_dsv4.py` 模块中。该目录
+  同时确立约定：向该 client 新增模型时，一并把它的 chat template 收录于此。

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
@@ -1,0 +1,20 @@
+# 按所服务的模型映射 vLLM 思考开关
+
+- **Date:** 2026-09-03
+- **Type:** fix
+- **Scope:** `vllm_openai_chat`, `docs`
+- **PR:** [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING)
+
+[English](2026-09-03-vllm-per-model-thinking.md)
+
+## 变更内容
+
+- `vllm-openai-chat` 改为按所服务的模型 id（转小写后按子串匹配）选择 `chat_template_kwargs` 的形态，
+  不再对所有模型一律发送 `enable_thinking`。
+- Qwen3.8-Flash-Next、Qwen3.6-35B-A3B、Qwen3.5-0.8B 与 Qwen3.5-9B 仍使用 `enable_thinking` 布尔开关。
+- Qwen3.8-27B 以 `enable_thinking: false` 关闭思考，并以 `reasoning_effort` 选择自适应模式；该字段只接受
+  `low`/`medium`/`xhigh`，因此 `high` 与 `max` 收敛到 `xhigh`。
+- DeepSeek-V4-Pro、DeepSeek-V4-Flash 与 DeepSeek-V4-Flash-Vision-Exp 以 `thinking: true` 搭配
+  `reasoning_effort`；该字段只接受 `low`/`high`/`max`，因此 `medium` 与 `xhigh` 收敛到 `high`；`none`
+  完全不发送 `chat_template_kwargs`，这正是这些模板判定为关闭的方式。
+- 不在表内的模型回退到 `enable_thinking` 布尔开关。

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
@@ -11,12 +11,16 @@
 
 - `openai-chat-vllm-adapter` 改为按所服务的模型 id（转小写后按子串匹配）选择
   `chat_template_kwargs` 的形态，不再对所有模型一律发送 `enable_thinking`。
-- Qwen3.8-Flash-Next、Qwen3.6-35B-A3B、Qwen3.5-0.8B 与 Qwen3.5-9B 仍使用 `enable_thinking` 布尔开关。
-- Qwen3.8-27B 以 `enable_thinking: false` 关闭思考，并以 `reasoning_effort` 选择自适应模式；该字段只接受
+- Qwen3.6-35B-A3B、Qwen3.5-0.8B 与 Qwen3.5-9B 仍使用 `enable_thinking` 布尔开关。
+- Qwen3.8-27B 与 Qwen3.8-Flash-Next 的 chat template 逐字节相同，因此共用一份 profile：以
+  `enable_thinking: false` 关闭思考，并以 `reasoning_effort` 选择自适应模式；该 template 只接受
   `low`/`medium`/`xhigh`，因此 `high` 与 `max` 收敛到 `xhigh`。
-- DeepSeek-V4-Pro、DeepSeek-V4-Flash 与 DeepSeek-V4-Flash-Vision-Exp 以 `thinking: true` 搭配
-  `reasoning_effort`；该字段只接受 `low`/`high`/`max`，因此 `medium` 与 `xhigh` 收敛到 `high`；`none`
-  完全不发送 `chat_template_kwargs`，这正是这些模型判定为关闭的方式。
+- DeepSeek-V4-Pro 与 DeepSeek-V4-Flash 以 `thinking: true` 搭配 `reasoning_effort`。二者的 encoding
+  模块断言 `reasoning_effort in ['max', None, 'high']`，因此 `low` 到 `xhigh` 一律发送 `high`——发送
+  `low` 会直接导致请求失败；又因为该模块只对 `max` 分支，`max` 以下各档渲染出的 prompt 完全一致。
+- DeepSeek-V4-Flash-Vision-Exp 的该模块是另一份副本，接受 `low`/`high`/`max`，因此单列一份 profile 并
+  保留更细的档位：`low` 发送 `low`，`medium` 与 `xhigh` 收敛到 `high`。
+- 三个 DeepSeek 模型在 `none` 档均完全不发送 `chat_template_kwargs`，这正是它们判定为关闭的方式。
 - 不在表内的模型回退到 `enable_thinking` 布尔开关。
 - 新增参考文档目录 `llmsdk_docs/openai_chat_vllm_adapter/`：五个 Qwen 模型的 chat template 按字节
   原样自 Hugging Face 快照，并记录来源 URL、快照日期、许可证与校验和；另附一篇说明，交代三个

--- a/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-per-model-thinking.zh.md
@@ -3,7 +3,7 @@
 - **Date:** 2026-09-03
 - **Type:** fix
 - **Scope:** `vllm_openai_chat`, `docs`
-- **PR:** [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING)
+- **PR:** [#198](https://github.com/Prism-Shadow/agenthub/pull/198)
 
 [English](2026-09-03-vllm-per-model-thinking.md)
 

--- a/changelog/unreleased/2026-09-03-vllm-thinking-switch.md
+++ b/changelog/unreleased/2026-09-03-vllm-thinking-switch.md
@@ -2,13 +2,13 @@
 
 - **Date:** 2026-09-03
 - **Type:** fix
-- **Scope:** `vllm_openai_chat`, `auto_client`, `docs`
+- **Scope:** `openai_chat_vllm_adapter`, `auto_client`, `docs`
 - **PR:** [#197](https://github.com/Prism-Shadow/agenthub/pull/197)
 
 [中文版](2026-09-03-vllm-thinking-switch.zh.md)
 
 ## What changed
 
-- Added the explicit `vllm-openai-chat` client type for models served through vLLM's OpenAI-compatible Chat Completions API.
+- Added the explicit `openai-chat-vllm-adapter` client type for models served through vLLM's OpenAI-compatible Chat Completions API.
 - Mapped `thinking_level: none` to `chat_template_kwargs.enable_thinking: false` and every enabled AgentHub level to `true`.
 - Left `chat_template_kwargs` absent when no level is selected and kept the generic `openai-chat` request unchanged.

--- a/changelog/unreleased/2026-09-03-vllm-thinking-switch.zh.md
+++ b/changelog/unreleased/2026-09-03-vllm-thinking-switch.zh.md
@@ -2,13 +2,13 @@
 
 - **Date:** 2026-09-03
 - **Type:** fix
-- **Scope:** `vllm_openai_chat`, `auto_client`, `docs`
+- **Scope:** `openai_chat_vllm_adapter`, `auto_client`, `docs`
 - **PR:** [#197](https://github.com/Prism-Shadow/agenthub/pull/197)
 
 [English](2026-09-03-vllm-thinking-switch.md)
 
 ## 变更内容
 
-- 为通过 vLLM OpenAI 兼容 Chat Completions API 提供的模型新增显式 `vllm-openai-chat` 客户端类型。
+- 为通过 vLLM OpenAI 兼容 Chat Completions API 提供的模型新增显式 `openai-chat-vllm-adapter` 客户端类型。
 - 将 `thinking_level: none` 映射为 `chat_template_kwargs.enable_thinking: false`，并将 AgentHub 的其他思考等级映射为 `true`。
 - 未选择思考等级时不添加 `chat_template_kwargs`，并保持通用 `openai-chat` 请求不变。

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -3,3 +3,4 @@
 [中文版](README.zh.md)
 
 - [2026-09-03] Map AgentHub thinking levels to vLLM's `enable_thinking` request switch. ([details](2026-09-03-vllm-thinking-switch.md), [#197](https://github.com/Prism-Shadow/agenthub/pull/197))
+- [2026-09-03] Pick the vLLM thinking switch from the served model instead of always sending `enable_thinking`. ([details](2026-09-03-vllm-per-model-thinking.md), [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING))

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -3,4 +3,4 @@
 [中文版](README.zh.md)
 
 - [2026-09-03] Map AgentHub thinking levels to vLLM's `enable_thinking` request switch. ([details](2026-09-03-vllm-thinking-switch.md), [#197](https://github.com/Prism-Shadow/agenthub/pull/197))
-- [2026-09-03] Pick the vLLM thinking switch from the served model instead of always sending `enable_thinking`. ([details](2026-09-03-vllm-per-model-thinking.md), [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING))
+- [2026-09-03] Pick the vLLM thinking switch from the served model instead of always sending `enable_thinking`. ([details](2026-09-03-vllm-per-model-thinking.md), [#198](https://github.com/Prism-Shadow/agenthub/pull/198))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -3,4 +3,4 @@
 [English](README.md)
 
 - [2026-09-03] 将 AgentHub 思考等级映射到 vLLM 的 `enable_thinking` 请求开关。([详情](2026-09-03-vllm-thinking-switch.zh.md), [#197](https://github.com/Prism-Shadow/agenthub/pull/197))
-- [2026-09-03] 按所服务的模型选择 vLLM 思考开关，不再一律发送 `enable_thinking`。([详情](2026-09-03-vllm-per-model-thinking.zh.md), [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING))
+- [2026-09-03] 按所服务的模型选择 vLLM 思考开关，不再一律发送 `enable_thinking`。([详情](2026-09-03-vllm-per-model-thinking.zh.md), [#198](https://github.com/Prism-Shadow/agenthub/pull/198))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -3,3 +3,4 @@
 [English](README.md)
 
 - [2026-09-03] 将 AgentHub 思考等级映射到 vLLM 的 `enable_thinking` 请求开关。([详情](2026-09-03-vllm-thinking-switch.zh.md), [#197](https://github.com/Prism-Shadow/agenthub/pull/197))
+- [2026-09-03] 按所服务的模型选择 vLLM 思考开关，不再一律发送 `enable_thinking`。([详情](2026-09-03-vllm-per-model-thinking.zh.md), [#PENDING](https://github.com/Prism-Shadow/agenthub/pull/PENDING))

--- a/llmsdk_docs/README.md
+++ b/llmsdk_docs/README.md
@@ -21,6 +21,7 @@ To use a specific model, please refer to its dedicated README:
 - **[GPT-5.6](./gpt5_6/README.md)** - OpenAI's GPT-5.6 generation (sol/terra/luna): reasoning modes, fast mode, and Responses migration
 - **[Kimi K3](./kimi_k3/README.md)** - Moonshot's Kimi K3 API documentation (reasoning_effort, tool calling, vision, caching)
 - **[MiniMax M-series](./minimax_m3/README.md)** - Responses API-compatible documentation for MiniMax M3 and M2.7, plus Token Plan Subscription Key integration
+- **[openai-chat-vllm-adapter model artifacts](./openai_chat_vllm_adapter/README.md)** - Upstream chat templates for the Qwen models served through vLLM, and the encoding module that stands in for one on DeepSeek V4; the source behind the adapter's per-model thinking switch
 - **[OpenAI Responses protocol](./openai_responses/README.md)** - The OpenAI Responses-compatible protocol across OpenAI, OpenRouter, DeepSeek, Z.AI, and MiniMax (generic `openai_responses` client)
 
 Each model directory contains:

--- a/llmsdk_docs/openai_chat_vllm_adapter/README.md
+++ b/llmsdk_docs/openai_chat_vllm_adapter/README.md
@@ -1,0 +1,107 @@
+# openai-chat-vllm-adapter Model Artifacts
+
+This directory holds the upstream prompt-formatting artifacts for every model the
+`openai_chat_vllm_adapter` client serves. vLLM passes `chat_template_kwargs` straight
+into the served model's chat template, so the template *is* the parameter contract: the
+switch that turns thinking on, the effort levels that are accepted, and the default that
+applies when a key is omitted are all readable here rather than inferred from vendor prose.
+
+The per-model thinking-switch table these artifacts back is
+[`_MODEL_THINKING_PROFILES`](../../src_py/agenthub/openai_chat_vllm_adapter/client.py)
+(and its TypeScript twin in
+[`src_ts/src/openai_chat_vllm_adapter/client.ts`](../../src_ts/src/openai_chat_vllm_adapter/client.ts)).
+
+## Chat templates
+
+`chat_templates/` stores each template **byte-identical to upstream**, so it can be diffed
+against the model repository and fed to Jinja unchanged. That rules out the usual
+`> Source:` header line — a Markdown header would corrupt the template — so provenance is
+recorded in the table below instead. None of these files ends in a newline, matching upstream,
+so `.pre-commit-config.yaml` excludes this directory from `end-of-file-fixer`.
+
+| Model | File | Upstream source | Snapshot | License | MD5 |
+|---|---|---|---|---|---|
+| `Qwen/Qwen3.8-Flash-Next` | [qwen3.8-flash-next.jinja](./chat_templates/qwen3.8-flash-next.jinja) | https://huggingface.co/Qwen/Qwen3.8-Flash-Next/raw/main/chat_template.jinja | 2026-09-04 | [Qwen Community License 1.0](https://huggingface.co/Qwen/Qwen3.8-Flash-Next/blob/main/LICENSE) | `519239a4908bb1f805bbce5fa8c8a242` |
+| `Qwen/Qwen3.8-27B` | [qwen3.8-27b.jinja](./chat_templates/qwen3.8-27b.jinja) | https://huggingface.co/Qwen/Qwen3.8-27B/raw/main/chat_template.jinja | 2026-09-04 | [Apache-2.0](https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/LICENSE) | `519239a4908bb1f805bbce5fa8c8a242` |
+| `Qwen/Qwen3.6-35B-A3B` | [qwen3.6-35b-a3b.jinja](./chat_templates/qwen3.6-35b-a3b.jinja) | https://huggingface.co/Qwen/Qwen3.6-35B-A3B/raw/main/chat_template.jinja | 2026-09-04 | [Apache-2.0](https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/LICENSE) | `52b6d51ae5b203cb67e64b648494dad2` |
+| `Qwen/Qwen3.5-0.8B` | [qwen3.5-0.8b.jinja](./chat_templates/qwen3.5-0.8b.jinja) | https://huggingface.co/Qwen/Qwen3.5-0.8B/raw/main/chat_template.jinja | 2026-09-04 | [Apache-2.0](https://huggingface.co/Qwen/Qwen3.5-0.8B/blob/main/LICENSE) | `3dd635d8e716410fb409839dfac61ea9` |
+| `Qwen/Qwen3.5-9B` | [qwen3.5-9b.jinja](./chat_templates/qwen3.5-9b.jinja) | https://huggingface.co/Qwen/Qwen3.5-9B/raw/main/chat_template.jinja | 2026-09-04 | [Apache-2.0](https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/LICENSE) | `94f89e03284d911fc65d06422439fd79` |
+
+`Qwen3.8-Flash-Next` and `Qwen3.8-27B` publish the **same template, byte for byte** (note
+the shared MD5). Both files are kept so either model can be looked up by name; edit both
+together, or neither.
+
+`Qwen/Qwen3.8-Flash-Next` is the one model here that is not Apache-2.0. The Qwen Community
+License 1.0 adds an attribution condition above 100M monthly active users or US$20M monthly
+revenue; the other four Qwen repositories ship plain Apache-2.0.
+
+### What the templates read
+
+| Model | Thinking switch | Effort key | Accepted effort values | Default when the key is absent |
+|---|---|---|---|---|
+| `Qwen3.8-Flash-Next` | `enable_thinking` | `reasoning_effort` | `xhigh`, `medium`, `low` | thinking on, effort `xhigh` |
+| `Qwen3.8-27B` | `enable_thinking` | `reasoning_effort` | `xhigh`, `medium`, `low` | thinking on, effort `xhigh` |
+| `Qwen3.6-35B-A3B` | `enable_thinking` | — | — | thinking on |
+| `Qwen3.5-0.8B` | `enable_thinking` | — | — | **thinking off** |
+| `Qwen3.5-9B` | `enable_thinking` | — | — | thinking on |
+
+Three details that only the templates make visible:
+
+- **The 3.8 templates validate `reasoning_effort` and abort on anything else.** An
+  unrecognised value raises `Unexpected reasoning effort ...`, so the request fails rather
+  than degrading. `xhigh` and `low` inject a reasoning instruction into the system prompt;
+  `medium` injects none, which is why it reads as the neutral setting.
+- **`reasoning_effort` is only consulted while thinking is on.** The whole block sits under
+  `enable_thinking is undefined or enable_thinking is true`, so pairing
+  `enable_thinking: false` with an effort value silently drops the effort.
+- **`Qwen3.5-0.8B` inverts the default.** It emits the reasoning block only for
+  `enable_thinking is defined and enable_thinking is true`; every other template here emits
+  it unless `enable_thinking` is explicitly `false`. Omitting the key therefore means
+  "thinking off" on `Qwen3.5-0.8B` and "thinking on" everywhere else. The adapter always
+  sends the key explicitly, which is what keeps this from mattering in practice.
+
+The 3.8 templates additionally read `preserve_thinking` (default true), which keeps
+`reasoning_content` from earlier assistant turns in the prompt. The adapter does not set it.
+
+### Where the adapter's table diverges from the templates
+
+Two profiles in `_MODEL_THINKING_PROFILES` do not follow the artifact above. Both are recorded
+here rather than corrected, because changing either alters what requests go out:
+
+- **`Qwen3.8-Flash-Next` gets the plain `enable_thinking` profile** even though its template is
+  byte-identical to `Qwen3.8-27B`'s and reads `reasoning_effort` the same way. Because the
+  adapter never sends the key for this model, every level from `LOW` up renders at the
+  template's `xhigh` default: `LOW` and `MEDIUM` on `Qwen3.8-Flash-Next` are not lower effort
+  than `MAX`, whereas on `Qwen3.8-27B` they are.
+- **All three DeepSeek V4 models get `reasoning_effort: "low"` at `LOW`**, but the encoding
+  module in the `DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` repositories accepts only
+  `high`, `max` and `None`, and asserts on anything else. See
+  [docs/deepseek-v4-encoding.md](./docs/deepseek-v4-encoding.md).
+
+## Models that publish no chat template
+
+- [deepseek-v4-encoding.md](./docs/deepseek-v4-encoding.md) - DeepSeek-V4-Pro,
+  DeepSeek-V4-Flash and DeepSeek-V4-Flash-Vision-Exp ship no template at all; their
+  parameter contract lives in an `encoding/encoding_dsv4.py` reference implementation.
+
+## Adding a model
+
+When a model is added to `openai_chat_vllm_adapter`, add its prompt-formatting artifact here
+in the same commit:
+
+1. Fetch `https://huggingface.co/<org>/<model>/raw/main/chat_template.jinja` with `curl`
+   (not a summarising fetch tool — Jinja must survive verbatim) and save it to
+   `chat_templates/<lowercased-model-id>.jinja` unmodified.
+2. Add a row to the provenance table with the source URL, the snapshot date, the license the
+   model repository actually states, and the file's MD5. Check the license per repository;
+   sibling models under the same org do not always match.
+3. Add a row to *What the templates read* covering the thinking switch, the effort key, its
+   accepted values, and the behaviour when the key is absent.
+4. Update the thinking profile in both `client.py` and `client.ts` to match what the template
+   reads.
+
+If the vendor publishes no `chat_template.jinja` (the URL returns 404 and
+`tokenizer_config.json` carries no `chat_template` key), do not invent one. Find the artifact
+that actually defines the prompt format — an `encoding/` module, a tokenizer plugin — and add
+a note under `docs/` that cites it, pins its checksum, and quotes the code that decides the
+request parameters. `deepseek-v4-encoding.md` is the worked example.

--- a/llmsdk_docs/openai_chat_vllm_adapter/README.md
+++ b/llmsdk_docs/openai_chat_vllm_adapter/README.md
@@ -63,20 +63,23 @@ Three details that only the templates make visible:
 The 3.8 templates additionally read `preserve_thinking` (default true), which keeps
 `reasoning_content` from earlier assistant turns in the prompt. The adapter does not set it.
 
-### Where the adapter's table diverges from the templates
+### Where the artifacts constrain the adapter's table
 
-Two profiles in `_MODEL_THINKING_PROFILES` do not follow the artifact above. Both are recorded
-here rather than corrected, because changing either alters what requests go out:
+Every profile in `_MODEL_THINKING_PROFILES` follows the artifact it is read off; no profile
+sends a value its model rejects. What the artifacts do force is coarser granularity than
+AgentHub's six levels, in two places:
 
-- **`Qwen3.8-Flash-Next` gets the plain `enable_thinking` profile** even though its template is
-  byte-identical to `Qwen3.8-27B`'s and reads `reasoning_effort` the same way. Because the
-  adapter never sends the key for this model, every level from `LOW` up renders at the
-  template's `xhigh` default: `LOW` and `MEDIUM` on `Qwen3.8-Flash-Next` are not lower effort
-  than `MAX`, whereas on `Qwen3.8-27B` they are.
-- **All three DeepSeek V4 models get `reasoning_effort: "low"` at `LOW`**, but the encoding
-  module in the `DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` repositories accepts only
-  `high`, `max` and `None`, and asserts on anything else. See
+- **`DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` render `LOW` through `XHIGH` identically.** Their
+  encoding module asserts `reasoning_effort in ['max', None, 'high']`, so `low` is not an option
+  at all and `high` is the lowest value they take; of the values that pass, only `max` changes
+  the rendered prompt. `DeepSeek-V4-Flash-Vision-Exp` has its own copy of that module, which
+  accepts `low`/`high`/`max`, so it keeps `LOW` distinct and takes a separate profile. See
   [docs/deepseek-v4-encoding.md](./docs/deepseek-v4-encoding.md).
+- **Both Qwen3.8 models clamp `HIGH`, `XHIGH` and `MAX` onto `xhigh`.** Their shared template
+  accepts only `xhigh`, `medium` and `low`, and `xhigh` is the strongest of the three. Because
+  the template defaults the key to `xhigh`, a model on this template that is *not* sent
+  `reasoning_effort` runs every level at full effort; the adapter therefore sends the key to
+  both of them.
 
 ## Models that publish no chat template
 

--- a/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.5-0.8b.jinja
+++ b/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.5-0.8b.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is true %}
+        {{- '<think>\n' }}
+    {%- else %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.5-9b.jinja
+++ b/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.5-9b.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.6-35b-a3b.jinja
+++ b/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.6-35b-a3b.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.8-27b.jinja
+++ b/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.8-27b.jinja
@@ -1,0 +1,170 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.8-flash-next.jinja
+++ b/llmsdk_docs/openai_chat_vllm_adapter/chat_templates/qwen3.8-flash-next.jinja
@@ -1,0 +1,170 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/llmsdk_docs/openai_chat_vllm_adapter/docs/deepseek-v4-encoding.md
+++ b/llmsdk_docs/openai_chat_vllm_adapter/docs/deepseek-v4-encoding.md
@@ -1,0 +1,90 @@
+# DeepSeek V4: no chat template, an encoding module instead
+
+> Source: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/encoding_dsv4.py,
+> https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py and
+> https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp/blob/main/encoding/encoding_dsv4.py
+> (snapshot 2026-09-04)
+
+The three DeepSeek V4 models served through `openai_chat_vllm_adapter` publish **no chat
+template**. `chat_template.jinja` returns HTTP 404 in all three repositories, and
+`tokenizer_config.json` (801 bytes) carries no `chat_template` key. Nothing in those
+repositories is a template, so there is nothing to snapshot into `../chat_templates/`.
+
+The prompt format is instead defined by a reference implementation, `encoding/encoding_dsv4.py`,
+documented by `encoding/README.md` beside it. It is executable Python rather than an inert
+template, and most of it covers tokenization, tool rendering and completion parsing that has no
+bearing on request parameters, so it is cited and quoted here rather than vendored.
+
+| Model | Upstream file | Size | License | MD5 |
+|---|---|---|---|---|
+| `deepseek-ai/DeepSeek-V4-Pro` | [encoding/encoding_dsv4.py](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/encoding_dsv4.py) | 27908 B | [MIT](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/LICENSE) | `f5e65effdf98...` |
+| `deepseek-ai/DeepSeek-V4-Flash` | [encoding/encoding_dsv4.py](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py) | 27908 B | [MIT](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/LICENSE) | `f5e65effdf98...` |
+| `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp` | [encoding/encoding_dsv4.py](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp/blob/main/encoding/encoding_dsv4.py) | 36707 B | [MIT](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp/blob/main/LICENSE) | `06a743aa6802...` |
+
+`DeepSeek-V4-Pro` and `DeepSeek-V4-Flash` ship the same file, byte for byte.
+`DeepSeek-V4-Flash-Vision-Exp` does not, and the difference is not confined to the image
+handling its name implies — **it changes the accepted `reasoning_effort` values**.
+
+## The parameters
+
+Both variants expose the same two knobs, on `encode_messages()` and the `render_message()` it
+calls per message:
+
+- `thinking_mode`, a string that must be `"chat"` or `"thinking"` — this is the on/off switch,
+  and it has no default: `assert thinking_mode in ["chat", "thinking"]`.
+- `reasoning_effort`, an optional string whose accepted values differ per variant.
+
+There is no boolean `thinking` parameter and no `enable_thinking` anywhere in the module; the
+`chat_template_kwargs` the adapter sends are the vLLM-side spelling of these two knobs, not
+names this module reads directly.
+
+### Pro and Flash accept only `high`, `max` and `None`
+
+```python
+    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
+    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
+        prompt += REASONING_EFFORT_MAX
+```
+
+`"low"` is **not** in the accepted set and trips the assertion. And of the values that do pass,
+only `'max'` changes the prompt: `'high'` and `None` both fall through to no prefix, so they are
+indistinguishable in the rendered output.
+
+### Flash-Vision-Exp accepts `low`, `high` and `max`
+
+```python
+# Reasoning effort levels. In thinking mode, the prompt for the selected level is
+# prepended at the very beginning of the conversation. `low` is the default and
+# adds nothing.
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (...),
+    "max": (...),
+}
+DEFAULT_REASONING_EFFORT = "low"
+```
+
+```python
+    # Reasoning effort prefix (only at index 0 in thinking mode; "low" adds nothing)
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    assert reasoning_effort in REASONING_EFFORT_PROMPTS, \
+        f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+    if index == 0 and thinking_mode == "thinking":
+        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
+```
+
+Here `low` is the documented default and contributes an empty prefix, `high` carries the text
+that Pro and Flash call `REASONING_EFFORT_MAX`, and `max` adds a stronger prefix that has no
+counterpart in the other two files. Effort levels therefore do not line up across the three
+models even where the names match: `high` on Flash-Vision-Exp is roughly `max` on Pro.
+
+In both variants the prefix is emitted only at `index == 0` and only in thinking mode, so
+`reasoning_effort` is inert whenever `thinking_mode == "chat"`.
+
+## Related
+
+DeepSeek's hosted API documents `reasoning_effort` as `low`/`high`/`max` for all V4 models; see
+[../../deepseek_v4/docs/thinking-mode.md](../../deepseek_v4/docs/thinking-mode.md). That is the
+platform contract, not the open-weights one recorded above, and the two disagree for
+`DeepSeek-V4-Pro` and `DeepSeek-V4-Flash`.

--- a/src_py/agenthub/auto_client.py
+++ b/src_py/agenthub/auto_client.py
@@ -21,7 +21,13 @@ from .types import UniConfig, UniEvent, UniMessage
 
 
 # The generic protocol clients are named explicitly rather than deduced from a model id.
-_PROTOCOL_CLIENT_TYPES = ("openai-chat", "vllm-openai-chat", "openai-responses", "ant-messages", "openai-embedding")
+_PROTOCOL_CLIENT_TYPES = (
+    "openai-chat",
+    "openai-chat-vllm-adapter",
+    "openai-responses",
+    "ant-messages",
+    "openai-embedding",
+)
 
 
 class AutoLLMClient(LLMClient):
@@ -99,11 +105,12 @@ class AutoLLMClient(LLMClient):
             from .deepseek_v4 import DeepSeekV4Client
 
             return DeepSeekV4Client
-        elif client_type == "vllm-openai-chat":
-            # exact match, since the "openai" branches below would otherwise claim it
-            from .vllm_openai_chat import VllmOpenaiChatClient
+        elif client_type == "openai-chat-vllm-adapter":
+            # exact match: "openai-chat-vllm-adapter" contains "openai", so the substring
+            # branches below would otherwise claim it
+            from .openai_chat_vllm_adapter import OpenaiChatVllmAdapterClient
 
-            return VllmOpenaiChatClient
+            return OpenaiChatVllmAdapterClient
         elif "ant-messages" in client_type:
             from .ant_messages import AntMessagesClient
 
@@ -139,7 +146,7 @@ class AutoLLMClient(LLMClient):
                 "Supported client types: minimax-m3, gemini-3.7, gemini-3.6, gemini-3, "
                 "claude-5, claude-4-8, claude-4-7, claude-4-6, gpt-5.6, gpt-5.5, gpt-5.4, "
                 "glm-5.3, glm-5.2, glm-5.1, kimi-k3, kimi-k2.6, kimi-k2.5, deepseek-v4, "
-                "vllm-openai-chat, openai-embedding, ant-messages, openai-responses, openai-chat."
+                "openai-chat-vllm-adapter, openai-embedding, ant-messages, openai-responses, openai-chat."
             )
 
         return client_class(model=model, api_key=api_key, base_url=base_url, default_headers=default_headers)

--- a/src_py/agenthub/openai_chat_vllm_adapter/__init__.py
+++ b/src_py/agenthub/openai_chat_vllm_adapter/__init__.py
@@ -1,0 +1,4 @@
+from .client import OpenaiChatVllmAdapterClient
+
+
+__all__ = ["OpenaiChatVllmAdapterClient"]

--- a/src_py/agenthub/openai_chat_vllm_adapter/client.py
+++ b/src_py/agenthub/openai_chat_vllm_adapter/client.py
@@ -23,13 +23,11 @@ from ..types import ThinkingLevel, UniConfig
 # below maps an AgentHub level onto one family's kwargs; an empty mapping means the
 # request carries no chat_template_kwargs at all.
 #
-# The upstream templates these profiles are read off, and the two places where a profile
-# knowingly diverges from one, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/.
-# Update that snapshot whenever a model is added here.
+# The upstream artifacts these profiles are read off, and the clamping those artifacts
+# force, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/. Update that snapshot
+# whenever a model is added here.
 
-# Qwen3 templates read a single enable_thinking boolean. Qwen3.8-Flash-Next is the
-# exception: it ships the same template as Qwen3.8-27B, which also reads reasoning_effort
-# and defaults it to xhigh, so LOW and MEDIUM land on xhigh here.
+# Qwen3 templates read a single enable_thinking boolean and no effort key at all.
 _QWEN3_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.NONE: {"enable_thinking": False},
     ThinkingLevel.LOW: {"enable_thinking": True},
@@ -39,9 +37,12 @@ _QWEN3_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.MAX: {"enable_thinking": True},
 }
 
-# Qwen3.8-27B keeps enable_thinking as the off switch and takes its adaptive modes as
-# reasoning_effort, which accepts only low/medium/xhigh, so high and max clamp to xhigh.
-_QWEN3_8_27B_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+# Qwen3.8-27B and Qwen3.8-Flash-Next ship the same chat template, byte for byte, so they
+# share a profile. It keeps enable_thinking as the off switch and takes its adaptive modes
+# as reasoning_effort, validated against low/medium/xhigh, so high and max clamp to xhigh.
+# The template defaults the key to xhigh, so a model on this template that is not sent the
+# key runs every level at full effort.
+_QWEN3_8_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.NONE: {"enable_thinking": False},
     ThinkingLevel.LOW: {"reasoning_effort": "low"},
     ThinkingLevel.MEDIUM: {"reasoning_effort": "medium"},
@@ -51,11 +52,24 @@ _QWEN3_8_27B_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
 }
 
 # DeepSeek V4 publishes no chat template; vLLM reads a thinking flag paired with
-# reasoning_effort, which accepts only low/high/max, so medium and xhigh clamp to high.
-# Thinking is off whenever the flag is absent, which is what NONE sends. Upstream's own
-# encoding module narrows that set to high/max on DeepSeek-V4-Pro and DeepSeek-V4-Flash,
-# where low is rejected outright; only Flash-Vision-Exp takes all three.
-_DEEPSEEK_V4_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+# reasoning_effort, and thinking is off whenever the flag is absent, which is what NONE
+# sends. DeepSeek-V4-Pro and DeepSeek-V4-Flash share an encoding module that asserts
+# reasoning_effort in ['max', None, 'high'], so low is a failed request rather than a
+# weaker answer and high is the lowest value they take. That module then branches on 'max'
+# alone, which means LOW through XHIGH all render the same prompt on these two models.
+_DEEPSEEK_V4_PRO_FLASH_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+    ThinkingLevel.NONE: {},
+    ThinkingLevel.LOW: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.MEDIUM: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.HIGH: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.XHIGH: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.MAX: {"thinking": True, "reasoning_effort": "max"},
+}
+
+# DeepSeek-V4-Flash-Vision-Exp ships a different copy of that encoding module, one that
+# validates reasoning_effort against a low/high/max table, so it keeps the finer scale;
+# medium and xhigh clamp to high.
+_DEEPSEEK_V4_VISION_EXP_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.NONE: {},
     ThinkingLevel.LOW: {"thinking": True, "reasoning_effort": "low"},
     ThinkingLevel.MEDIUM: {"thinking": True, "reasoning_effort": "high"},
@@ -69,14 +83,14 @@ _DEEPSEEK_V4_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
 # first match wins, so a key that contains another must come first: deepseek-v4-flash is a
 # prefix of deepseek-v4-flash-vision-exp.
 _MODEL_THINKING_PROFILES: tuple[tuple[str, dict[ThinkingLevel, dict[str, Any]]], ...] = (
-    ("qwen3.8-flash-next", _QWEN3_THINKING),
-    ("qwen3.8-27b", _QWEN3_8_27B_THINKING),
+    ("qwen3.8-flash-next", _QWEN3_8_THINKING),
+    ("qwen3.8-27b", _QWEN3_8_THINKING),
     ("qwen3.6-35b-a3b", _QWEN3_THINKING),
     ("qwen3.5-0.8b", _QWEN3_THINKING),
     ("qwen3.5-9b", _QWEN3_THINKING),
-    ("deepseek-v4-flash-vision-exp", _DEEPSEEK_V4_THINKING),
-    ("deepseek-v4-pro", _DEEPSEEK_V4_THINKING),
-    ("deepseek-v4-flash", _DEEPSEEK_V4_THINKING),
+    ("deepseek-v4-flash-vision-exp", _DEEPSEEK_V4_VISION_EXP_THINKING),
+    ("deepseek-v4-pro", _DEEPSEEK_V4_PRO_FLASH_THINKING),
+    ("deepseek-v4-flash", _DEEPSEEK_V4_PRO_FLASH_THINKING),
 )
 
 

--- a/src_py/agenthub/openai_chat_vllm_adapter/client.py
+++ b/src_py/agenthub/openai_chat_vllm_adapter/client.py
@@ -22,8 +22,14 @@ from ..types import ThinkingLevel, UniConfig
 # switch that turns thinking on is whatever that template happens to read. Each profile
 # below maps an AgentHub level onto one family's kwargs; an empty mapping means the
 # request carries no chat_template_kwargs at all.
+#
+# The upstream templates these profiles are read off, and the two places where a profile
+# knowingly diverges from one, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/.
+# Update that snapshot whenever a model is added here.
 
-# Qwen3 templates read a single enable_thinking boolean.
+# Qwen3 templates read a single enable_thinking boolean. Qwen3.8-Flash-Next is the
+# exception: it ships the same template as Qwen3.8-27B, which also reads reasoning_effort
+# and defaults it to xhigh, so LOW and MEDIUM land on xhigh here.
 _QWEN3_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.NONE: {"enable_thinking": False},
     ThinkingLevel.LOW: {"enable_thinking": True},
@@ -44,9 +50,11 @@ _QWEN3_8_27B_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.MAX: {"reasoning_effort": "xhigh"},
 }
 
-# DeepSeek V4 templates read a thinking flag paired with reasoning_effort, which accepts
-# only low/high/max, so medium and xhigh clamp to high. Thinking is off whenever the flag
-# is absent, which is what NONE sends.
+# DeepSeek V4 publishes no chat template; vLLM reads a thinking flag paired with
+# reasoning_effort, which accepts only low/high/max, so medium and xhigh clamp to high.
+# Thinking is off whenever the flag is absent, which is what NONE sends. Upstream's own
+# encoding module narrows that set to high/max on DeepSeek-V4-Pro and DeepSeek-V4-Flash,
+# where low is rejected outright; only Flash-Vision-Exp takes all three.
 _DEEPSEEK_V4_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
     ThinkingLevel.NONE: {},
     ThinkingLevel.LOW: {"thinking": True, "reasoning_effort": "low"},

--- a/src_py/agenthub/openai_chat_vllm_adapter/client.py
+++ b/src_py/agenthub/openai_chat_vllm_adapter/client.py
@@ -72,7 +72,7 @@ _MODEL_THINKING_PROFILES: tuple[tuple[str, dict[ThinkingLevel, dict[str, Any]]],
 )
 
 
-class VllmOpenaiChatClient(OpenaiChatClient):
+class OpenaiChatVllmAdapterClient(OpenaiChatClient):
     """Models served through vLLM's OpenAI-compatible Chat Completions API."""
 
     def _thinking_chat_template_kwargs(self, thinking_level: ThinkingLevel) -> dict[str, Any]:

--- a/src_py/agenthub/vllm_openai_chat/__init__.py
+++ b/src_py/agenthub/vllm_openai_chat/__init__.py
@@ -1,4 +1,0 @@
-from .client import VllmOpenaiChatClient
-
-
-__all__ = ["VllmOpenaiChatClient"]

--- a/src_py/agenthub/vllm_openai_chat/client.py
+++ b/src_py/agenthub/vllm_openai_chat/client.py
@@ -18,16 +18,83 @@ from ..openai_chat import OpenaiChatClient
 from ..types import ThinkingLevel, UniConfig
 
 
+# vLLM passes chat_template_kwargs straight to the served model's chat template, so the
+# switch that turns thinking on is whatever that template happens to read. Each profile
+# below maps an AgentHub level onto one family's kwargs; an empty mapping means the
+# request carries no chat_template_kwargs at all.
+
+# Qwen3 templates read a single enable_thinking boolean.
+_QWEN3_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+    ThinkingLevel.NONE: {"enable_thinking": False},
+    ThinkingLevel.LOW: {"enable_thinking": True},
+    ThinkingLevel.MEDIUM: {"enable_thinking": True},
+    ThinkingLevel.HIGH: {"enable_thinking": True},
+    ThinkingLevel.XHIGH: {"enable_thinking": True},
+    ThinkingLevel.MAX: {"enable_thinking": True},
+}
+
+# Qwen3.8-27B keeps enable_thinking as the off switch and takes its adaptive modes as
+# reasoning_effort, which accepts only low/medium/xhigh, so high and max clamp to xhigh.
+_QWEN3_8_27B_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+    ThinkingLevel.NONE: {"enable_thinking": False},
+    ThinkingLevel.LOW: {"reasoning_effort": "low"},
+    ThinkingLevel.MEDIUM: {"reasoning_effort": "medium"},
+    ThinkingLevel.HIGH: {"reasoning_effort": "xhigh"},
+    ThinkingLevel.XHIGH: {"reasoning_effort": "xhigh"},
+    ThinkingLevel.MAX: {"reasoning_effort": "xhigh"},
+}
+
+# DeepSeek V4 templates read a thinking flag paired with reasoning_effort, which accepts
+# only low/high/max, so medium and xhigh clamp to high. Thinking is off whenever the flag
+# is absent, which is what NONE sends.
+_DEEPSEEK_V4_THINKING: dict[ThinkingLevel, dict[str, Any]] = {
+    ThinkingLevel.NONE: {},
+    ThinkingLevel.LOW: {"thinking": True, "reasoning_effort": "low"},
+    ThinkingLevel.MEDIUM: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.HIGH: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.XHIGH: {"thinking": True, "reasoning_effort": "high"},
+    ThinkingLevel.MAX: {"thinking": True, "reasoning_effort": "max"},
+}
+
+# Keys are matched as substrings of the lowercased model id, so a served id keeps whatever
+# prefix the deployment gave it (Qwen/Qwen3.6-35B-A3B, deepseek-ai/DeepSeek-V4-Pro). The
+# first match wins, so a key that contains another must come first: deepseek-v4-flash is a
+# prefix of deepseek-v4-flash-vision-exp.
+_MODEL_THINKING_PROFILES: tuple[tuple[str, dict[ThinkingLevel, dict[str, Any]]], ...] = (
+    ("qwen3.8-flash-next", _QWEN3_THINKING),
+    ("qwen3.8-27b", _QWEN3_8_27B_THINKING),
+    ("qwen3.6-35b-a3b", _QWEN3_THINKING),
+    ("qwen3.5-0.8b", _QWEN3_THINKING),
+    ("qwen3.5-9b", _QWEN3_THINKING),
+    ("deepseek-v4-flash-vision-exp", _DEEPSEEK_V4_THINKING),
+    ("deepseek-v4-pro", _DEEPSEEK_V4_THINKING),
+    ("deepseek-v4-flash", _DEEPSEEK_V4_THINKING),
+)
+
+
 class VllmOpenaiChatClient(OpenaiChatClient):
     """Models served through vLLM's OpenAI-compatible Chat Completions API."""
 
+    def _thinking_chat_template_kwargs(self, thinking_level: ThinkingLevel) -> dict[str, Any]:
+        """Return the chat_template_kwargs this model's template reads for the level.
+
+        A model outside the table falls back to Qwen3's enable_thinking, the most
+        widespread of the conventions and inert on a template that ignores the key.
+        """
+        model = self._model.lower()
+        for name, profile in _MODEL_THINKING_PROFILES:
+            if name in model:
+                return dict(profile[thinking_level])
+
+        return dict(_QWEN3_THINKING[thinking_level])
+
     def transform_uni_config_to_model_config(self, config: UniConfig) -> dict[str, Any]:
-        """Map AgentHub's level to the enable_thinking switch vLLM hands to the chat template."""
+        """Map AgentHub's level onto the thinking switch this model's chat template reads."""
         vllm_config = super().transform_uni_config_to_model_config(config)
 
         if config.get("thinking_level") is not None:
-            vllm_config["chat_template_kwargs"] = {
-                "enable_thinking": config["thinking_level"] != ThinkingLevel.NONE,
-            }
+            chat_template_kwargs = self._thinking_chat_template_kwargs(config["thinking_level"])
+            if chat_template_kwargs:
+                vllm_config["chat_template_kwargs"] = chat_template_kwargs
 
         return vllm_config

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -225,30 +225,30 @@ VLLM_THINKING_LEVEL_CASES = [
 
 
 @pytest.mark.parametrize(("model", "level", "expected"), VLLM_THINKING_LEVEL_CASES)
-def test_vllm_openai_chat_thinking_level_maps_to_chat_template_kwargs(
+def test_openai_chat_vllm_adapter_thinking_level_maps_to_chat_template_kwargs(
     model: str, level: ThinkingLevel, expected: dict | None
 ):
     client = AutoLLMClient(
         model=model,
         api_key="test-key",
         base_url="http://localhost:8000/v1",
-        client_type="vllm-openai-chat",
+        client_type="openai-chat-vllm-adapter",
     )
     config = client._client.transform_uni_config_to_model_config({"thinking_level": level})  # noqa: SLF001
     assert config.get("chat_template_kwargs") == expected
 
 
-def test_vllm_openai_chat_omits_chat_template_kwargs_without_thinking_level():
+def test_openai_chat_vllm_adapter_omits_chat_template_kwargs_without_thinking_level():
     client = AutoLLMClient(
         model="Qwen/Qwen3.6-35B-A3B",
         api_key="test-key",
-        client_type="vllm-openai-chat",
+        client_type="openai-chat-vllm-adapter",
     )
     config = client._client.transform_uni_config_to_model_config({})  # noqa: SLF001
     assert "chat_template_kwargs" not in config
 
 
-def test_openai_chat_does_not_receive_vllm_openai_chat_extension():
+def test_openai_chat_does_not_receive_the_vllm_extension():
     client = AutoLLMClient(
         model="Qwen/Qwen3.6-35B-A3B",
         api_key="test-key",

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -190,18 +190,20 @@ def test_thinking_level_maps_to_vendor_effort(
 
 
 # vLLM hands chat_template_kwargs to the served model's own chat template, so the switch
-# differs per model (recipes.vllm.ai, read 2026-09-03): Qwen3 reads a single
-# enable_thinking boolean, Qwen3.8-27B takes its adaptive modes as reasoning_effort
-# (low/medium/xhigh only), and DeepSeek V4 reads a thinking flag paired with
-# reasoning_effort (low/high/max only, absent kwargs meaning off). Levels the model does
-# not offer clamp to the closest one it does; a model outside the table falls back to
-# Qwen3's boolean. None as the expectation means the request carries no kwargs at all.
+# differs per model. The shapes come from the artifacts snapshotted in
+# llmsdk_docs/openai_chat_vllm_adapter/: Qwen3 reads a single enable_thinking boolean; the
+# two Qwen3.8 models share one template that takes reasoning_effort (low/medium/xhigh
+# only); and DeepSeek V4 reads a thinking flag paired with reasoning_effort, which its Pro
+# and Flash encoder narrows to high/max while Flash-Vision-Exp also accepts low. Absent
+# kwargs are how DeepSeek reads as off. Levels the model does not offer clamp to the
+# closest one it does; a model outside the table falls back to Qwen3's boolean. None as
+# the expectation means the request carries no kwargs at all.
 VLLM_THINKING_LEVEL_CASES = [
     ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.NONE, {"enable_thinking": False}),
     ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.LOW, {"enable_thinking": True}),
     ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.MAX, {"enable_thinking": True}),
     ("Qwen/Qwen3.8-Flash-Next", ThinkingLevel.NONE, {"enable_thinking": False}),
-    ("Qwen/Qwen3.8-Flash-Next", ThinkingLevel.HIGH, {"enable_thinking": True}),
+    ("Qwen/Qwen3.8-Flash-Next", ThinkingLevel.LOW, {"reasoning_effort": "low"}),
     ("Qwen/Qwen3.5-0.8B", ThinkingLevel.NONE, {"enable_thinking": False}),
     ("Qwen/Qwen3.5-9B", ThinkingLevel.MEDIUM, {"enable_thinking": True}),
     ("Qwen/Qwen3.8-27B", ThinkingLevel.NONE, {"enable_thinking": False}),
@@ -211,13 +213,14 @@ VLLM_THINKING_LEVEL_CASES = [
     ("Qwen/Qwen3.8-27B", ThinkingLevel.XHIGH, {"reasoning_effort": "xhigh"}),
     ("Qwen/Qwen3.8-27B", ThinkingLevel.MAX, {"reasoning_effort": "xhigh"}),
     ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.NONE, None),
-    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.LOW, {"thinking": True, "reasoning_effort": "low"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.LOW, {"thinking": True, "reasoning_effort": "high"}),
     ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.MEDIUM, {"thinking": True, "reasoning_effort": "high"}),
     ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.HIGH, {"thinking": True, "reasoning_effort": "high"}),
     ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.XHIGH, {"thinking": True, "reasoning_effort": "high"}),
     ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.MAX, {"thinking": True, "reasoning_effort": "max"}),
-    ("deepseek-ai/DeepSeek-V4-Flash", ThinkingLevel.MAX, {"thinking": True, "reasoning_effort": "max"}),
+    ("deepseek-ai/DeepSeek-V4-Flash", ThinkingLevel.LOW, {"thinking": True, "reasoning_effort": "high"}),
     ("deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.NONE, None),
+    ("deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.LOW, {"thinking": True, "reasoning_effort": "low"}),
     ("deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.HIGH, {"thinking": True, "reasoning_effort": "high"}),
     ("meta-llama/Llama-4-70B", ThinkingLevel.NONE, {"enable_thinking": False}),
     ("meta-llama/Llama-4-70B", ThinkingLevel.HIGH, {"enable_thinking": True}),

--- a/src_py/tests/test_thinking_level_mapping.py
+++ b/src_py/tests/test_thinking_level_mapping.py
@@ -189,26 +189,53 @@ def test_thinking_level_maps_to_vendor_effort(
     assert _wire_effort(config) == expected
 
 
-@pytest.mark.parametrize(
-    ("level", "expected"),
-    [
-        (ThinkingLevel.NONE, False),
-        (ThinkingLevel.LOW, True),
-        (ThinkingLevel.MEDIUM, True),
-        (ThinkingLevel.HIGH, True),
-        (ThinkingLevel.XHIGH, True),
-        (ThinkingLevel.MAX, True),
-    ],
-)
-def test_vllm_openai_chat_thinking_level_maps_to_enable_thinking(level: ThinkingLevel, expected: bool):
+# vLLM hands chat_template_kwargs to the served model's own chat template, so the switch
+# differs per model (recipes.vllm.ai, read 2026-09-03): Qwen3 reads a single
+# enable_thinking boolean, Qwen3.8-27B takes its adaptive modes as reasoning_effort
+# (low/medium/xhigh only), and DeepSeek V4 reads a thinking flag paired with
+# reasoning_effort (low/high/max only, absent kwargs meaning off). Levels the model does
+# not offer clamp to the closest one it does; a model outside the table falls back to
+# Qwen3's boolean. None as the expectation means the request carries no kwargs at all.
+VLLM_THINKING_LEVEL_CASES = [
+    ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.NONE, {"enable_thinking": False}),
+    ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.LOW, {"enable_thinking": True}),
+    ("Qwen/Qwen3.6-35B-A3B", ThinkingLevel.MAX, {"enable_thinking": True}),
+    ("Qwen/Qwen3.8-Flash-Next", ThinkingLevel.NONE, {"enable_thinking": False}),
+    ("Qwen/Qwen3.8-Flash-Next", ThinkingLevel.HIGH, {"enable_thinking": True}),
+    ("Qwen/Qwen3.5-0.8B", ThinkingLevel.NONE, {"enable_thinking": False}),
+    ("Qwen/Qwen3.5-9B", ThinkingLevel.MEDIUM, {"enable_thinking": True}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.NONE, {"enable_thinking": False}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.LOW, {"reasoning_effort": "low"}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.MEDIUM, {"reasoning_effort": "medium"}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.HIGH, {"reasoning_effort": "xhigh"}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.XHIGH, {"reasoning_effort": "xhigh"}),
+    ("Qwen/Qwen3.8-27B", ThinkingLevel.MAX, {"reasoning_effort": "xhigh"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.NONE, None),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.LOW, {"thinking": True, "reasoning_effort": "low"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.MEDIUM, {"thinking": True, "reasoning_effort": "high"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.HIGH, {"thinking": True, "reasoning_effort": "high"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.XHIGH, {"thinking": True, "reasoning_effort": "high"}),
+    ("deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.MAX, {"thinking": True, "reasoning_effort": "max"}),
+    ("deepseek-ai/DeepSeek-V4-Flash", ThinkingLevel.MAX, {"thinking": True, "reasoning_effort": "max"}),
+    ("deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.NONE, None),
+    ("deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.HIGH, {"thinking": True, "reasoning_effort": "high"}),
+    ("meta-llama/Llama-4-70B", ThinkingLevel.NONE, {"enable_thinking": False}),
+    ("meta-llama/Llama-4-70B", ThinkingLevel.HIGH, {"enable_thinking": True}),
+]
+
+
+@pytest.mark.parametrize(("model", "level", "expected"), VLLM_THINKING_LEVEL_CASES)
+def test_vllm_openai_chat_thinking_level_maps_to_chat_template_kwargs(
+    model: str, level: ThinkingLevel, expected: dict | None
+):
     client = AutoLLMClient(
-        model="Qwen/Qwen3.6-35B-A3B",
+        model=model,
         api_key="test-key",
         base_url="http://localhost:8000/v1",
         client_type="vllm-openai-chat",
     )
     config = client._client.transform_uni_config_to_model_config({"thinking_level": level})  # noqa: SLF001
-    assert config["chat_template_kwargs"] == {"enable_thinking": expected}
+    assert config.get("chat_template_kwargs") == expected
 
 
 def test_vllm_openai_chat_omits_chat_template_kwargs_without_thinking_level():

--- a/src_ts/src/autoClient.ts
+++ b/src_ts/src/autoClient.ts
@@ -24,7 +24,7 @@ import { AntMessagesClient } from "./ant_messages";
 import { OpenaiEmbeddingClient } from "./openai_embedding";
 import { DeepSeekV4Client } from "./deepseek_v4";
 import { MiniMaxM3Client } from "./minimax_m3";
-import { VllmOpenaiChatClient } from "./vllm_openai_chat";
+import { OpenaiChatVllmAdapterClient } from "./openai_chat_vllm_adapter";
 import { UniConfig, UniEvent, UniMessage } from "./types";
 
 type LLMClientConstructor = new (options: {
@@ -38,7 +38,7 @@ type LLMClientConstructor = new (options: {
 // The generic protocol clients are named explicitly rather than deduced from a model id.
 const PROTOCOL_CLIENT_TYPES = [
   "openai-chat",
-  "vllm-openai-chat",
+  "openai-chat-vllm-adapter",
   "openai-responses",
   "ant-messages",
   "openai-embedding",
@@ -128,9 +128,10 @@ export class AutoLLMClient extends LLMClient {
       return MiniMaxM3Client;
     } else if (clientType.includes("deepseek-v4")) {
       return DeepSeekV4Client;
-    } else if (clientType === "vllm-openai-chat") {
-      // exact match, since the "openai" branches below would otherwise claim it
-      return VllmOpenaiChatClient;
+    } else if (clientType === "openai-chat-vllm-adapter") {
+      // exact match: "openai-chat-vllm-adapter" contains "openai", so the substring
+      // branches below would otherwise claim it
+      return OpenaiChatVllmAdapterClient;
     } else if (clientType.includes("ant-messages")) {
       return AntMessagesClient;
     } else if (clientType.includes("openai-responses")) {
@@ -165,7 +166,7 @@ export class AutoLLMClient extends LLMClient {
           "Supported client types: minimax-m3, gemini-3.7, gemini-3.6, gemini-3, " +
           "claude-5, claude-4-8, claude-4-7, " +
           "claude-4-6, gpt-5.6, gpt-5.5, gpt-5.4, glm-5.3, glm-5.2, glm-5.1, kimi-k3, kimi-k2.6, kimi-k2.5, " +
-          "deepseek-v4, vllm-openai-chat, openai-embedding, ant-messages, openai-responses, openai-chat.",
+          "deepseek-v4, openai-chat-vllm-adapter, openai-embedding, ant-messages, openai-responses, openai-chat.",
       );
     }
 

--- a/src_ts/src/openai_chat_vllm_adapter/client.ts
+++ b/src_ts/src/openai_chat_vllm_adapter/client.ts
@@ -73,7 +73,7 @@ const MODEL_THINKING_PROFILES: readonly (readonly [string, ThinkingProfile])[] =
   ];
 
 /** Models served through vLLM's OpenAI-compatible Chat Completions API. */
-export class VllmOpenaiChatClient extends OpenaiChatClient {
+export class OpenaiChatVllmAdapterClient extends OpenaiChatClient {
   /**
    * Return the chat_template_kwargs this model's template reads for the level.
    *

--- a/src_ts/src/openai_chat_vllm_adapter/client.ts
+++ b/src_ts/src/openai_chat_vllm_adapter/client.ts
@@ -23,13 +23,11 @@ type ThinkingProfile = Record<ThinkingLevel, ChatTemplateKwargs>;
 // below maps an AgentHub level onto one family's kwargs; an empty mapping means the
 // request carries no chat_template_kwargs at all.
 //
-// The upstream templates these profiles are read off, and the two places where a profile
-// knowingly diverges from one, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/.
-// Update that snapshot whenever a model is added here.
+// The upstream artifacts these profiles are read off, and the clamping those artifacts
+// force, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/. Update that snapshot
+// whenever a model is added here.
 
-// Qwen3 templates read a single enable_thinking boolean. Qwen3.8-Flash-Next is the
-// exception: it ships the same template as Qwen3.8-27B, which also reads reasoning_effort
-// and defaults it to xhigh, so LOW and MEDIUM land on xhigh here.
+// Qwen3 templates read a single enable_thinking boolean and no effort key at all.
 const QWEN3_THINKING: ThinkingProfile = {
   [ThinkingLevel.NONE]: { enable_thinking: false },
   [ThinkingLevel.LOW]: { enable_thinking: true },
@@ -39,9 +37,12 @@ const QWEN3_THINKING: ThinkingProfile = {
   [ThinkingLevel.MAX]: { enable_thinking: true },
 };
 
-// Qwen3.8-27B keeps enable_thinking as the off switch and takes its adaptive modes as
-// reasoning_effort, which accepts only low/medium/xhigh, so high and max clamp to xhigh.
-const QWEN3_8_27B_THINKING: ThinkingProfile = {
+// Qwen3.8-27B and Qwen3.8-Flash-Next ship the same chat template, byte for byte, so they
+// share a profile. It keeps enable_thinking as the off switch and takes its adaptive modes
+// as reasoning_effort, validated against low/medium/xhigh, so high and max clamp to xhigh.
+// The template defaults the key to xhigh, so a model on this template that is not sent the
+// key runs every level at full effort.
+const QWEN3_8_THINKING: ThinkingProfile = {
   [ThinkingLevel.NONE]: { enable_thinking: false },
   [ThinkingLevel.LOW]: { reasoning_effort: "low" },
   [ThinkingLevel.MEDIUM]: { reasoning_effort: "medium" },
@@ -51,11 +52,24 @@ const QWEN3_8_27B_THINKING: ThinkingProfile = {
 };
 
 // DeepSeek V4 publishes no chat template; vLLM reads a thinking flag paired with
-// reasoning_effort, which accepts only low/high/max, so medium and xhigh clamp to high.
-// Thinking is off whenever the flag is absent, which is what NONE sends. Upstream's own
-// encoding module narrows that set to high/max on DeepSeek-V4-Pro and DeepSeek-V4-Flash,
-// where low is rejected outright; only Flash-Vision-Exp takes all three.
-const DEEPSEEK_V4_THINKING: ThinkingProfile = {
+// reasoning_effort, and thinking is off whenever the flag is absent, which is what NONE
+// sends. DeepSeek-V4-Pro and DeepSeek-V4-Flash share an encoding module that asserts
+// reasoning_effort in ['max', None, 'high'], so low is a failed request rather than a
+// weaker answer and high is the lowest value they take. That module then branches on 'max'
+// alone, which means LOW through XHIGH all render the same prompt on these two models.
+const DEEPSEEK_V4_PRO_FLASH_THINKING: ThinkingProfile = {
+  [ThinkingLevel.NONE]: {},
+  [ThinkingLevel.LOW]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.MEDIUM]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.HIGH]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.XHIGH]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.MAX]: { thinking: true, reasoning_effort: "max" },
+};
+
+// DeepSeek-V4-Flash-Vision-Exp ships a different copy of that encoding module, one that
+// validates reasoning_effort against a low/high/max table, so it keeps the finer scale;
+// medium and xhigh clamp to high.
+const DEEPSEEK_V4_VISION_EXP_THINKING: ThinkingProfile = {
   [ThinkingLevel.NONE]: {},
   [ThinkingLevel.LOW]: { thinking: true, reasoning_effort: "low" },
   [ThinkingLevel.MEDIUM]: { thinking: true, reasoning_effort: "high" },
@@ -70,14 +84,14 @@ const DEEPSEEK_V4_THINKING: ThinkingProfile = {
 // prefix of deepseek-v4-flash-vision-exp.
 const MODEL_THINKING_PROFILES: readonly (readonly [string, ThinkingProfile])[] =
   [
-    ["qwen3.8-flash-next", QWEN3_THINKING],
-    ["qwen3.8-27b", QWEN3_8_27B_THINKING],
+    ["qwen3.8-flash-next", QWEN3_8_THINKING],
+    ["qwen3.8-27b", QWEN3_8_THINKING],
     ["qwen3.6-35b-a3b", QWEN3_THINKING],
     ["qwen3.5-0.8b", QWEN3_THINKING],
     ["qwen3.5-9b", QWEN3_THINKING],
-    ["deepseek-v4-flash-vision-exp", DEEPSEEK_V4_THINKING],
-    ["deepseek-v4-pro", DEEPSEEK_V4_THINKING],
-    ["deepseek-v4-flash", DEEPSEEK_V4_THINKING],
+    ["deepseek-v4-flash-vision-exp", DEEPSEEK_V4_VISION_EXP_THINKING],
+    ["deepseek-v4-pro", DEEPSEEK_V4_PRO_FLASH_THINKING],
+    ["deepseek-v4-flash", DEEPSEEK_V4_PRO_FLASH_THINKING],
   ];
 
 /** Models served through vLLM's OpenAI-compatible Chat Completions API. */

--- a/src_ts/src/openai_chat_vllm_adapter/client.ts
+++ b/src_ts/src/openai_chat_vllm_adapter/client.ts
@@ -22,8 +22,14 @@ type ThinkingProfile = Record<ThinkingLevel, ChatTemplateKwargs>;
 // switch that turns thinking on is whatever that template happens to read. Each profile
 // below maps an AgentHub level onto one family's kwargs; an empty mapping means the
 // request carries no chat_template_kwargs at all.
+//
+// The upstream templates these profiles are read off, and the two places where a profile
+// knowingly diverges from one, are snapshotted in llmsdk_docs/openai_chat_vllm_adapter/.
+// Update that snapshot whenever a model is added here.
 
-// Qwen3 templates read a single enable_thinking boolean.
+// Qwen3 templates read a single enable_thinking boolean. Qwen3.8-Flash-Next is the
+// exception: it ships the same template as Qwen3.8-27B, which also reads reasoning_effort
+// and defaults it to xhigh, so LOW and MEDIUM land on xhigh here.
 const QWEN3_THINKING: ThinkingProfile = {
   [ThinkingLevel.NONE]: { enable_thinking: false },
   [ThinkingLevel.LOW]: { enable_thinking: true },
@@ -44,9 +50,11 @@ const QWEN3_8_27B_THINKING: ThinkingProfile = {
   [ThinkingLevel.MAX]: { reasoning_effort: "xhigh" },
 };
 
-// DeepSeek V4 templates read a thinking flag paired with reasoning_effort, which accepts
-// only low/high/max, so medium and xhigh clamp to high. Thinking is off whenever the flag
-// is absent, which is what NONE sends.
+// DeepSeek V4 publishes no chat template; vLLM reads a thinking flag paired with
+// reasoning_effort, which accepts only low/high/max, so medium and xhigh clamp to high.
+// Thinking is off whenever the flag is absent, which is what NONE sends. Upstream's own
+// encoding module narrows that set to high/max on DeepSeek-V4-Pro and DeepSeek-V4-Flash,
+// where low is rejected outright; only Flash-Vision-Exp takes all three.
 const DEEPSEEK_V4_THINKING: ThinkingProfile = {
   [ThinkingLevel.NONE]: {},
   [ThinkingLevel.LOW]: { thinking: true, reasoning_effort: "low" },

--- a/src_ts/src/openai_chat_vllm_adapter/index.ts
+++ b/src_ts/src/openai_chat_vllm_adapter/index.ts
@@ -1,0 +1,1 @@
+export { OpenaiChatVllmAdapterClient } from "./client";

--- a/src_ts/src/vllm_openai_chat/client.ts
+++ b/src_ts/src/vllm_openai_chat/client.ts
@@ -15,17 +15,96 @@
 import { OpenaiChatClient } from "../openai_chat";
 import { ThinkingLevel, UniConfig } from "../types";
 
+type ChatTemplateKwargs = Record<string, unknown>;
+type ThinkingProfile = Record<ThinkingLevel, ChatTemplateKwargs>;
+
+// vLLM passes chat_template_kwargs straight to the served model's chat template, so the
+// switch that turns thinking on is whatever that template happens to read. Each profile
+// below maps an AgentHub level onto one family's kwargs; an empty mapping means the
+// request carries no chat_template_kwargs at all.
+
+// Qwen3 templates read a single enable_thinking boolean.
+const QWEN3_THINKING: ThinkingProfile = {
+  [ThinkingLevel.NONE]: { enable_thinking: false },
+  [ThinkingLevel.LOW]: { enable_thinking: true },
+  [ThinkingLevel.MEDIUM]: { enable_thinking: true },
+  [ThinkingLevel.HIGH]: { enable_thinking: true },
+  [ThinkingLevel.XHIGH]: { enable_thinking: true },
+  [ThinkingLevel.MAX]: { enable_thinking: true },
+};
+
+// Qwen3.8-27B keeps enable_thinking as the off switch and takes its adaptive modes as
+// reasoning_effort, which accepts only low/medium/xhigh, so high and max clamp to xhigh.
+const QWEN3_8_27B_THINKING: ThinkingProfile = {
+  [ThinkingLevel.NONE]: { enable_thinking: false },
+  [ThinkingLevel.LOW]: { reasoning_effort: "low" },
+  [ThinkingLevel.MEDIUM]: { reasoning_effort: "medium" },
+  [ThinkingLevel.HIGH]: { reasoning_effort: "xhigh" },
+  [ThinkingLevel.XHIGH]: { reasoning_effort: "xhigh" },
+  [ThinkingLevel.MAX]: { reasoning_effort: "xhigh" },
+};
+
+// DeepSeek V4 templates read a thinking flag paired with reasoning_effort, which accepts
+// only low/high/max, so medium and xhigh clamp to high. Thinking is off whenever the flag
+// is absent, which is what NONE sends.
+const DEEPSEEK_V4_THINKING: ThinkingProfile = {
+  [ThinkingLevel.NONE]: {},
+  [ThinkingLevel.LOW]: { thinking: true, reasoning_effort: "low" },
+  [ThinkingLevel.MEDIUM]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.HIGH]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.XHIGH]: { thinking: true, reasoning_effort: "high" },
+  [ThinkingLevel.MAX]: { thinking: true, reasoning_effort: "max" },
+};
+
+// Keys are matched as substrings of the lowercased model id, so a served id keeps whatever
+// prefix the deployment gave it (Qwen/Qwen3.6-35B-A3B, deepseek-ai/DeepSeek-V4-Pro). The
+// first match wins, so a key that contains another must come first: deepseek-v4-flash is a
+// prefix of deepseek-v4-flash-vision-exp.
+const MODEL_THINKING_PROFILES: readonly (readonly [string, ThinkingProfile])[] =
+  [
+    ["qwen3.8-flash-next", QWEN3_THINKING],
+    ["qwen3.8-27b", QWEN3_8_27B_THINKING],
+    ["qwen3.6-35b-a3b", QWEN3_THINKING],
+    ["qwen3.5-0.8b", QWEN3_THINKING],
+    ["qwen3.5-9b", QWEN3_THINKING],
+    ["deepseek-v4-flash-vision-exp", DEEPSEEK_V4_THINKING],
+    ["deepseek-v4-pro", DEEPSEEK_V4_THINKING],
+    ["deepseek-v4-flash", DEEPSEEK_V4_THINKING],
+  ];
+
 /** Models served through vLLM's OpenAI-compatible Chat Completions API. */
 export class VllmOpenaiChatClient extends OpenaiChatClient {
-  /** Map AgentHub's level to the enable_thinking switch vLLM hands to the chat template. */
+  /**
+   * Return the chat_template_kwargs this model's template reads for the level.
+   *
+   * A model outside the table falls back to Qwen3's enable_thinking, the most widespread
+   * of the conventions and inert on a template that ignores the key.
+   */
+  private _thinkingChatTemplateKwargs(
+    thinkingLevel: ThinkingLevel,
+  ): ChatTemplateKwargs {
+    const model = this._model.toLowerCase();
+    for (const [name, profile] of MODEL_THINKING_PROFILES) {
+      if (model.includes(name)) {
+        return { ...profile[thinkingLevel] };
+      }
+    }
+
+    return { ...QWEN3_THINKING[thinkingLevel] };
+  }
+
+  /** Map AgentHub's level onto the thinking switch this model's chat template reads. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   override transformUniConfigToModelConfig(config: UniConfig): any {
     const vllmConfig = super.transformUniConfigToModelConfig(config);
 
     if (config.thinking_level !== undefined) {
-      vllmConfig.chat_template_kwargs = {
-        enable_thinking: config.thinking_level !== ThinkingLevel.NONE,
-      };
+      const chatTemplateKwargs = this._thinkingChatTemplateKwargs(
+        config.thinking_level,
+      );
+      if (Object.keys(chatTemplateKwargs).length > 0) {
+        vllmConfig.chat_template_kwargs = chatTemplateKwargs;
+      }
     }
 
     return vllmConfig;

--- a/src_ts/src/vllm_openai_chat/index.ts
+++ b/src_ts/src/vllm_openai_chat/index.ts
@@ -1,1 +1,0 @@
-export { VllmOpenaiChatClient } from "./client";

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -224,18 +224,20 @@ describe("thinking level to vendor effort", () => {
 
 describe("vLLM thinking switch", () => {
   // vLLM hands chat_template_kwargs to the served model's own chat template, so the switch
-  // differs per model (recipes.vllm.ai, read 2026-09-03): Qwen3 reads a single
-  // enable_thinking boolean, Qwen3.8-27B takes its adaptive modes as reasoning_effort
-  // (low/medium/xhigh only), and DeepSeek V4 reads a thinking flag paired with
-  // reasoning_effort (low/high/max only, absent kwargs meaning off). Levels the model does
-  // not offer clamp to the closest one it does; a model outside the table falls back to
-  // Qwen3's boolean. undefined as the expectation means no kwargs are sent at all.
+  // differs per model. The shapes come from the artifacts snapshotted in
+  // llmsdk_docs/openai_chat_vllm_adapter/: Qwen3 reads a single enable_thinking boolean;
+  // the two Qwen3.8 models share one template that takes reasoning_effort (low/medium/xhigh
+  // only); and DeepSeek V4 reads a thinking flag paired with reasoning_effort, which its
+  // Pro and Flash encoder narrows to high/max while Flash-Vision-Exp also accepts low.
+  // Absent kwargs are how DeepSeek reads as off. Levels the model does not offer clamp to
+  // the closest one it does; a model outside the table falls back to Qwen3's boolean.
+  // undefined as the expectation means no kwargs are sent at all.
   test.each([
     ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.NONE, { enable_thinking: false }],
     ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.LOW, { enable_thinking: true }],
     ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.MAX, { enable_thinking: true }],
     ["Qwen/Qwen3.8-Flash-Next", ThinkingLevel.NONE, { enable_thinking: false }],
-    ["Qwen/Qwen3.8-Flash-Next", ThinkingLevel.HIGH, { enable_thinking: true }],
+    ["Qwen/Qwen3.8-Flash-Next", ThinkingLevel.LOW, { reasoning_effort: "low" }],
     ["Qwen/Qwen3.5-0.8B", ThinkingLevel.NONE, { enable_thinking: false }],
     ["Qwen/Qwen3.5-9B", ThinkingLevel.MEDIUM, { enable_thinking: true }],
     ["Qwen/Qwen3.8-27B", ThinkingLevel.NONE, { enable_thinking: false }],
@@ -248,7 +250,7 @@ describe("vLLM thinking switch", () => {
     [
       "deepseek-ai/DeepSeek-V4-Pro",
       ThinkingLevel.LOW,
-      { thinking: true, reasoning_effort: "low" },
+      { thinking: true, reasoning_effort: "high" },
     ],
     [
       "deepseek-ai/DeepSeek-V4-Pro",
@@ -272,10 +274,15 @@ describe("vLLM thinking switch", () => {
     ],
     [
       "deepseek-ai/DeepSeek-V4-Flash",
-      ThinkingLevel.MAX,
-      { thinking: true, reasoning_effort: "max" },
+      ThinkingLevel.LOW,
+      { thinking: true, reasoning_effort: "high" },
     ],
     ["deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.NONE, undefined],
+    [
+      "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+      ThinkingLevel.LOW,
+      { thinking: true, reasoning_effort: "low" },
+    ],
     [
       "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
       ThinkingLevel.HIGH,

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -223,28 +223,82 @@ describe("thinking level to vendor effort", () => {
 });
 
 describe("vLLM thinking switch", () => {
+  // vLLM hands chat_template_kwargs to the served model's own chat template, so the switch
+  // differs per model (recipes.vllm.ai, read 2026-09-03): Qwen3 reads a single
+  // enable_thinking boolean, Qwen3.8-27B takes its adaptive modes as reasoning_effort
+  // (low/medium/xhigh only), and DeepSeek V4 reads a thinking flag paired with
+  // reasoning_effort (low/high/max only, absent kwargs meaning off). Levels the model does
+  // not offer clamp to the closest one it does; a model outside the table falls back to
+  // Qwen3's boolean. undefined as the expectation means no kwargs are sent at all.
   test.each([
-    [ThinkingLevel.NONE, false],
-    [ThinkingLevel.LOW, true],
-    [ThinkingLevel.MEDIUM, true],
-    [ThinkingLevel.HIGH, true],
-    [ThinkingLevel.XHIGH, true],
-    [ThinkingLevel.MAX, true],
-  ])("maps %s to enable_thinking=%s", (level, expected) => {
-    const client = new AutoLLMClient({
-      model: "Qwen/Qwen3.6-35B-A3B",
-      apiKey: "test-key",
-      baseUrl: "http://localhost:8000/v1",
-      clientType: "vllm-openai-chat",
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config = (client as any)._client.transformUniConfigToModelConfig({
-      thinking_level: level,
-    });
-    expect(config.chat_template_kwargs).toEqual({
-      enable_thinking: expected,
-    });
-  });
+    ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.NONE, { enable_thinking: false }],
+    ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.LOW, { enable_thinking: true }],
+    ["Qwen/Qwen3.6-35B-A3B", ThinkingLevel.MAX, { enable_thinking: true }],
+    ["Qwen/Qwen3.8-Flash-Next", ThinkingLevel.NONE, { enable_thinking: false }],
+    ["Qwen/Qwen3.8-Flash-Next", ThinkingLevel.HIGH, { enable_thinking: true }],
+    ["Qwen/Qwen3.5-0.8B", ThinkingLevel.NONE, { enable_thinking: false }],
+    ["Qwen/Qwen3.5-9B", ThinkingLevel.MEDIUM, { enable_thinking: true }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.NONE, { enable_thinking: false }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.LOW, { reasoning_effort: "low" }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.MEDIUM, { reasoning_effort: "medium" }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.HIGH, { reasoning_effort: "xhigh" }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.XHIGH, { reasoning_effort: "xhigh" }],
+    ["Qwen/Qwen3.8-27B", ThinkingLevel.MAX, { reasoning_effort: "xhigh" }],
+    ["deepseek-ai/DeepSeek-V4-Pro", ThinkingLevel.NONE, undefined],
+    [
+      "deepseek-ai/DeepSeek-V4-Pro",
+      ThinkingLevel.LOW,
+      { thinking: true, reasoning_effort: "low" },
+    ],
+    [
+      "deepseek-ai/DeepSeek-V4-Pro",
+      ThinkingLevel.MEDIUM,
+      { thinking: true, reasoning_effort: "high" },
+    ],
+    [
+      "deepseek-ai/DeepSeek-V4-Pro",
+      ThinkingLevel.HIGH,
+      { thinking: true, reasoning_effort: "high" },
+    ],
+    [
+      "deepseek-ai/DeepSeek-V4-Pro",
+      ThinkingLevel.XHIGH,
+      { thinking: true, reasoning_effort: "high" },
+    ],
+    [
+      "deepseek-ai/DeepSeek-V4-Pro",
+      ThinkingLevel.MAX,
+      { thinking: true, reasoning_effort: "max" },
+    ],
+    [
+      "deepseek-ai/DeepSeek-V4-Flash",
+      ThinkingLevel.MAX,
+      { thinking: true, reasoning_effort: "max" },
+    ],
+    ["deepseek-ai/DeepSeek-V4-Flash-Vision-Exp", ThinkingLevel.NONE, undefined],
+    [
+      "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+      ThinkingLevel.HIGH,
+      { thinking: true, reasoning_effort: "high" },
+    ],
+    ["meta-llama/Llama-4-70B", ThinkingLevel.NONE, { enable_thinking: false }],
+    ["meta-llama/Llama-4-70B", ThinkingLevel.HIGH, { enable_thinking: true }],
+  ])(
+    "maps %s at %s onto its own chat template kwargs",
+    (model, level, expected) => {
+      const client = new AutoLLMClient({
+        model: model as string,
+        apiKey: "test-key",
+        baseUrl: "http://localhost:8000/v1",
+        clientType: "vllm-openai-chat",
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const config = (client as any)._client.transformUniConfigToModelConfig({
+        thinking_level: level,
+      });
+      expect(config.chat_template_kwargs).toEqual(expected);
+    },
+  );
 
   test("does not add the vLLM extension when no level is selected", () => {
     const client = new AutoLLMClient({

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -290,7 +290,7 @@ describe("vLLM thinking switch", () => {
         model: model as string,
         apiKey: "test-key",
         baseUrl: "http://localhost:8000/v1",
-        clientType: "vllm-openai-chat",
+        clientType: "openai-chat-vllm-adapter",
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const config = (client as any)._client.transformUniConfigToModelConfig({
@@ -304,7 +304,7 @@ describe("vLLM thinking switch", () => {
     const client = new AutoLLMClient({
       model: "Qwen/Qwen3.6-35B-A3B",
       apiKey: "test-key",
-      clientType: "vllm-openai-chat",
+      clientType: "openai-chat-vllm-adapter",
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const config = (client as any)._client.transformUniConfigToModelConfig({});


### PR DESCRIPTION
## Summary

- `openai-chat-vllm-adapter` chose one `chat_template_kwargs` shape for every model: `enable_thinking`. That is the Qwen3 convention, and vLLM passes the object straight to the served model's own chat template, so it is wrong for anything that reads a different key.
- The client now carries a profile per model family, selected by matching the lowercased model id as a substring, and maps `thinking_level` onto that family's kwargs.

| Models | Off | On |
| --- | --- | --- |
| Qwen3.6-35B-A3B, Qwen3.5-0.8B, Qwen3.5-9B | `enable_thinking: false` | `enable_thinking: true` |
| Qwen3.8-27B, Qwen3.8-Flash-Next | `enable_thinking: false` | `reasoning_effort` — the shared template takes `low`/`medium`/`xhigh` only, so `high` and `max` clamp to `xhigh` |
| DeepSeek-V4-Pro, DeepSeek-V4-Flash | no `chat_template_kwargs` at all | `thinking: true` + `reasoning_effort` — the encoder takes `high`/`max`/`None` only, so `low` through `xhigh` all send `high` |
| DeepSeek-V4-Flash-Vision-Exp | no `chat_template_kwargs` at all | `thinking: true` + `reasoning_effort` — its own encoder takes `low`/`high`/`max`, so only `medium` and `xhigh` clamp to `high` |

Shapes and allowed values are read off each model's own prompt-formatting artifact, vendored or cited under `llmsdk_docs/openai_chat_vllm_adapter/` in this PR — not off vendor prose.

A model outside the table falls back to `enable_thinking`, which keeps the previous behaviour and is inert on a template that does not read the key. Levels clamp rather than raise, per the invariant stated in `errors.py`: a thinking level never raises.

## Renamed: `vllm-openai-chat` → `openai-chat-vllm-adapter`

The rename is folded into this PR because it already owns every file involved. The client type is now `openai-chat-vllm-adapter`, and the module and class mirror it the way every other client in this repo does (`openai_chat`/`OpenaiChatClient`, `ant_messages`/`AntMessagesClient`, `gemini3_7`/`Gemini3_7Client`):

| | Before | After |
| --- | --- | --- |
| Client type | `vllm-openai-chat` | `openai-chat-vllm-adapter` |
| Module | `vllm_openai_chat/` | `openai_chat_vllm_adapter/` |
| Class | `VllmOpenaiChatClient` | `OpenaiChatVllmAdapterClient` |

`vllm-openai-chat` has shipped in no release — it exists only on `dev` (#197) and here — so the old spelling is simply gone: no alias, no deprecation path, nothing to migrate. The four `changelog/unreleased/` entries from #197 and #198 were updated too, since they describe a name that will never ship. `changelog/0.4.x/` is untouched. The directories moved with `git mv`, so the rename is visible in history.

The routing branch in `auto_client.py` / `autoClient.ts` keeps its position and its reason. `openai-chat-vllm-adapter` contains `openai`, so the exact-equality test still has to precede the `openai` substring branches; lose that ordering and the type silently falls through to `OpenaiChatClient`, dropping every per-model thinking mapping with no error. The comment on the branch now names the new string. `_PROTOCOL_CLIENT_TYPES` / `PROTOCOL_CLIENT_TYPES`, the "Supported client types:" error message and the README's wire-protocol table all carry the new name in both languages.

## New: `llmsdk_docs/openai_chat_vllm_adapter/`

The table above was originally derived from recipes.vllm.ai prose, which left the source data outside the repo. This adds the artifacts themselves, at the owner's request, so per-model parameters can be read off the template instead of inferred — and so future model additions extend the same place.

```
llmsdk_docs/openai_chat_vllm_adapter/
├── README.md                          provenance table, what each template reads,
│                                      what the artifacts force on the client's
│                                      table, how to add a model
├── chat_templates/
│   ├── qwen3.8-flash-next.jinja       8952 B  519239a4908b…
│   ├── qwen3.8-27b.jinja              8952 B  519239a4908b…  (same bytes as above)
│   ├── qwen3.6-35b-a3b.jinja          7764 B  52b6d51ae5b2…
│   ├── qwen3.5-0.8b.jinja             7755 B  3dd635d8e716…
│   └── qwen3.5-9b.jinja               7756 B  94f89e03284d…
└── docs/
    └── deepseek-v4-encoding.md        the three models that publish no template
```

Templates are stored **byte-identical to upstream** so they can be diffed against the model repository and fed to Jinja unchanged. That rules out the `> Source:` header line the other `llmsdk_docs/` sections use, so source URL, snapshot date, license and MD5 live in a table in the README instead. None of the five ends in a newline, matching upstream, so `.pre-commit-config.yaml` now excludes the directory from `end-of-file-fixer` — without that, the first contributor with hooks installed would silently rewrite all five.

`Qwen3.8-Flash-Next` and `Qwen3.8-27B` publish the same template byte for byte. Both files are kept, since the point is to look a model up by name, and the README says plainly that they are one artifact.

**Licenses, checked per repository rather than assumed:** `Qwen/Qwen3.8-Flash-Next` is *not* Apache-2.0 — it ships the Qwen Community License 1.0, which adds an attribution condition above 100M MAU or US$20M monthly revenue. The other four Qwen repositories are Apache-2.0. All three DeepSeek repositories are plain MIT.

### DeepSeek publishes no chat template

`chat_template.jinja` returns 404 for all three DeepSeek models, and their 801-byte `tokenizer_config.json` has no `chat_template` key. The premise "every parameter is in the chat template" holds for Qwen and not for DeepSeek, so the section says so rather than papering over it.

Their equivalent artifact is `encoding/encoding_dsv4.py` (~28 KB). It is cited and quoted rather than vendored: it is executable Python, not an inert template; two of the three copies are byte-identical; and ~99% of it is tokenization, tool rendering and completion parsing that has no bearing on request parameters. The note quotes the ~10 lines that actually decide them, verbatim and indentation-exact, with the upstream checksum pinned so drift is detectable.

## Two defects the artifacts exposed, both now fixed

Reading the artifacts surfaced two places where the profile table contradicted its own source. Both are corrected here.

1. **`reasoning_effort: "low"` was a failed request on `DeepSeek-V4-Pro` and `DeepSeek-V4-Flash`.** Those two repositories ship the same `encoding/encoding_dsv4.py` (md5 `f5e65effdf98af0a4edcf5842e719989`), whose line 261 reads:

   ```python
   assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
   ```

   The old table sent `{"thinking": true, "reasoning_effort": "low"}` at `LOW` to all three DeepSeek models, so on Pro and Flash `LOW` tripped that assertion — a failed request, not a weaker answer. The profile is now split. Pro and Flash take `high` at `LOW` (the lowest value they accept); `DeepSeek-V4-Flash-Vision-Exp`, whose own copy of the file (md5 `06a743aa6802e28f1f0e9d5fe49f1def`) validates against `REASONING_EFFORT_PROMPTS = {"low": …, "high": …, "max": …}` with `DEFAULT_REASONING_EFFORT = "low"`, keeps the finer scale on a profile of its own.

   Line 262 of the Pro/Flash file branches on `'max'` alone, so `'high'` and `None` render an identical prompt there. `LOW` through `XHIGH` therefore all produce the same prompt on those two models. That is honest clamping forced by the encoder, and both the client comment and the new README say so rather than leaving a reader to rediscover it.

2. **`Qwen3.8-Flash-Next` silently ignored `LOW` and `MEDIUM`.** It ships a byte-identical `chat_template.jinja` to `Qwen3.8-27B` (md5 `519239a4908bb1f805bbce5fa8c8a242`), and that shared template does read the effort key:

   ```jinja
   {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
   {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
   ```

   The old table nevertheless gave Flash-Next the plain `enable_thinking` profile and never sent the key, so every level from `LOW` up fell through to the template's `xhigh` default — `LOW` and `MEDIUM` were not lower effort than `MAX`. Flash-Next now points at the effort-aware profile it shares a template with, and that profile is named `_QWEN3_8_THINKING` / `QWEN3_8_THINKING` rather than after a single model.

One further asymmetry worth noting, which is *not* a defect: `Qwen3.5-0.8B` inverts the template default (`enable_thinking is defined and enable_thinking is true` → think; everything else here thinks unless the key is explicitly `false`). The client always sends the key, so this is harmless — but it means an omitted key is not a safe no-op across these five models.

## Verification

Python and TypeScript were run strictly one at a time — they share vendor endpoints and rate-limit each other.

- Python: 434 passed, 85 skipped (full suite, live E2E included) — the pre-change baseline on this branch was 433 passed / 85 skipped, and the +1 is the single parameterized case the DeepSeek split adds
- TypeScript: 505 passed, 12/12 suites (full suite, live E2E included) — baseline 504, same +1 case. No flakes on either run; nothing needed a re-run
- `ruff check` and `ruff format --check` clean; `npm run lint` and `npm run build` clean
- The py and ts case tables mirror each other row for row, covering all 8 models plus the fallback

Test-row changes, all corrections to existing parameterized rows rather than new test functions:

- `Qwen/Qwen3.8-Flash-Next` at `LOW` now expects `{reasoning_effort: "low"}` (was `HIGH` → `{enable_thinking: true}`); it is the row that pins Flash-Next onto the shared 3.8 profile, since `NONE` is `{enable_thinking: false}` on both profiles.
- `DeepSeek-V4-Pro` at `LOW` now expects `reasoning_effort: "high"`.
- `DeepSeek-V4-Flash` at `LOW` expects `reasoning_effort: "high"` (was `MAX` → `"max"`, which no longer distinguishes the two DeepSeek profiles).
- `DeepSeek-V4-Flash-Vision-Exp` gains one row, `LOW` → `reasoning_effort: "low"` — the only row that pins the finer scale the split introduces.

Net +1 parameterized case in each language.

For the reference section:

- Every vendored template re-fetched from Hugging Face and checked against the committed file: all five byte-identical, checksums as listed
- All three `encoding_dsv4.py` files re-fetched and checksummed; Pro and Flash confirmed byte-identical, Vision-Exp confirmed different, and the quoted assert lines read straight out of the downloaded files
- All recorded upstream URLs return HTTP 200; all relative links in the new files resolve

## Note

`changelog/unreleased/README.md` and its `.zh.md` are also touched by #199, so whichever merges second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YR7K8nFEYgUBGVLPK4hd2
