### PR TITLE
fix(openai_chat,kimi_k3,glm5_3): send a tool result's images in the following user message

### DIFF
--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
@@ -17,9 +17,9 @@
 - Both clients now put the image parts in the user message that follows the turn's tool
   messages, on every endpoint. SiliconFlow already took this placement as a special case;
   the special case is gone.
-- `openai-chat` therefore sends every tool result as a plain string, the text-only form
-  [0.4.11 introduced](../0.4.11/2026-09-09-tool-result-text-form.md); `kimi-k3` keeps its
-  one-part text list.
+- Both clients therefore send every tool result as a plain string: `openai-chat` keeps the
+  text-only form [0.4.11 introduced](../0.4.11/2026-09-09-tool-result-text-form.md), and
+  `kimi-k3` drops its one-part text list for the string Moonshot's own examples send.
 - `openai-chat-vllm-adapter` inherits the transform and follows the same rule.
 - The offline image-detail test reads the tool result's images from the trailing user
   message and covers `kimi-k3` next to `openai-chat`.

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-09-10
 - **Type:** fix
-- **Scope:** `openai_chat`, `kimi_k3`
+- **Scope:** `openai_chat`, `kimi_k3`, `glm5_3`
 - **PR:** [#209](https://github.com/Prism-Shadow/agenthub/pull/209)
 
 [中文版](2026-09-10-tool-result-images-user-message.zh.md)
@@ -10,19 +10,21 @@
 ## What changed
 
 - `openai-chat` and `kimi-k3` sent the images of a tool result inside the `tool` message as
-  `image_url` parts on every endpoint but SiliconFlow. A Chat Completions tool message holds
+  `image_url` parts on every endpoint but SiliconFlow, and `glm-5.3` did the same for
+  `glm-5.3-flash`, the one GLM id that reads images. A Chat Completions tool message holds
   text only, so a server that validates the schema refused the whole request with
   `400 Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ChatCompletionRequestToolMessageContent`,
   and reading an image with a tool ended the turn on such a gateway.
-- Both clients now put the image parts in the user message that follows the turn's tool
-  messages, on every endpoint. SiliconFlow already took this placement as a special case;
-  the special case is gone.
-- Both clients therefore send every tool result as a plain string: `openai-chat` keeps the
-  text-only form [0.4.11 introduced](../0.4.11/2026-09-09-tool-result-text-form.md), and
-  `kimi-k3` drops its one-part text list for the string Moonshot's own examples send.
+- All three clients now put the image parts in the user message that follows the turn's
+  tool messages, on every endpoint. SiliconFlow already took this placement as a special
+  case; the special case is gone.
+- Every tool result therefore goes out as a plain string: `openai-chat` keeps the text-only
+  form [0.4.11 introduced](../0.4.11/2026-09-09-tool-result-text-form.md), `kimi-k3` drops
+  its one-part text list for the string Moonshot's own examples send, and `glm-5.3` sent the
+  string already.
 - `openai-chat-vllm-adapter` inherits the transform and follows the same rule.
 - The offline image-detail test reads the tool result's images from the trailing user
-  message and covers `kimi-k3` next to `openai-chat`.
+  message and covers `kimi-k3` and `glm-5.3-flash` next to `openai-chat`.
 
 ## Wire shape
 

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `openai_chat`, `kimi_k3`
+- **PR:** [#209](https://github.com/Prism-Shadow/agenthub/pull/209)
 
 [中文版](2026-09-10-tool-result-images-user-message.zh.md)
 

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.md
@@ -1,0 +1,33 @@
+# Send a tool result's images in the following user message on every Chat Completions endpoint
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `openai_chat`, `kimi_k3`
+
+[中文版](2026-09-10-tool-result-images-user-message.zh.md)
+
+## What changed
+
+- `openai-chat` and `kimi-k3` sent the images of a tool result inside the `tool` message as
+  `image_url` parts on every endpoint but SiliconFlow. A Chat Completions tool message holds
+  text only, so a server that validates the schema refused the whole request with
+  `400 Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ChatCompletionRequestToolMessageContent`,
+  and reading an image with a tool ended the turn on such a gateway.
+- Both clients now put the image parts in the user message that follows the turn's tool
+  messages, on every endpoint. SiliconFlow already took this placement as a special case;
+  the special case is gone.
+- `openai-chat` therefore sends every tool result as a plain string, the text-only form
+  [0.4.11 introduced](../0.4.11/2026-09-09-tool-result-text-form.md); `kimi-k3` keeps its
+  one-part text list.
+- `openai-chat-vllm-adapter` inherits the transform and follows the same rule.
+- The offline image-detail test reads the tool result's images from the trailing user
+  message and covers `kimi-k3` next to `openai-chat`.
+
+## Wire shape
+
+A tool result carrying an image, `{"type": "tool_result", "text": "image/png", "images": ["data:…"], "tool_call_id": "call_1"}`, goes out as two messages:
+
+```json
+{"role": "tool", "tool_call_id": "call_1", "content": "image/png"}
+{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:…"}}]}
+```

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
@@ -1,0 +1,32 @@
+# 在所有 Chat Completions 端点上，工具结果的图片改由其后的 user 消息携带
+
+- **Date:** 2026-09-10
+- **Type:** fix
+- **Scope:** `openai_chat`, `kimi_k3`
+
+[English](2026-09-10-tool-result-images-user-message.md)
+
+## 变更内容
+
+- `openai-chat` 与 `kimi-k3` 此前在除 SiliconFlow 之外的所有端点上，都把工具结果的图片作为
+  `image_url` 部件放进 `tool` 消息。Chat Completions 的 tool 消息只容纳文本，校验 schema 的服务端
+  因此拒绝整个请求：
+  `400 Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ChatCompletionRequestToolMessageContent`，
+  经此类网关用工具读图会直接终止该轮。
+- 两个 client 现在在所有端点上都把图片部件放进本轮 tool 消息之后的 user 消息。SiliconFlow 此前
+  已作为特例采用这一位置，该特例随之移除。
+- 因此 `openai-chat` 的每条工具结果都以纯字符串发送，即
+  [0.4.11 引入](../0.4.11/2026-09-09-tool-result-text-form.zh.md)的纯文本形态；`kimi-k3` 保持其
+  单部件文本列表。
+- `openai-chat-vllm-adapter` 继承该消息转换，遵循同一规则。
+- 离线的 image-detail 测试改从末尾的 user 消息读取工具结果的图片，并在 `openai-chat` 之外覆盖
+  `kimi-k3`。
+
+## 线上形状
+
+带图片的工具结果 `{"type": "tool_result", "text": "image/png", "images": ["data:…"], "tool_call_id": "call_1"}` 以两条消息发出：
+
+```json
+{"role": "tool", "tool_call_id": "call_1", "content": "image/png"}
+{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:…"}}]}
+```

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
@@ -16,9 +16,9 @@
   经此类网关用工具读图会直接终止该轮。
 - 两个 client 现在在所有端点上都把图片部件放进本轮 tool 消息之后的 user 消息。SiliconFlow 此前
   已作为特例采用这一位置，该特例随之移除。
-- 因此 `openai-chat` 的每条工具结果都以纯字符串发送，即
-  [0.4.11 引入](../0.4.11/2026-09-09-tool-result-text-form.zh.md)的纯文本形态；`kimi-k3` 保持其
-  单部件文本列表。
+- 因此两个 client 的每条工具结果都以纯字符串发送：`openai-chat` 沿用
+  [0.4.11 引入](../0.4.11/2026-09-09-tool-result-text-form.zh.md)的纯文本形态，`kimi-k3` 则放弃
+  单部件文本列表，改为 Moonshot 官方示例所用的字符串。
 - `openai-chat-vllm-adapter` 继承该消息转换，遵循同一规则。
 - 离线的 image-detail 测试改从末尾的 user 消息读取工具结果的图片，并在 `openai-chat` 之外覆盖
   `kimi-k3`。

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
@@ -3,6 +3,7 @@
 - **Date:** 2026-09-10
 - **Type:** fix
 - **Scope:** `openai_chat`, `kimi_k3`
+- **PR:** [#209](https://github.com/Prism-Shadow/agenthub/pull/209)
 
 [English](2026-09-10-tool-result-images-user-message.md)
 

--- a/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
+++ b/changelog/unreleased/2026-09-10-tool-result-images-user-message.zh.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-09-10
 - **Type:** fix
-- **Scope:** `openai_chat`, `kimi_k3`
+- **Scope:** `openai_chat`, `kimi_k3`, `glm5_3`
 - **PR:** [#209](https://github.com/Prism-Shadow/agenthub/pull/209)
 
 [English](2026-09-10-tool-result-images-user-message.md)
@@ -10,18 +10,19 @@
 ## 变更内容
 
 - `openai-chat` 与 `kimi-k3` 此前在除 SiliconFlow 之外的所有端点上，都把工具结果的图片作为
-  `image_url` 部件放进 `tool` 消息。Chat Completions 的 tool 消息只容纳文本，校验 schema 的服务端
+  `image_url` 部件放进 `tool` 消息；`glm-5.3` 对唯一能读图的 GLM id `glm-5.3-flash` 也是如此。
+  Chat Completions 的 tool 消息只容纳文本，校验 schema 的服务端
   因此拒绝整个请求：
   `400 Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ChatCompletionRequestToolMessageContent`，
   经此类网关用工具读图会直接终止该轮。
-- 两个 client 现在在所有端点上都把图片部件放进本轮 tool 消息之后的 user 消息。SiliconFlow 此前
+- 三个 client 现在在所有端点上都把图片部件放进本轮 tool 消息之后的 user 消息。SiliconFlow 此前
   已作为特例采用这一位置，该特例随之移除。
-- 因此两个 client 的每条工具结果都以纯字符串发送：`openai-chat` 沿用
-  [0.4.11 引入](../0.4.11/2026-09-09-tool-result-text-form.zh.md)的纯文本形态，`kimi-k3` 则放弃
-  单部件文本列表，改为 Moonshot 官方示例所用的字符串。
+- 因此每条工具结果都以纯字符串发送：`openai-chat` 沿用
+  [0.4.11 引入](../0.4.11/2026-09-09-tool-result-text-form.zh.md)的纯文本形态，`kimi-k3` 放弃
+  单部件文本列表，改为 Moonshot 官方示例所用的字符串，`glm-5.3` 原本就发字符串。
 - `openai-chat-vllm-adapter` 继承该消息转换，遵循同一规则。
 - 离线的 image-detail 测试改从末尾的 user 消息读取工具结果的图片，并在 `openai-chat` 之外覆盖
-  `kimi-k3`。
+  `kimi-k3` 与 `glm-5.3-flash`。
 
 ## 线上形状
 

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+[中文版](README.zh.md)
+
+- [2026-09-10] Send a tool result's images in the user message that follows the tool messages on every Chat Completions endpoint, on the `openai_chat` and `kimi_k3` clients. ([details](2026-09-10-tool-result-images-user-message.md))

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,4 +2,4 @@
 
 [中文版](README.zh.md)
 
-- [2026-09-10] Send a tool result's images in the user message that follows the tool messages on every Chat Completions endpoint, on the `openai_chat` and `kimi_k3` clients. ([details](2026-09-10-tool-result-images-user-message.md))
+- [2026-09-10] Send a tool result's images in the user message that follows the tool messages on every Chat Completions endpoint, on the `openai_chat` and `kimi_k3` clients. ([details](2026-09-10-tool-result-images-user-message.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))

--- a/changelog/unreleased/README.md
+++ b/changelog/unreleased/README.md
@@ -2,4 +2,4 @@
 
 [中文版](README.zh.md)
 
-- [2026-09-10] Send a tool result's images in the user message that follows the tool messages on every Chat Completions endpoint, on the `openai_chat` and `kimi_k3` clients. ([details](2026-09-10-tool-result-images-user-message.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))
+- [2026-09-10] Send a tool result's images in the user message that follows the tool messages on every Chat Completions endpoint, on the `openai_chat`, `kimi_k3` and `glm5_3` clients. ([details](2026-09-10-tool-result-images-user-message.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -2,4 +2,4 @@
 
 [English](README.md)
 
-- [2026-09-10] `openai_chat` 与 `kimi_k3` client 在所有 Chat Completions 端点上，都把工具结果的图片放进 tool 消息之后的 user 消息发送。([详情](2026-09-10-tool-result-images-user-message.zh.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))
+- [2026-09-10] `openai_chat`、`kimi_k3` 与 `glm5_3` client 在所有 Chat Completions 端点上，都把工具结果的图片放进 tool 消息之后的 user 消息发送。([详情](2026-09-10-tool-result-images-user-message.zh.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -2,4 +2,4 @@
 
 [English](README.md)
 
-- [2026-09-10] `openai_chat` 与 `kimi_k3` client 在所有 Chat Completions 端点上，都把工具结果的图片放进 tool 消息之后的 user 消息发送。([详情](2026-09-10-tool-result-images-user-message.zh.md))
+- [2026-09-10] `openai_chat` 与 `kimi_k3` client 在所有 Chat Completions 端点上，都把工具结果的图片放进 tool 消息之后的 user 消息发送。([详情](2026-09-10-tool-result-images-user-message.zh.md), [#209](https://github.com/Prism-Shadow/agenthub/pull/209))

--- a/changelog/unreleased/README.zh.md
+++ b/changelog/unreleased/README.zh.md
@@ -1,0 +1,5 @@
+# 未发布
+
+[English](README.md)
+
+- [2026-09-10] `openai_chat` 与 `kimi_k3` client 在所有 Chat Completions 端点上，都把工具结果的图片放进 tool 消息之后的 user 消息发送。([详情](2026-09-10-tool-result-images-user-message.zh.md))

--- a/src_py/agenthub/glm5_3/client.py
+++ b/src_py/agenthub/glm5_3/client.py
@@ -203,23 +203,24 @@ class GLM5_3Client(LLMClient):
                     if "tool_call_id" not in item:
                         raise ValueError("tool_call_id is required for tool result.")
 
-                    # a tool result without images stays a plain string, the only content shape
-                    # the Chat Completion schema documents for a tool message
-                    content = item["text"]
+                    # Chat Completions lets a tool message carry text only, and a server that
+                    # validates the schema rejects the whole request over an image part in one.
+                    # The images ride in the user message that follows the turn's tool messages,
+                    # the one place every OpenAI-compatible server reads them.
                     if "images" in item and item["images"]:
                         if not supports_image:
                             raise ValueError(f"GLM {self._model} does not support images in tool results.")
 
-                        content = [{"type": "text", "text": item["text"]}]
                         for image_url in item["images"]:
-                            content.append({"type": "image_url", "image_url": {"url": image_url}})
+                            content_parts.append({"type": "image_url", "image_url": {"url": image_url}})
 
-                    # Tool results are sent as separate messages
+                    # the plain string is the only content shape the Chat Completion schema
+                    # documents for a tool message
                     openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
-                            "content": content,
+                            "content": item["text"],
                         }
                     )
                 else:

--- a/src_py/agenthub/kimi_k3/client.py
+++ b/src_py/agenthub/kimi_k3/client.py
@@ -223,12 +223,13 @@ class KimiK3Client(LLMClient):
                             base64_image = await self._convert_image_url_to_base64(image_url)
                             content_parts.append({"type": "image_url", "image_url": {"url": base64_image}})
 
-                    # Tool results are sent as separate messages
+                    # the plain string is the form Moonshot's own tool-call examples send and every
+                    # OpenAI-compatible server accepts
                     openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
-                            "content": [{"type": "text", "text": item["text"]}],
+                            "content": item["text"],
                         }
                     )
                 else:

--- a/src_py/agenthub/kimi_k3/client.py
+++ b/src_py/agenthub/kimi_k3/client.py
@@ -214,23 +214,21 @@ class KimiK3Client(LLMClient):
                     if "tool_call_id" not in item:
                         raise ValueError("tool_call_id is required for tool result.")
 
-                    content = [{"type": "text", "text": item["text"]}]
-
+                    # Chat Completions lets a tool message carry text only, and a server that
+                    # validates the schema rejects the whole request over an image part in one.
+                    # The images ride in the user message that follows the turn's tool messages,
+                    # the one place every OpenAI-compatible server reads them.
                     if "images" in item and item["images"]:
                         for image_url in item["images"]:
                             base64_image = await self._convert_image_url_to_base64(image_url)
-                            if "siliconflow.cn" in str(self._client.base_url):
-                                # siliconflow does not support image_url in tool result
-                                content_parts.append({"type": "image_url", "image_url": {"url": base64_image}})
-                            else:
-                                content.append({"type": "image_url", "image_url": {"url": base64_image}})
+                            content_parts.append({"type": "image_url", "image_url": {"url": base64_image}})
 
                     # Tool results are sent as separate messages
                     openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
-                            "content": content,
+                            "content": [{"type": "text", "text": item["text"]}],
                         }
                     )
                 else:

--- a/src_py/agenthub/openai_chat/client.py
+++ b/src_py/agenthub/openai_chat/client.py
@@ -173,28 +173,22 @@ class OpenaiChatClient(LLMClient):
                     if "tool_call_id" not in item:
                         raise ValueError("tool_call_id is required for tool result.")
 
-                    image_parts = []
-
+                    # Chat Completions lets a tool message carry text only, and a server that
+                    # validates the schema rejects the whole request over an image part in one.
+                    # The images ride in the user message that follows the turn's tool messages,
+                    # the one place every OpenAI-compatible server reads them.
                     if "images" in item and item["images"]:
                         for image_url in item["images"]:
-                            part = self._convert_image_url(await self._convert_image_url_to_base64(image_url))
-                            if "siliconflow.cn" in str(self._client.base_url):
-                                # siliconflow does not support image_url in tool result
-                                content_parts.append(part)
-                            else:
-                                image_parts.append(part)
+                            content_parts.append(
+                                self._convert_image_url(await self._convert_image_url_to_base64(image_url))
+                            )
 
-                    # a plain string is the form every OpenAI-compatible server accepts for a text
-                    # result; the content-part list is reserved for results carrying images, which
-                    # only servers with multimodal tool messages take
-                    content = [{"type": "text", "text": item["text"]}, *image_parts] if image_parts else item["text"]
-
-                    # Tool results are sent as separate messages
+                    # the plain string is the form every OpenAI-compatible server accepts
                     openai_messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": item["tool_call_id"],
-                            "content": content,
+                            "content": item["text"],
                         }
                     )
                 else:

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -14,6 +14,7 @@
 
 import base64
 import inspect
