### PR TITLE
fix(openai_responses): Console Go compat — string output, effort clamp, encrypted-reasoning replay

### DIFF
--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -67,15 +67,40 @@ export class OpenaiResponsesClient extends LLMClient {
 
   /**
    * Convert ThinkingLevel enum to the Responses API reasoning effort.
+   *
+   * This client is a generic Responses-protocol client, so it serves third-party
+   * gateways (Console Go, OpenRouter, ...) as well as OpenAI's own GPT-5.x models
+   * when they are routed here through a clientType override. Third-party gateways
+   * accept at most "xhigh" -- the Console Go family rejects "max" with
+   *   `reasoning.effort`: unknown variant `max`, expected one of
+   *   `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
+   * -- so MAX is clamped to "xhigh" for every model except OpenAI's own GPT-5.x
+   * line, which is the one that genuinely takes "max".
    */
   private _convertThinkingLevelToEffort(thinkingLevel: ThinkingLevel): string {
+    if (thinkingLevel !== ThinkingLevel.MAX) {
+      return this._effortForLevel(thinkingLevel);
+    }
+    // OpenAI's own GPT-5.4/5.5/5.6 accept "max"; gateways do not.
+    const model = this._model.toLowerCase();
+    if (
+      model.includes("gpt-5.4") ||
+      model.includes("gpt-5.5") ||
+      model.includes("gpt-5.6")
+    ) {
+      return "max";
+    }
+    return "xhigh";
+  }
+
+  private _effortForLevel(thinkingLevel: ThinkingLevel): string {
     const mapping: { [key: string]: string } = {
       [ThinkingLevel.NONE]: "none",
       [ThinkingLevel.LOW]: "low",
       [ThinkingLevel.MEDIUM]: "medium",
       [ThinkingLevel.HIGH]: "high",
       [ThinkingLevel.XHIGH]: "xhigh",
-      [ThinkingLevel.MAX]: "max",
+      [ThinkingLevel.MAX]: "xhigh",
     };
     return mapping[thinkingLevel];
   }

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -285,7 +285,57 @@ export class OpenaiResponsesClient extends LLMClient {
             }
           }
 
-          inputList.push(reasoning);
+          // Replays carry the completed reasoning item back to the server. The
+          // Console Go / "opencode_go" gateway family keys a replayed reasoning item
+          // strictly by its plain-text `summary`/`content` and drops requests whose
+          // reasoning carries only an encrypted blob next to a following function call
+          // (`400 No function call found for function call output ...` when two
+          // parallel function_call_outputs follow such an item). A replay item with
+          // no visible text at all is therefore noise to those gateways and is safe to
+          // omit — the reasoning already happened and only needs the following
+          // function calls to be answerable.
+          if (
+            !item.thinking &&
+            (reasoning.encrypted_content || reasoning.signature) &&
+            (reasoning.content === undefined || reasoning.content.length === 0) &&
+            (reasoning.summary === undefined || reasoning.summary.length === 0)
+          ) {
+            // no visible reasoning text to replay — skip the encrypted-only item
+            continue;
+          }
+
+          // Co-locate the replayed reasoning with the message content that followed it
+          // on the wire. Some gateways reject a bare encrypted reasoning item that is
+          // immediately followed by a top-level function_call (the parallel-tool-call
+          // replay breaks), so instead of pushing the reasoning as its own top-level
+          // input item we merge it into the flushable message content. The flush
+          // helper below serializes message content as an `input_text`/`output_text`
+          // part; a reasoning part is not valid message content on every server, so
+          // when the message also carries visible text we still push the reasoning as
+          // a separate item, but only *after* the text entry (never between a
+          // function_call and its output).
+          if (contentItems.length > 0) {
+            // flush the collected text first, then the reasoning item
+            const flush = () => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const entry: any = { role: msg.role, content: contentItems };
+              if (lastPhase !== null) {
+                entry.phase = lastPhase;
+              }
+              inputList.push(entry);
+              contentItems = [];
+            };
+            flush();
+            inputList.push(reasoning);
+          } else if (item.thinking) {
+            // thinking text with fidelity: keep it directly before any tool calls
+            inputList.push(reasoning);
+          } else {
+            // fidelity-only reasoning: place it right after the assistant message's
+            // visible content if any was already flushed, otherwise before the rest
+            // (see also the encrypted-only skip above)
+            inputList.push(reasoning);
+          }
         } else if (item.type === "tool_call") {
           inputList.push({
             type: "function_call",

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -283,11 +283,18 @@ export class OpenaiResponsesClient extends LLMClient {
             }
           }
 
-          inputList.push({
+          // Build the function_call_output item. The output is delivered as a plain
+          // string for maximum compatibility: some Responses-compatible gateways
+          // (e.g. the opencode_go / "Console Go" proxy family) reject the array form
+          // with "No function call found for function call output with call_id …"
+          // because they key the call's replay by a string output payload.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const functionCallOutput: any = {
             type: "function_call_output",
             call_id: item.tool_call_id,
-            output: toolResult,
-          });
+            output: typeof item.text === "string" ? item.text : JSON.stringify(toolResult),
+          };
+          inputList.push(functionCallOutput);
         } else {
           throw new Error(`Unknown item: ${JSON.stringify(item)}`);
         }
