### PR TITLE
fix(openai_chat,openai_responses): send a text-only tool result as a plain string

### DIFF
--- a/changelog/unreleased/2026-09-09-tool-result-text-form.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-09
 - **Type:** fix
 - **Scope:** `openai_chat`, `openai_responses`
+- **PR:** [#205](https://github.com/Prism-Shadow/agenthub/pull/205)
 
 [中文版](2026-09-09-tool-result-text-form.zh.md)
 

--- a/changelog/unreleased/2026-09-09-tool-result-text-form.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.md
@@ -1,0 +1,29 @@
+# Send a text-only tool result as a plain string on the generic OpenAI clients
+
+- **Date:** 2026-09-09
+- **Type:** fix
+- **Scope:** `openai_chat`, `openai_responses`
+
+[中文版](2026-09-09-tool-result-text-form.zh.md)
+
+## What changed
+
+- `openai-responses` and `openai-chat` sent a tool result that carries no image as a plain
+  string, instead of wrapping the text in a one-part content list.
+- A tool result that carries images kept the content-part list, the only form that can hold
+  an image part.
+- The `openai-chat` client moves image parts into the following user message on SiliconFlow,
+  which accepts no image in a tool message. The form is therefore decided by what lands in
+  the tool message itself, so on that endpoint a tool result with images also went out as a
+  plain string, with its image parts in the user message as before.
+- `openai-chat-vllm-adapter` inherits the message transform from `openai-chat` and followed
+  the same rule.
+- The first-party `gpt5_6`, `deepseek_v4` and `minimax_m3` clients were left untouched, on
+  the list form their live captures record.
+
+## Wire shapes
+
+| Protocol | Text-only result | Result carrying images |
+| --- | --- | --- |
+| Responses | `{"type": "function_call_output", "call_id": "call_1", "output": "20 degrees."}` | `"output": [{"type": "input_text", "text": "..."}, {"type": "input_image", "image_url": "..."}]` |
+| Chat Completions | `{"role": "tool", "tool_call_id": "call_1", "content": "20 degrees."}` | `"content": [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "..."}}]` |

--- a/changelog/unreleased/2026-09-09-tool-result-text-form.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.md
@@ -19,8 +19,9 @@
   plain string, with its image parts in the user message as before.
 - `openai-chat-vllm-adapter` inherits the message transform from `openai-chat` and followed
   the same rule.
-- The first-party `gpt5_6`, `deepseek_v4` and `minimax_m3` clients were left untouched, on
-  the list form their live captures record.
+- The first-party clients were left untouched: `gpt5_6`, `deepseek_v4`, `minimax_m3` and
+  `kimi_k3` on the list form their live captures record, and `glm5_3`, which already sent a
+  text-only tool result as a plain string.
 
 ## Wire shapes
 

--- a/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-09
 - **Type:** fix
 - **Scope:** `openai_chat`, `openai_responses`
+- **PR:** [#205](https://github.com/Prism-Shadow/agenthub/pull/205)
 
 [English](2026-09-09-tool-result-text-form.md)
 

--- a/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
@@ -1,0 +1,25 @@
+# 通用 OpenAI client 将纯文本工具结果作为纯字符串发送
+
+- **Date:** 2026-09-09
+- **Type:** fix
+- **Scope:** `openai_chat`, `openai_responses`
+
+[English](2026-09-09-tool-result-text-form.md)
+
+## 变更内容
+
+- `openai-responses` 与 `openai-chat` 将不带图片的工具结果作为纯字符串发送，不再把文本包进只有
+  一个部件的 content 列表。
+- 带图片的工具结果仍使用 content 部件列表——只有这种形态能容纳图片部件。
+- 在 SiliconFlow 上，`openai-chat` client 会把图片部件移入其后的 user 消息，因为该端点的 tool
+  消息不接受图片。因此形态由实际落入 tool 消息的内容决定：在该端点上，带图片的工具结果同样以
+  纯字符串发送，图片部件一如既往留在 user 消息中。
+- `openai-chat-vllm-adapter` 继承 `openai-chat` 的消息转换，因而遵循同一规则。
+- 第一方的 `gpt5_6`、`deepseek_v4` 与 `minimax_m3` client 未作改动，保持其实况抓包所记录的列表形态。
+
+## 线上形状
+
+| 协议 | 纯文本结果 | 带图片的结果 |
+| --- | --- | --- |
+| Responses | `{"type": "function_call_output", "call_id": "call_1", "output": "20 degrees."}` | `"output": [{"type": "input_text", "text": "..."}, {"type": "input_image", "image_url": "..."}]` |
+| Chat Completions | `{"role": "tool", "tool_call_id": "call_1", "content": "20 degrees."}` | `"content": [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "..."}}]` |

--- a/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
+++ b/changelog/unreleased/2026-09-09-tool-result-text-form.zh.md
@@ -16,7 +16,8 @@
   消息不接受图片。因此形态由实际落入 tool 消息的内容决定：在该端点上，带图片的工具结果同样以
   纯字符串发送，图片部件一如既往留在 user 消息中。
 - `openai-chat-vllm-adapter` 继承 `openai-chat` 的消息转换，因而遵循同一规则。
-- 第一方的 `gpt5_6`、`deepseek_v4` 与 `minimax_m3` client 未作改动，保持其实况抓包所记录的列表形态。
+- 第一方 client 均未改动：`gpt5_6`、`deepseek_v4`、`minimax_m3` 与 `kimi_k3` 保持其实况抓包所记录的
+  列表形态；`glm5_3` 本就以纯字符串发送纯文本工具结果。
 
 ## 线上形状
 

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,4 +2,4 @@
 
 [中文版](README.zh.md)
 
-- [2026-09-09] Send a tool result that carries no image as a plain string on the generic `openai_chat` and `openai_responses` clients. ([details](2026-09-09-tool-result-text-form.md))
+- [2026-09-09] Send a tool result that carries no image as a plain string on the generic `openai_chat` and `openai_responses` clients. ([details](2026-09-09-tool-result-text-form.md), [#205](https://github.com/Prism-Shadow/agenthub/pull/205))

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+[中文版](README.zh.md)
+
+- [2026-09-09] Send a tool result that carries no image as a plain string on the generic `openai_chat` and `openai_responses` clients. ([details](2026-09-09-tool-result-text-form.md))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -1,0 +1,5 @@
+# 未发布
+
+[English](README.md)
+
+- [2026-09-09] 通用 `openai_chat` 与 `openai_responses` client 将不带图片的工具结果作为纯字符串发送。([详情](2026-09-09-tool-result-text-form.zh.md))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -2,4 +2,4 @@
 
 [English](README.md)
 
-- [2026-09-09] 通用 `openai_chat` 与 `openai_responses` client 将不带图片的工具结果作为纯字符串发送。([详情](2026-09-09-tool-result-text-form.zh.md))
+- [2026-09-09] 通用 `openai_chat` 与 `openai_responses` client 将不带图片的工具结果作为纯字符串发送。([详情](2026-09-09-tool-result-text-form.zh.md), [#205](https://github.com/Prism-Shadow/agenthub/pull/205))

--- a/src_py/agenthub/openai_chat/client.py
+++ b/src_py/agenthub/openai_chat/client.py
@@ -173,7 +173,7 @@ class OpenaiChatClient(LLMClient):
                     if "tool_call_id" not in item:
                         raise ValueError("tool_call_id is required for tool result.")
 
-                    content = [{"type": "text", "text": item["text"]}]
+                    image_parts = []
 
                     if "images" in item and item["images"]:
                         for image_url in item["images"]:
@@ -182,7 +182,12 @@ class OpenaiChatClient(LLMClient):
                                 # siliconflow does not support image_url in tool result
                                 content_parts.append(part)
                             else:
-                                content.append(part)
+                                image_parts.append(part)
+
+                    # a plain string is the form every OpenAI-compatible server accepts for a text
+                    # result; the content-part list is reserved for results carrying images, which
+                    # only servers with multimodal tool messages take
+                    content = [{"type": "text", "text": item["text"]}, *image_parts] if image_parts else item["text"]
 
                     # Tool results are sent as separate messages
                     openai_messages.append(

--- a/src_py/agenthub/openai_responses/client.py
+++ b/src_py/agenthub/openai_responses/client.py
@@ -202,13 +202,20 @@ class OpenaiResponsesClient(LLMClient):
                         raise ValueError("tool_call_id is required for tool result.")
 
                     # NOTE: tool results are input items
-                    tool_result = [{"type": "input_text", "text": item["text"]}]
+                    image_parts = []
                     if "images" in item:
                         for image_url in item["images"]:
-                            tool_result.append(self._convert_image_url(image_url))
+                            image_parts.append(self._convert_image_url(image_url))
+
+                    # a plain string is the form every OpenAI-compatible server accepts for a text
+                    # result; the content-part list is reserved for results carrying images, which
+                    # only servers with multimodal tool messages take
+                    output = (
+                        [{"type": "input_text", "text": item["text"]}, *image_parts] if image_parts else item["text"]
+                    )
 
                     input_list.append(
-                        {"type": "function_call_output", "call_id": item["tool_call_id"], "output": tool_result}
+                        {"type": "function_call_output", "call_id": item["tool_call_id"], "output": output}
                     )
                 else:
                     raise ValueError(f"Unknown item: {item}")

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -246,3 +246,5 @@ async def test_image_over_the_patch_limit_goes_out_at_high_detail_on_gpt_5_6(cas
 
     shrunk = "high" if case.shrinks else "absent"
     assert _details(case, model_input) == [shrunk, "absent", shrunk, "absent"]
+    # the list form is what images require
+    assert isinstance(model_input[2]["output" if case.protocol == "responses" else "content"], list)

--- a/src_py/tests/test_message_order.py
+++ b/src_py/tests/test_message_order.py
@@ -30,6 +30,8 @@ class MessageOrderCase:
     expected: list[str]
     # Claude replays the signature as text, Gemini as the bytes it streamed
     thought_signature: str | bytes = "sig-1"
+    # a text-only tool result goes out as a plain string rather than a one-part list
+    bare_text_tool_result: bool = False
 
 
 # A turn where the model thought, spoke, and then called a tool. Every protocol that can
@@ -44,13 +46,20 @@ CHAT_ORDER = ["user:text", "assistant:text,tool_calls,thinking", "tool:call_1"]
 
 MESSAGE_ORDER_CASES = [
     MessageOrderCase("GPT5_6Client", "gpt-5.6", None, "responses", RESPONSES_ORDER),
-    MessageOrderCase("OpenaiResponsesClient", "gpt-5.6", "openai-responses", "responses", RESPONSES_ORDER),
+    MessageOrderCase(
+        "OpenaiResponsesClient",
+        "gpt-5.6",
+        "openai-responses",
+        "responses",
+        RESPONSES_ORDER,
+        bare_text_tool_result=True,
+    ),
     MessageOrderCase("DeepSeekV4Client", "deepseek-v4", "deepseek-v4", "responses", RESPONSES_ORDER),
     MessageOrderCase("MiniMaxM3Client", "MiniMax-M3", "minimax-m3", "responses", RESPONSES_ORDER),
     MessageOrderCase("Claude5Client", "claude-sonnet-5", None, "messages", MESSAGES_ORDER),
     MessageOrderCase("AntMessagesClient", "claude-sonnet-5", "ant-messages", "messages", MESSAGES_ORDER),
     MessageOrderCase("Gemini3_8Client", "gemini-3.8-flash", None, "gemini", GEMINI_ORDER, b"sig-1"),
-    MessageOrderCase("OpenaiChatClient", "gpt-5.6", "openai-chat", "chat", CHAT_ORDER),
+    MessageOrderCase("OpenaiChatClient", "gpt-5.6", "openai-chat", "chat", CHAT_ORDER, bare_text_tool_result=True),
     MessageOrderCase("GLM5_3Client", "glm-5.3", None, "chat", CHAT_ORDER),
     MessageOrderCase("KimiK3Client", "kimi-k3", None, "chat", CHAT_ORDER),
 ]
@@ -153,3 +162,7 @@ async def test_message_transform_keeps_content_item_order(case: MessageOrderCase
         model_input = await model_input
 
     assert _SIGNATURES[case.protocol](model_input) == case.expected
+
+    if case.bare_text_tool_result:
+        tool_result = model_input[4]["output"] if case.protocol == "responses" else model_input[2]["content"]
+        assert tool_result == "20 degrees."

--- a/src_ts/src/openai_chat/client.ts
+++ b/src_ts/src/openai_chat/client.ts
@@ -238,7 +238,7 @@ export class OpenaiChatClient extends LLMClient {
           }
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const content: any[] = [{ type: "text", text: item.text }];
+          const imageParts: any[] = [];
 
           if (item.images && item.images.length > 0) {
             for (const imageUrl of item.images) {
@@ -250,10 +250,18 @@ export class OpenaiChatClient extends LLMClient {
               if (this._client.baseURL.includes("siliconflow.cn")) {
                 contentParts.push(part);
               } else {
-                content.push(part);
+                imageParts.push(part);
               }
             }
           }
+
+          // a plain string is the form every OpenAI-compatible server accepts for a text
+          // result; the content-part list is reserved for results carrying images, which
+          // only servers with multimodal tool messages take
+          const content =
+            imageParts.length > 0
+              ? [{ type: "text", text: item.text }, ...imageParts]
+              : item.text;
 
           openaiMessages.push({
             role: "tool",

--- a/src_ts/src/openai_responses/client.ts
+++ b/src_ts/src/openai_responses/client.ts
@@ -275,18 +275,26 @@ export class OpenaiResponsesClient extends LLMClient {
 
           // NOTE: tool results are input items
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const toolResult: any[] = [{ type: "input_text", text: item.text }];
+          const imageParts: any[] = [];
 
           if (item.images) {
             for (const imageUrl of item.images) {
-              toolResult.push(this._convertImageUrl(imageUrl));
+              imageParts.push(this._convertImageUrl(imageUrl));
             }
           }
+
+          // a plain string is the form every OpenAI-compatible server accepts for a text
+          // result; the content-part list is reserved for results carrying images, which
+          // only servers with multimodal tool messages take
+          const output =
+            imageParts.length > 0
+              ? [{ type: "input_text", text: item.text }, ...imageParts]
+              : item.text;
 
           inputList.push({
             type: "function_call_output",
             call_id: item.tool_call_id,
-            output: toolResult,
+            output,
           });
         } else {
           throw new Error(`Unknown item: ${JSON.stringify(item)}`);

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -391,6 +391,12 @@ describe.each(IMAGE_DETAIL_CASES)(
           shrunk,
           "absent",
         ]);
+        // the list form is what images require
+        expect(
+          testCase.protocol === "responses"
+            ? Array.isArray(modelInput[2].output)
+            : Array.isArray(modelInput[2].content),
+        ).toBe(true);
       },
     );
   },

--- a/src_ts/tests/message-order.test.ts
+++ b/src_ts/tests/message-order.test.ts
@@ -23,6 +23,8 @@ interface MessageOrderCase {
   expected: string[];
   // Claude replays the signature as text, Gemini as the bytes it streamed
   thoughtSignature?: string | Buffer;
+  // a text-only tool result goes out as a plain string rather than a one-part list
+  bareTextToolResult?: boolean;
 }
 
 // A turn where the model thought, spoke, and then called a tool. Every protocol that can
@@ -66,6 +68,7 @@ const MESSAGE_ORDER_CASES: MessageOrderCase[] = [
     clientType: "openai-responses",
     protocol: "responses",
     expected: RESPONSES_ORDER,
+    bareTextToolResult: true,
   },
   {
     expectedClient: "DeepSeekV4Client",
@@ -107,6 +110,7 @@ const MESSAGE_ORDER_CASES: MessageOrderCase[] = [
     clientType: "openai-chat",
     protocol: "chat",
     expected: CHAT_ORDER,
+    bareTextToolResult: true,
   },
   {
     expectedClient: "GLM5_3Client",
@@ -222,6 +226,14 @@ describe.each(MESSAGE_ORDER_CASES)(
       );
 
       expect(signature(testCase, modelInput)).toEqual(testCase.expected);
+
+      if (testCase.bareTextToolResult) {
+        expect(
+          testCase.protocol === "responses"
+            ? modelInput[4].output
+            : modelInput[2].content,
+        ).toBe("20 degrees.");
+      }
     });
   },
 );


### PR DESCRIPTION
The generic `openai_responses` and `openai_chat` clients wrapped every tool result in a content-part list. That list is the multimodal form: plenty of OpenAI-compatible servers accept only a plain string in a tool result and reject the list outright. This changes both clients, in both languages, to pick the form by content.

## The rule

- A tool result that carries **no image** goes out as a **plain string**.
- A tool result that carries **images** keeps the **content-part list** — it is the only form that can hold an image part.

## Wire shapes

| Protocol | Text-only result | Result carrying images |
| --- | --- | --- |
| Responses | `{"type": "function_call_output", "call_id": "call_1", "output": "20 degrees."}` | `"output": [{"type": "input_text", "text": "..."}, {"type": "input_image", "image_url": "..."}]` |
| Chat Completions | `{"role": "tool", "tool_call_id": "call_1", "content": "20 degrees."}` | `"content": [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "..."}}]` |

## Scope

**In:** the two generic clients, `openai_responses` and `openai_chat`, in `src_ts/` and `src_py/`. `openai_chat_vllm_adapter` subclasses `OpenaiChatClient` and overrides only the config transform (`transformUniConfigToModelConfig` / `transform_uni_config_to_model_config`), so it inherits the new message transform unchanged in both languages.

**Out:** the first-party clients keep their current form. Each one talks to a single known endpoint and its transform follows that endpoint's live captures; there is no generic server on the other side to accommodate. `gpt5_6`, `deepseek_v4`, `minimax_m3` and `kimi_k3` stay on the list form; `glm5_3` already applies exactly this rule ("a tool result without images stays a plain string, the only content shape the Chat Completion schema documents for a tool message"), which is the precedent the generic clients now follow.

## SiliconFlow

`OpenaiChatClient` already special-cases SiliconFlow, which accepts no image in a tool message: image parts are moved into the following user message rather than the tool message. The form is therefore decided by whether an image part actually lands in the tool message's own content, not by whether the result has images. On SiliconFlow a tool result with images consequently goes out as a plain string, with the image parts in the user message exactly as before.

## Tests

No new files and no per-model suites; the existing parameterized suites were extended.

- `src_ts/tests/message-order.test.ts` / `src_py/tests/test_message_order.py` — a capability flag on the case type (`bareTextToolResult` / `bare_text_tool_result`), set on the `OpenaiResponsesClient` and `OpenaiChatClient` rows only. When set, the test asserts the tool result's wire text is exactly `"20 degrees."`: the `function_call_output` item's `output` on Responses, the `role: "tool"` message's `content` on Chat. Rows without the flag are unasserted, so the first-party clients' shape stays unpinned.
- `src_ts/tests/image-detail.test.ts` / `src_py/tests/test_image_detail.py` — one assertion next to the existing detail check that a tool result carrying images went out as a list.

## Relation to #202

The external PR [#202](https://github.com/Prism-Shadow/agenthub/pull/202) (base `main`, TypeScript only) makes the same string change for `openai_responses` as one part of a Console Go compatibility fix. This PR covers both generic clients, in both languages, on `dev`.

## Verification

Local (`src_ts`): `npm ci && npm run lint && npm run build` — clean.
Local (`src_py`): `uvx ruff check && uvx ruff format --check` — `All checks passed!`, `59 files already formatted`.

Offline suites on the test box:

```
cd src_ts && npm ci && npm run build && npm test -- tests/message-order.test.ts tests/image-detail.test.ts tests/tool-call-arguments.test.ts tests/unknown-events.test.ts tests/reasoning-fidelity.test.ts
```
→ `Test Suites: 5 passed, 5 total` / `Tests: 143 passed, 143 total`

```
cd src_py && uv venv .venv && uv pip install -e ".[dev]" && .venv/bin/python -m pytest -q tests/test_message_order.py tests/test_image_detail.py tests/test_tool_call_arguments.py tests/test_unknown_events.py tests/test_reasoning_fidelity.py
```
→ `143 passed in 1.51s`

Both wire forms were also read off the built `dist`, including the SiliconFlow endpoint, which produced `{"role":"tool","tool_call_id":"call_1","content":"20 degrees."}` followed by a user message holding the image part.

The env-gated live-model suites (`tests/client.test.ts`, `tests/test_client.py`) were not run locally; CI ran them on this PR and both jobs are green. The rows that exercise the new form against a live server — `test_tool_use` and `test_tool_result_mixed_with_text` on `deepseek-v4-flash:deepseek:openai-chat` and `deepseek-v4-flash:deepseek:openai-responses` — pass. The OpenRouter rows are gated behind `RUN_SLOW_TEST=1`, which neither workflow sets, so they did not run.

Reruns along the way, all on tests this diff does not touch: `test_tool_use[MiniMax-M3:official:minimax-m3]` (`minimax_m3`, out of scope; it also passed on another branch's run half an hour earlier) and `test_tool_result_with_image[gpt-5.6-luna:official]` (`gpt5_6`, out of scope — a keyword assertion on the model's own prose). Both passed on rerun. Several runs were also cancelled by the `ci-task-lock` concurrency group while other PRs held it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXyqK5bgTH99HuXmroCPYs