+import json
 import struct
 from dataclasses import dataclass
 from typing import Any
@@ -188,6 +189,7 @@ IMAGE_DETAIL_CASES = [
     ImageDetailCase("OpenaiResponsesClient", "deepseek-v4-flash-vision-exp", "openai-responses", "responses", False),
     ImageDetailCase("OpenaiChatClient", "GPT-5.6-Sol", "openai-chat", "chat", True),
     ImageDetailCase("OpenaiChatClient", "gpt-5.5", "openai-chat", "chat", False),
+    ImageDetailCase("KimiK3Client", "kimi-k3", None, "chat", False),
     # The DeepSeek client forwards images to every id except the text-only V4 Flash / V4 Pro
     # (bare, dated snapshot, any gateway prefix, any case).
     ImageDetailCase("DeepSeekV4Client", "deepseek-v4-flash", None, "responses", False, refuses_images=True),
@@ -235,7 +237,9 @@ def _details(case: ImageDetailCase, model_input: list[dict[str, Any]]) -> list[s
     if case.protocol == "responses":
         parts = model_input[0]["content"][1:] + model_input[2]["output"][1:]
     else:
-        parts = [part["image_url"] for part in model_input[0]["content"][1:] + model_input[2]["content"][1:]]
+        # Chat Completions takes no image in a tool message: the tool result's images follow it
+        # in a user message of their own.
+        parts = [part["image_url"] for part in model_input[0]["content"][1:] + model_input[3]["content"]]
 
     return [part.get("detail", "absent") for part in parts]
 
@@ -263,5 +267,13 @@ async def test_image_parts_go_out_at_the_detail_the_client_needs_or_are_refused_
 
     shrunk = "high" if case.shrinks else "absent"
     assert _details(case, model_input) == [shrunk, "absent", shrunk, "absent"]
-    # the list form is what images require
-    assert isinstance(model_input[2]["output" if case.protocol == "responses" else "content"], list)
+    if case.protocol == "responses":
+        # the list form is what images require
+        assert isinstance(model_input[2]["output"], list)
+    else:
+        # the tool message carries the text alone, and the images follow it in a user message
+        assert len(model_input) == 4
+        assert model_input[2]["role"] == "tool"
+        assert "image_url" not in json.dumps(model_input[2])
+        assert model_input[3]["role"] == "user"
+        assert [part["type"] for part in model_input[3]["content"]] == ["image_url", "image_url"]

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -14,7 +14,6 @@
 
 import base64
 import inspect
-import json
 import struct
 from dataclasses import dataclass
 from typing import Any
@@ -274,6 +273,6 @@ async def test_image_parts_go_out_at_the_detail_the_client_needs_or_are_refused_
         # the tool message carries the text alone, and the images follow it in a user message
         assert len(model_input) == 4
         assert model_input[2]["role"] == "tool"
-        assert "image_url" not in json.dumps(model_input[2])
+        assert isinstance(model_input[2]["content"], str)
         assert model_input[3]["role"] == "user"
         assert [part["type"] for part in model_input[3]["content"]] == ["image_url", "image_url"]

--- a/src_py/tests/test_image_detail.py
+++ b/src_py/tests/test_image_detail.py
@@ -189,6 +189,7 @@ IMAGE_DETAIL_CASES = [
     ImageDetailCase("OpenaiChatClient", "GPT-5.6-Sol", "openai-chat", "chat", True),
     ImageDetailCase("OpenaiChatClient", "gpt-5.5", "openai-chat", "chat", False),
     ImageDetailCase("KimiK3Client", "kimi-k3", None, "chat", False),
+    ImageDetailCase("GLM5_3Client", "glm-5.3-flash", None, "chat", False),
     # The DeepSeek client forwards images to every id except the text-only V4 Flash / V4 Pro
     # (bare, dated snapshot, any gateway prefix, any case).
     ImageDetailCase("DeepSeekV4Client", "deepseek-v4-flash", None, "responses", False, refuses_images=True),

--- a/src_py/tests/test_message_order.py
+++ b/src_py/tests/test_message_order.py
@@ -61,7 +61,7 @@ MESSAGE_ORDER_CASES = [
     MessageOrderCase("Gemini3_8Client", "gemini-3.8-flash", None, "gemini", GEMINI_ORDER, b"sig-1"),
     MessageOrderCase("OpenaiChatClient", "gpt-5.6", "openai-chat", "chat", CHAT_ORDER, bare_text_tool_result=True),
     MessageOrderCase("GLM5_3Client", "glm-5.3", None, "chat", CHAT_ORDER),
-    MessageOrderCase("KimiK3Client", "kimi-k3", None, "chat", CHAT_ORDER),
+    MessageOrderCase("KimiK3Client", "kimi-k3", None, "chat", CHAT_ORDER, bare_text_tool_result=True),
 ]
 
 

--- a/src_py/tests/test_message_order.py
+++ b/src_py/tests/test_message_order.py
@@ -60,7 +60,7 @@ MESSAGE_ORDER_CASES = [
     MessageOrderCase("AntMessagesClient", "claude-sonnet-5", "ant-messages", "messages", MESSAGES_ORDER),
     MessageOrderCase("Gemini3_8Client", "gemini-3.8-flash", None, "gemini", GEMINI_ORDER, b"sig-1"),
     MessageOrderCase("OpenaiChatClient", "gpt-5.6", "openai-chat", "chat", CHAT_ORDER, bare_text_tool_result=True),
-    MessageOrderCase("GLM5_3Client", "glm-5.3", None, "chat", CHAT_ORDER),
+    MessageOrderCase("GLM5_3Client", "glm-5.3", None, "chat", CHAT_ORDER, bare_text_tool_result=True),
     MessageOrderCase("KimiK3Client", "kimi-k3", None, "chat", CHAT_ORDER, bare_text_tool_result=True),
 ]
 

--- a/src_ts/src/glm5_3/client.ts
+++ b/src_ts/src/glm5_3/client.ts
@@ -271,11 +271,10 @@ export class GLM5_3Client extends LLMClient {
             throw new Error("tool_call_id is required for tool result.");
           }
 
-          // a tool result without images stays a plain string, the only content shape
-          // the Chat Completion schema documents for a tool message
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let content: any = item.text;
-
+          // Chat Completions lets a tool message carry text only, and a server that
+          // validates the schema rejects the whole request over an image part in one.
+          // The images ride in the user message that follows the turn's tool messages,
+          // the one place every OpenAI-compatible server reads them.
           if (item.images && item.images.length > 0) {
             if (!supportsImage) {
               throw new Error(
@@ -283,19 +282,20 @@ export class GLM5_3Client extends LLMClient {
               );
             }
 
-            content = [{ type: "text", text: item.text }];
             for (const imageUrl of item.images) {
-              content.push({
+              contentParts.push({
                 type: "image_url",
                 image_url: { url: imageUrl },
               });
             }
           }
 
+          // the plain string is the only content shape the Chat Completion schema
+          // documents for a tool message
           openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
-            content,
+            content: item.text,
           });
         } else {
           throw new Error(

--- a/src_ts/src/kimi_k3/client.ts
+++ b/src_ts/src/kimi_k3/client.ts
@@ -318,10 +318,12 @@ export class KimiK3Client extends LLMClient {
             }
           }
 
+          // the plain string is the form Moonshot's own tool-call examples send and every
+          // OpenAI-compatible server accepts
           openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
-            content: [{ type: "text", text: item.text }],
+            content: item.text,
           });
         } else {
           throw new Error(

--- a/src_ts/src/kimi_k3/client.ts
+++ b/src_ts/src/kimi_k3/client.ts
@@ -301,34 +301,27 @@ export class KimiK3Client extends LLMClient {
             throw new Error("tool_call_id is required for tool result.");
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const content: any[] = [{ type: "text", text: item.text }];
-
+          // Chat Completions lets a tool message carry text only, and a server that
+          // validates the schema rejects the whole request over an image part in one.
+          // The images ride in the user message that follows the turn's tool messages,
+          // the one place every OpenAI-compatible server reads them.
           if (item.images && item.images.length > 0) {
             for (const imageUrl of item.images) {
               const base64Image = await this._convertImageUrlToBase64(
                 imageUrl,
                 signal,
               );
-              if (this._client.baseURL.includes("siliconflow.cn")) {
-                // siliconflow does not support image_url in tool result
-                contentParts.push({
-                  type: "image_url",
-                  image_url: { url: base64Image },
-                });
-              } else {
-                content.push({
-                  type: "image_url",
-                  image_url: { url: base64Image },
-                });
-              }
+              contentParts.push({
+                type: "image_url",
+                image_url: { url: base64Image },
+              });
             }
           }
 
           openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
-            content,
+            content: [{ type: "text", text: item.text }],
           });
         } else {
           throw new Error(

--- a/src_ts/src/openai_chat/client.ts
+++ b/src_ts/src/openai_chat/client.ts
@@ -237,36 +237,25 @@ export class OpenaiChatClient extends LLMClient {
             throw new Error("tool_call_id is required for tool result.");
           }
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const imageParts: any[] = [];
-
+          // Chat Completions lets a tool message carry text only, and a server that
+          // validates the schema rejects the whole request over an image part in one.
+          // The images ride in the user message that follows the turn's tool messages,
+          // the one place every OpenAI-compatible server reads them.
           if (item.images && item.images.length > 0) {
             for (const imageUrl of item.images) {
               const base64Image = await this._convertImageUrlToBase64(
                 imageUrl,
                 signal,
               );
-              const part = this._convertImageUrl(base64Image);
-              if (this._client.baseURL.includes("siliconflow.cn")) {
-                contentParts.push(part);
-              } else {
-                imageParts.push(part);
-              }
+              contentParts.push(this._convertImageUrl(base64Image));
             }
           }
 
-          // a plain string is the form every OpenAI-compatible server accepts for a text
-          // result; the content-part list is reserved for results carrying images, which
-          // only servers with multimodal tool messages take
-          const content =
-            imageParts.length > 0
-              ? [{ type: "text", text: item.text }, ...imageParts]
-              : item.text;
-
+          // the plain string is the form every OpenAI-compatible server accepts
           openaiMessages.push({
             role: "tool",
             tool_call_id: item.tool_call_id,
-            content,
+            content: item.text,
           });
         } else {
           throw new Error(

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -309,6 +309,12 @@ const IMAGE_DETAIL_CASES: ImageDetailCase[] = [
     protocol: "chat",
     shrinks: false,
   },
+  {
+    expectedClient: "GLM5_3Client",
+    model: "glm-5.3-flash",
+    protocol: "chat",
+    shrinks: false,
+  },
   // The DeepSeek client forwards images to every id except the text-only V4 Flash / V4 Pro
   // (bare, dated snapshot, any gateway prefix, any case).
   {

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -444,7 +444,7 @@ describe.each(IMAGE_DETAIL_CASES)(
           // message
           expect(modelInput).toHaveLength(4);
           expect(modelInput[2].role).toBe("tool");
-          expect(JSON.stringify(modelInput[2])).not.toContain("image_url");
+          expect(typeof modelInput[2].content).toBe("string");
           expect(modelInput[3].role).toBe("user");
           expect(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src_ts/tests/image-detail.test.ts
+++ b/src_ts/tests/image-detail.test.ts
@@ -303,6 +303,12 @@ const IMAGE_DETAIL_CASES: ImageDetailCase[] = [
     protocol: "chat",
     shrinks: false,
   },
+  {
+    expectedClient: "KimiK3Client",
+    model: "kimi-k3",
+    protocol: "chat",
+    shrinks: false,
+  },
   // The DeepSeek client forwards images to every id except the text-only V4 Flash / V4 Pro
   // (bare, dated snapshot, any gateway prefix, any case).
   {
@@ -375,12 +381,14 @@ const MESSAGES: UniMessage[] = [
 // An absent key and an explicit undefined differ on the wire, so the key itself is reported.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function details(testCase: ImageDetailCase, modelInput: any[]): string[] {
+  // Chat Completions takes no image in a tool message: the tool result's images follow it
+  // in a user message of their own.
   const parts =
     testCase.protocol === "responses"
       ? [...modelInput[0].content.slice(1), ...modelInput[2].output.slice(1)]
       : [
           ...modelInput[0].content.slice(1),
-          ...modelInput[2].content.slice(1),
+          ...modelInput[3].content,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ].map((part: any) => part.image_url);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -428,12 +436,21 @@ describe.each(IMAGE_DETAIL_CASES)(
           shrunk,
           "absent",
         ]);
-        // the list form is what images require
-        expect(
-          testCase.protocol === "responses"
-            ? Array.isArray(modelInput[2].output)
-            : Array.isArray(modelInput[2].content),
-        ).toBe(true);
+        if (testCase.protocol === "responses") {
+          // the list form is what images require
+          expect(Array.isArray(modelInput[2].output)).toBe(true);
+        } else {
+          // the tool message carries the text alone, and the images follow it in a user
+          // message
+          expect(modelInput).toHaveLength(4);
+          expect(modelInput[2].role).toBe("tool");
+          expect(JSON.stringify(modelInput[2])).not.toContain("image_url");
+          expect(modelInput[3].role).toBe("user");
+          expect(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            modelInput[3].content.map((part: any) => part.type),
+          ).toEqual(["image_url", "image_url"]);
+        }
       },
     );
   },

--- a/src_ts/tests/message-order.test.ts
+++ b/src_ts/tests/message-order.test.ts
@@ -117,6 +117,7 @@ const MESSAGE_ORDER_CASES: MessageOrderCase[] = [
     model: "glm-5.3",
     protocol: "chat",
     expected: CHAT_ORDER,
+    bareTextToolResult: true,
   },
   {
     expectedClient: "KimiK3Client",

--- a/src_ts/tests/message-order.test.ts
+++ b/src_ts/tests/message-order.test.ts
@@ -123,6 +123,7 @@ const MESSAGE_ORDER_CASES: MessageOrderCase[] = [
     model: "kimi-k3",
     protocol: "chat",
     expected: CHAT_ORDER,
+    bareTextToolResult: true,
   },
 ];
 


### PR DESCRIPTION
## Summary

- A Chat Completions `tool` message holds text only. `openai_chat` and `kimi_k3` (TypeScript and Python) put a tool result's `image_url` parts inside the tool message on every endpoint except SiliconFlow, and `glm5_3` did the same for `glm-5.3-flash` (the one GLM id that reads images), and a server that validates the schema refuses the whole request: `400 Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ChatCompletionRequestToolMessageContent` (an `async-openai` type name; the column number points into the base64 image). Reading an image with a tool ends the turn behind such a gateway, which is how `kimi-k3` and the GPT ids reached through an OpenAI-compatible gateway fail today.
- All three Chat Completions clients now put the image parts in the user message that follows the turn's tool messages, on every endpoint. (`deepseek_v4` and `minimax_m3` speak the Responses protocol, where a `function_call_output` list with `input_image` is the documented form, so they are unchanged.) That is the placement the SiliconFlow special case already used, so the special case is gone. Every tool result goes out as a plain string: `openai_chat` keeps the form #205 introduced for text-only results, `kimi_k3` drops its one-part text list for the string Moonshot's own tool-call examples send, and `glm5_3` sent the string already. `openai_chat_vllm_adapter` inherits the transform.
- Alternatives considered: keeping image parts in the tool message on endpoints known to accept them would need an allowlist maintained per gateway, while the trailing user message is read the same way by every server. No label text is added ahead of the images: the SiliconFlow path has run without one, and the images directly follow the tool message they belong to. If a model turns out to misattribute them, a one-part text label is the follow-up.

## Verification

On a remote test host (Node 24.20, Python 3.13):

- `src_ts`: `tsc --noEmit`, `eslint src --ext .ts`, `jest tests/image-detail.test.ts tests/message-order.test.ts tests/reasoning-fidelity.test.ts tests/unknown-events.test.ts` — 135 passed. The image-detail test now asserts the tool message carries no `image_url` and the trailing user message carries both images, and gains a `kimi-k3` case.
- `src_py`: `ruff check`, `ruff format --check`, `pytest tests/test_image_detail.py tests/test_message_order.py tests/test_reasoning_fidelity.py tests/test_unknown_events.py` — 135 passed.
- Live, `jest tests/client.test.ts -t "tool result with image"` with `RUN_SLOW_TEST=1` on the same host: passes on `kimi-k3:official` (Moonshot direct, `kimi_k3`), `Qwen/Qwen3.6-35B-A3B:siliconflow:openai-chat` (`openai_chat`) and `Pro/moonshotai/Kimi-K2.6:siliconflow` (`kimi_k3`), alongside every first-party client. The OpenRouter entries could not be checked: the OpenRouter key available to me answers `401 User not found` on untouched routes too, so those five failures are the key, not the shape.
- CI attempt 1 passed the same test on every model it covers (`kimi-k3:official` included); its two failures were the MiniMax-M3 tool-use / system-prompt nondeterminism and were rerun.

Second commit (kimi-k3 tool result as a plain string), on the same host: `tsc --noEmit`, `eslint`, the four offline jest suites (135 passed), `ruff check` + `ruff format --check`, the four offline pytest files (135 passed). Live `tool result with image` in both languages: `kimi-k3:official` and `Pro/moonshotai/Kimi-K2.6:siliconflow` pass; `moonshotai/kimi-k3:openrouter` fails with the same `401 User not found` as before, which is the key, not the shape.

Third commit (`glm5_3`), on the same host: `tsc --noEmit`, `eslint`, the four offline jest suites (136 passed), `ruff check` + `ruff format --check`, the four offline pytest files (136 passed). Live `tool result with image` on `glm-5.3-flash:official` (Z.ai direct) passes in both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ggUKAni35vEFcZPjFj8LC