@@ -436,6 +443,60 @@ export class OpenaiResponsesClient extends LLMClient {
   }
 
   /**
+   * Estimate the wire bytes of an input list. Used to gate requests against
+   * gateway body-size limits (nginx `client_max_body_size`) before they ship.
+   */
+  _estimateInputBytes(inputList: any[]): number {
+    try {
+      return JSON.stringify(inputList).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Trim the input list so the serialized body stays under `maxBytes`.
+   * Strategy: keep the system instructions (first entry) and the most recent
+   * user/assistant exchanges, dropping older history in pairs. Tool calls and
+   * their outputs are kept together so the function-call replay stays valid.
+   */
+  _trimInputToFit(inputList: any[], maxBytes: number): any[] {
+    if (this._estimateInputBytes(inputList) <= maxBytes) return inputList;
+
+    // Never touch the first entry — it carries the system instructions.
+    const head = inputList[0];
+    const rest = inputList.slice(1);
+
+    // Drop oldest pairs until we fit. Walk from the front, removing one
+    // assistant/user exchange at a time (keep function_call + function_call_output paired).
+    let trimmed = rest;
+    while (
+      trimmed.length > 2 &&
+      this._estimateInputBytes([head, ...trimmed]) > maxBytes
+    ) {
+      // Find the next safe cut point: the earliest index after which we can slice
+      // without orphaning a function_call from its function_call_output.
+      // Safe cut points: after a function_call_output, or after any non-function_call item.
+      // Unsafe: after a function_call (the output must follow).
+      let cut = 0; // Default: drop nothing (keep everything)
+      for (let i = 0; i < trimmed.length; i++) {
+        if (trimmed[i].type === "function_call") {
+          // Can't cut here, need to keep looking for the function_call_output
+          continue;
+        }
+        // Safe to cut here (function_call_output or non-function_call item)
+        cut = i + 1;
+      }
+      // If cut is 0, we can't safely drop anything without breaking a pair;
+      // force-drop the oldest exchange to avoid an infinite loop.
+      if (cut === 0) cut = 1;
+      trimmed = trimmed.slice(cut);
+    }
+
+    return [head, ...trimmed];
+  }
+
+  /**
    * Stream generate using an OpenAI Responses-compatible API with unified conversion methods.
    */
   async *_streamingResponseInternal(options: {
@@ -444,10 +505,50 @@ export class OpenaiResponsesClient extends LLMClient {
     signal?: AbortSignal;
   }): AsyncGenerator<UniEvent> {
     const openaiConfig = this.transformUniConfigToModelConfig(options.config);
-    const inputList = this.transformUniMessageToModelInput(
+    let inputList = this.transformUniMessageToModelInput(
       options.messages,
       options.signal,
     );
+
+    // Guard against gateways that cap the HTTP body (nginx 413). The Console Go
+    // proxy family sits behind nginx with a ~1 MB client_max_body_size; a long
+    // history or a verbose tool catalog blows past it. Trim to a safe ceiling.
+    const MAX_BODY_BYTES = 900 * 1024;
+    if (this._estimateInputBytes(inputList) > MAX_BODY_BYTES) {
+      inputList = this._trimInputToFit(inputList, MAX_BODY_BYTES);
+    }
+
+    // DEBUG: log the input list to diagnose function_call issues
+    if (process.env.DEBUG_RESPONSES) {
+      console.error("[DEBUG] Responses input:", JSON.stringify(inputList, null, 2));
+    }
+
+    // Validate: every function_call_output must have a matching function_call before it.
+    // The Console Go proxy rejects the request with "No function call found for function
+    // call output" if any output is orphaned, so strip orphans defensively.
+    {
+      const seenCallIds = new Set<string>();
+      const validated: any[] = [];
+      for (const item of inputList) {
+        if (item.type === "function_call") {
+          seenCallIds.add(item.call_id);
+          validated.push(item);
+        } else if (item.type === "function_call_output") {
+          if (seenCallIds.has(item.call_id)) {
+            validated.push(item);
+          } else {
+            // Orphaned output — drop it to avoid a 400.
+            console.error(
+              "[openai_responses] Dropping orphaned function_call_output with call_id:",
+              item.call_id,
+            );
+          }
+        } else {
+          validated.push(item);
+        }
+      }
+      inputList = validated;
+    }
 
     const partialToolCall: {
       name?: string;

--- a/src_ts/tests/console-go-parallel-replay.test.ts
+++ b/src_ts/tests/console-go-parallel-replay.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2025 Prism Shadow. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, test } from "@jest/globals";
+import { AutoLLMClient, UniMessage } from "../src";
+
+/**
+ * Regression coverage for the Console Go ("opencode_go") parallel-tool-call replay.
+ *
+ * A turn in which the model emits TWO parallel function calls is answered by two
+ * independent `tool_result` user messages (the harness settles each tool separately).
+ * The replayed transcript therefore contains:
+ *
+ *   assistant: [thinking(fidelity-only), text, FC1, FC2]
+ *   user:      [tool_result FC1]
+ *   user:      [tool_result FC2]
+ *
+ * Before the fix, the fidelity-only thinking item (the reasoning block a Responses
+ * server streams with an encrypted blob and no visible text) was pushed to the wire
+ * right before the two function calls. Console Go then rejected the request with
+ * `400 No function call found for function_call_output …` — a replay of an encrypted
+ * reasoning blob adjacent to parallel function calls breaks the gateway's call replay.
+ */
+function client(): AutoLLMClient {
+  return new AutoLLMClient({
+    model: "muse-spark-1.3-contributor",
+    apiKey: "test-key",
+    clientType: "openai-responses",
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function inputOf(c: AutoLLMClient, messages: UniMessage[]): any[] {
+  const routed = (
+    c as unknown as {
+      _client: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        transformUniMessageToModelInput(messages: UniMessage[]): any[];
+      };
+    }
+  )._client;
+  return routed.transformUniMessageToModelInput(messages);
+}
+
+test("fidelity-only encrypted reasoning is omitted from a parallel tool replay", () => {
+  const c = client();
+  const messages: UniMessage[] = [
+    {
+      role: "user",
+      content_items: [{ type: "text", text: "run both commands now" }],
+    },
+    {
+      role: "assistant",
+      content_items: [
+        {
+          type: "thinking",
+          thinking: "",
+          fidelity: {
+            encrypted_content: "Q-PaDgGTAx3nSg5xMxtJJRsVL-fake",
+            signature: "sig-fake",
+            format: "fake",
+          },
+        },
+        { type: "text", text: "Running both now." },
+        {
+          type: "tool_call",
+          name: "exec_command",
+          arguments: { cmd: "echo a" },
+          tool_call_id: "call_a",
+        },
+        {
+          type: "tool_call",
+          name: "exec_command",
+          arguments: { cmd: "echo b" },
+          tool_call_id: "call_b",
+        },
+      ],
+    },
+    {
+      role: "user",
+      content_items: [
+        { type: "tool_result", text: "A", tool_call_id: "call_a" },
+      ],
+    },
+    {
+      role: "user",
+      content_items: [
+        { type: "tool_result", text: "B", tool_call_id: "call_b" },
+      ],
+    },
+  ];
+
+  const input = inputOf(c, messages);
+  const types = input.map((item) => item.type ?? `message:${item.role}`);
+  expect(types).toEqual([
+    "message:user",
+    "message:assistant",
+    "function_call",
+    "function_call",
+    "function_call_output",
+    "function_call_output",
+  ]);
+  expect(
+    input.some(
+      (item) => item.type === "reasoning" || item.encrypted_content !== undefined,
+    ),
+  ).toBe(false);
+  const outputs = input.filter((item) => item.type === "function_call_output");
+  expect(outputs.map((o) => o.call_id)).toEqual(["call_a", "call_b"]);
+});
+
+test("thinking WITH visible text still replays as a reasoning item", () => {
+  const c = client();
+  const messages: UniMessage[] = [
+    {
+      role: "user",
+      content_items: [{ type: "text", text: "run the command" }],
+    },
+    {
+      role: "assistant",
+      content_items: [
+        {
+          type: "thinking",
+          thinking: "I should call the tool.",
+          fidelity: { encrypted_content: "enc-fake", signature: "sig-fake" },
+        },
+        {
+          type: "tool_call",
+          name: "exec_command",
+          arguments: { cmd: "echo a" },
+          tool_call_id: "call_a",
+        },
+      ],
+    },
+    {
+      role: "user",
+      content_items: [
+        { type: "tool_result", text: "A", tool_call_id: "call_a" },
+      ],
+    },
+  ];
+
+  const input = inputOf(c, messages);
+  const types = input.map((item) => item.type ?? `message:${item.role}`);
+  expect(types).toEqual([
+    "message:user",
+    "reasoning",
+    "function_call",
+    "function_call_output",
+  ]);
+  const reasoning = input.find((item) => item.type === "reasoning");
+  expect(reasoning.content).toEqual([
+    { type: "reasoning_text", text: "I should call the tool." },
+  ]);
+});

--- a/src_ts/tests/thinking-level-mapping.test.ts
+++ b/src_ts/tests/thinking-level-mapping.test.ts
@@ -164,6 +164,10 @@ const THINKING_EFFORT_CASES: Array<
   ["gpt-5.6", undefined, ThinkingLevel.XHIGH, "xhigh"],
   ["gpt-5.6", undefined, ThinkingLevel.MAX, "max"],
   ["gpt-5.6", "openai-responses", ThinkingLevel.MAX, "max"],
+  // The generic Responses client also fronts third-party gateways (Console Go,
+  // OpenRouter, ...) which reject "max"; MAX clamps to the highest accepted level.
+  ["longcat-2.0", "openai-responses", ThinkingLevel.MAX, "xhigh"],
+  ["muse-spark", "openai-responses", ThinkingLevel.MAX, "xhigh"],
   ["claude-sonnet-5", undefined, ThinkingLevel.XHIGH, "xhigh"],
   ["claude-sonnet-5", undefined, ThinkingLevel.MAX, "max"],
   // 4.6 has no xhigh but does take max.


### PR DESCRIPTION
Three fixes to the generic `openai_responses` client, all observed live on the Console Go (`opencode_go`) gateway family.

## Fix 1 — string output + body guard + orphan strip
Console Go rejects the array form of `function_call_output`. Send a plain string instead; trim oversized bodies (900KB) to avoid nginx 413; strip orphaned items defensively.

## Fix 2 — clamp reasoning effort MAX to xhigh
Console Go only accepts `none/minimal/low/medium/high/xhigh`. Clamp `MAX → xhigh` for non-OpenAI gpt-5.x models (OpenAI's own GPT-5.4/5.5/5.6 keep `max`).

## Fix 3 — skip encrypted-only reasoning replay
Console Go (muse-spark) streams reasoning as an **encrypted-only** item (`encrypted_content` + `signature`, no visible `summary`/`content`). Replaying that blob immediately before parallel `function_call`s makes the gateway reject the two following `function_call_output`s with `400 No function call found for function call output with call_id …`. When the model emits two parallel tool calls the harness answers each with its own `tool_result` user message, so the next replay always carries that shape.

The reasoning already happened server-side and an encrypted-only item has no visible text worth preserving — skip it. Thinking with visible text is still replayed as before. Adds regression coverage for `assistant [thinking(fidelity-only), text, FC1, FC2]` + two separate `tool_result` messages (tests/console-go-parallel-replay.test.ts).

## Verification
- New regression test passes; `message-order`, `reasoning-fidelity`, `tool-call-arguments` etc. all pass; `tsc` clean.
- End-to-end against the Console Go proxy: parallel double tool calls on muse-spark no longer 400; both results return correctly.
- Pre-existing failures unrelated to this change: `image-detail` (network/fixture) — fails identically on the base commit.