### PR TITLE
Name the renamed GPT client in the 0.4.11 tool-result entry

### DIFF
--- a/changelog/0.4.11/2026-09-09-tool-result-text-form.md
+++ b/changelog/0.4.11/2026-09-09-tool-result-text-form.md
@@ -19,7 +19,7 @@
   plain string, with its image parts in the user message as before.
 - `openai-chat-vllm-adapter` inherits the message transform from `openai-chat` and followed
   the same rule.
-- The first-party clients were left untouched: `gpt5_6`, `deepseek_v4`, `minimax_m3` and
+- The first-party clients were left untouched: `gpt6`, `deepseek_v4`, `minimax_m3` and
   `kimi_k3` on the list form their live captures record, and `glm5_3`, which already sent a
   text-only tool result as a plain string.
 

--- a/changelog/0.4.11/2026-09-09-tool-result-text-form.zh.md
+++ b/changelog/0.4.11/2026-09-09-tool-result-text-form.zh.md
@@ -16,7 +16,7 @@
   消息不接受图片。因此形态由实际落入 tool 消息的内容决定：在该端点上，带图片的工具结果同样以
   纯字符串发送，图片部件一如既往留在 user 消息中。
 - `openai-chat-vllm-adapter` 继承 `openai-chat` 的消息转换，因而遵循同一规则。
-- 第一方 client 均未改动：`gpt5_6`、`deepseek_v4`、`minimax_m3` 与 `kimi_k3` 保持其实况抓包所记录的
+- 第一方 client 均未改动：`gpt6`、`deepseek_v4`、`minimax_m3` 与 `kimi_k3` 保持其实况抓包所记录的
   列表形态；`glm5_3` 本就以纯字符串发送纯文本工具结果。
 
 ## 线上形状


### PR DESCRIPTION
The 0.4.11 changelog entry for the plain-string tool result (#205) lists the first-party clients the rule leaves alone as `gpt5_6`, `deepseek_v4`, `minimax_m3` and `kimi_k3`. In the same release, #204 renamed that folder to `gpt6`, so a reader of `changelog/0.4.11/` would look for a client that does not exist there. Both language files now say `gpt6`.

Docs-only; no code changes.

## Verification

- `git diff` touches two lines in `changelog/0.4.11/2026-09-09-tool-result-text-form.md` / `.zh.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXyqK5bgTH99HuXmroCPYs
